### PR TITLE
Updated sandbox docs with the version numbers of libraries relative to chrome vs native app

### DIFF
--- a/_posts/06_api_testing_and_collection_runner/2016-07-11-sandbox.md
+++ b/_posts/06_api_testing_and_collection_runner/2016-07-11-sandbox.md
@@ -11,13 +11,13 @@ The Postman Sandbox is a JavaScript execution environment that is available to y
 
 ### Commonly used libraries and utilities
 
-* [Lodash][0]: JS utility library
-* [cheerio][1]: A fast, lean implementation of the core jQuery API (available in versions 4.6.0 and up)
+* [Lodash][0]: JS utility library  [ chrome `v3.6.0` | native `v4.17.2` ]
+* [cheerio][1]: A fast, lean implementation of the core jQuery API (available in versions 4.6.0 and up) [ native `v0.22.0` ]
 * [BackboneJS][2] **Deprecated**: Provides simple models, views, and collections. This will be removed in future versions of the sandbox.
-* [SugarJS][3]: Extends native JS objects with useful methods
-* [tv4 JSON schema validator][4]: Validates JSON objects against v4 of the json-schema draft
-* [CryptoJS][5]: standard and secure cryptographic algorithms. Supported algorithms: AES, DES, EvpKDF, HMAC-MD5, HMAC-SHA1/3/256/512, MD5, PBKDF2, Rabbit, SHA1/3/224/256/512, TripleDES
-* `xml2Json(xmlString)`: This function behaves the same in Newman and Postman
+* [SugarJS][3]: Extends native JS objects with useful methods [ `v1.4.1`]
+* [tv4 JSON schema validator][4]: Validates JSON objects against v4 of the json-schema draft [ `v1.2.7` ]
+* [CryptoJS][5]: standard and secure cryptographic algorithms. Supported algorithms: AES, DES, EvpKDF, HMAC-MD5, HMAC-SHA1/3/256/512, MD5, PBKDF2, Rabbit, SHA1/3/224/256/512, TripleDES [ chrome `v3.1.2` | native `v3.1.9-1` ]
+* [xml2Json][6]: `xml2Json(xmlString)` This function behaves the same in Newman and Postman [ `v0.4.17` ]
 * `xmlToJson(xmlString)` **Deprecated**: This function does NOT behave the same in Newman and Postman
 * `postman.getResponseHeader(headerName)` Test-only: returns the response header with name "headerName", if it exists. Returns null if no such header exists.
 **Note**: According to W3C specifications, header names are case-insensitive.

--- a/_posts/06_api_testing_and_collection_runner/2016-07-11-sandbox.md
+++ b/_posts/06_api_testing_and_collection_runner/2016-07-11-sandbox.md
@@ -11,19 +11,19 @@ The Postman Sandbox is a JavaScript execution environment that is available to y
 
 ### Commonly used libraries and utilities
 
-* [Lodash][0]: JS utility library  [ chrome `v3.6.0` | native `v3.10.1` ]
-* [cheerio][1]: A fast, lean implementation of the core jQuery API (available in versions 4.6.0 and up) [ native `v0.22.0` ]
+* [Lodash][0]: JS utility library  &nbsp; [native `v3.10.1`, chrome `v3.6.0`]
+* [cheerio][1]: A fast, lean implementation of the core jQuery API (available in versions 4.6.0 and up) &nbsp; [ native `v0.22.0` ]
 * [BackboneJS][2] **Deprecated**: Provides simple models, views, and collections. This will be removed in future versions of the sandbox.
-* [SugarJS][3]: Extends native JS objects with useful methods [ `v1.4.1`]
+* [SugarJS][3]: Extends native JS objects with useful methods &nbsp; [ `v1.4.1`]
 * [tv4 JSON schema validator][4]: Validates JSON objects against v4 of the json-schema draft [ `v1.2.7` ]
-* [CryptoJS][5]: standard and secure cryptographic algorithms. Supported algorithms: AES, DES, EvpKDF, HMAC-MD5, HMAC-SHA1/3/256/512, MD5, PBKDF2, Rabbit, SHA1/3/224/256/512, TripleDES [ chrome `v3.1.2` | native `v3.1.9-1` ]
+* [CryptoJS][5]: standard and secure cryptographic algorithms. Supported algorithms: AES, DES, EvpKDF, HMAC-MD5, HMAC-SHA1/3/256/512, MD5, PBKDF2, Rabbit, SHA1/3/224/256/512, TripleDES  &nbsp; [ native `v3.1.9-1`, chrome `v3.1.2` ]
 * [xml2Json][6]: `xml2Json(xmlString)` This function behaves the same in Newman and Postman [ `v0.4.17` ]
 * `xmlToJson(xmlString)` **Deprecated**: This function does NOT behave the same in Newman and Postman
 * `postman.getResponseHeader(headerName)` Test-only: returns the response header with name "headerName", if it exists. Returns null if no such header exists.
 **Note**: According to W3C specifications, header names are case-insensitive.
 This method takes care of this. `postman.getResponseHeader("Content-type")` and `postman.getResponseHeader("content-Type")` will return the same value.
 
-Note: jQuery support has been discontinued since version 4.6.0, in favour of [cheerio][1]. Also, here, chrome `vX.X.X` indicates the version of the library on the Chrome app, where as, native `vX.X.X` indicates the same for the native apps.
+Note: jQuery support has been discontinued since version 4.6.0, in favour of [cheerio][1]. Also, here, "native `vX.X.X`" indicates the version of the library on the native app, where as, "chrome `vX.X.X`" indicates the same for the chrome app.
 
 ### Environment and global variables
 

--- a/_posts/06_api_testing_and_collection_runner/2016-07-11-sandbox.md
+++ b/_posts/06_api_testing_and_collection_runner/2016-07-11-sandbox.md
@@ -11,7 +11,7 @@ The Postman Sandbox is a JavaScript execution environment that is available to y
 
 ### Commonly used libraries and utilities
 
-* [Lodash][0]: JS utility library  [ chrome `v3.6.0` | native `v4.17.2` ]
+* [Lodash][0]: JS utility library  [ chrome `v3.6.0` | native `v3.10.1` ]
 * [cheerio][1]: A fast, lean implementation of the core jQuery API (available in versions 4.6.0 and up) [ native `v0.22.0` ]
 * [BackboneJS][2] **Deprecated**: Provides simple models, views, and collections. This will be removed in future versions of the sandbox.
 * [SugarJS][3]: Extends native JS objects with useful methods [ `v1.4.1`]

--- a/_posts/06_api_testing_and_collection_runner/2016-07-11-sandbox.md
+++ b/_posts/06_api_testing_and_collection_runner/2016-07-11-sandbox.md
@@ -23,7 +23,7 @@ The Postman Sandbox is a JavaScript execution environment that is available to y
 **Note**: According to W3C specifications, header names are case-insensitive.
 This method takes care of this. `postman.getResponseHeader("Content-type")` and `postman.getResponseHeader("content-Type")` will return the same value.
 
-Note: jQuery support has been discontinued since version 4.6.0, in favour of [cheerio][1].
+Note: jQuery support has been discontinued since version 4.6.0, in favour of [cheerio][1]. Also, here, chrome `vX.X.X` indicates the version of the library on the Chrome app, where as, native `vX.X.X` indicates the same for the native apps.
 
 ### Environment and global variables
 


### PR DESCRIPTION
cc @shamasis Please review the version numbers and the link to library set for `xml2json`.
cc @numaanashraf 