### PR TITLE
add examples page

### DIFF
--- a/_data/doc_map.json
+++ b/_data/doc_map.json
@@ -135,6 +135,11 @@
             "external": false
           },
           {
+            "title": "Examples",
+            "href": "/docs/postman/collections/examples",
+            "external": false
+          },
+          {
             "title": "Data formats",
             "href": "/docs/postman/collections/data_formats",
             "external": false

--- a/_posts/01_postman/03_collections/2017-05-04-examples.md
+++ b/_posts/01_postman/03_collections/2017-05-04-examples.md
@@ -1,0 +1,78 @@
+---
+categories:
+  - "postman"
+  - "collections"
+title: "Examples"
+page_id: "examples"
+warning: false
+---
+
+Developers can mock a request and response in Postman before sending the actual request or setting up a single endpoint to return the response. Establishing an **example** during the earliest phase of API development requires clear communication between team members, aligns their expectations, and means developers and testers can get started more quickly.
+
+[![API lifecycle](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/apiLifecycle.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/apiLifecycle.png)
+
+### What is an example?
+
+[![whats an example](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/whats-an-example-illustration-1.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/whats-an-example-illustration-1.jpg)
+
+An example is a tightly coupled request and response pair. For instance, in this illustration, '200 OK custom response' is the name of an example, which contains an 'example request' and an 'example response'.
+
+### Why use examples?
+
+More often than not, it is useful to create and save a couple of example responses alongside a request – status codes for a 200, a 404, a 500, etc. – to make your API more understandable to others. Thus, a teammate looking at your API can quickly view these examples and get a good idea of the responses a particular request is going to return – all this, without having to hit 'Send' on the request. 
+
+Furthermore, let's say that you are going to build an API with an endpoint which does not yet exist, or your server just isn’t ready. With examples, you can mock raw responses and save them. Then, you'll be able to generate a mock endpoint for each of them using [Postman's mock service](/docs/postman/mock_servers). With this setup, developers can makes requests to the mock endpoint, and get started on front-end development or [writing tests](/docs/postman/scripts/test_scripts) based on the mock response returned from the mock endpoint.
+
+### Adding an example
+
+[![start dropdown](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/start-dropdown.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/start-dropdown.gif)
+
+Adding examples to each of your API endpoints involves just a few clicks. Let’s say you are working on a request that is saved inside a [collection](/docs/postman/collections/creating_collections). You can add examples to this request with **a new custom response** or **the response received from the server**.
+
+##### **A new custom response**
+
+Examples let you define what the response should look like by letting you create your own custom responses from scratch. The illustration below outlines the steps for creating an example with a new response.
+
+[![adding example with new response](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Adding-example-with-a-new-response.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Adding-example-with-a-new-response.png)
+
+1. Click on the **Examples** dropdown.
+2. Click the **Add Example** button. The base request gets loaded as **'example request'** in the examples editor.
+3. Enter the **name** of your example.
+4. Edit the **request** part of the example.
+5. Enter a **status code**.
+6. Create a new **response** for your example.
+7. Click the **Save Example** button in the upper right corner of the builder to save your example.
+
+##### **The response received from the server**
+
+After you've received a response from a server, you might want to save the current request and response pair as an example. Steps for doing so are similar to creating a new response from scratch.
+
+[![adding example with response from server](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Adding-example-with-the-response-from-the-server.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Adding-example-with-the-response-from-the-server.png)
+
+Later on, you can go back to your base request, and continue right where you left off by clicking on the request name in the upper left corner of the builder.
+
+[![going back to the base request](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/going-back-to-the-base-request.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/going-back-to-the-base-request.png)
+
+### Accessing your saved examples
+
+Click on the **Examples** dropdown in the upper right corner of the builder to access all your saved examples.
+
+[![accessing saved examples](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/accessing-saved-examples.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/accessing-saved-examples.jpg)
+
+### What happened to the 'Save Response' feature?
+
+The ability to [save responses](/docs/postman/sending_api_requests/responses) has been available in Postman for a long time. However, our users wanted to edit these responses before saving them, and also to add new responses. Examples make all of this possible!
+
+Responses can be saved to examples. Save responses, like before, but now you can edit them whenever you want. Access your already saved responses by clicking on the **Examples** dropdown. 
+
+[![accessing saved examples](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/accessing-saved-examples-1.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/accessing-saved-examples-1.jpg)
+
+### How your examples appear in Postman documentation
+
+You might already know that Postman has [API documentation](/docs/postman/api_documentation/intro_to_api_documentation), published to the web with a single click. Examples are displayed in your API documentation, providing additional details and clarification for your API. 
+
+And you can always go back and edit these examples, with real-time updates to the documentation!
+
+[![how examples appear in documentation](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/in-documenter.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/in-documenter.gif)
+
+This allows teams to mock an example request and response, along with simulating the endpoint using [mock servers](/docs/postman/mock_servers). Front-end and back-end developers and testers can all begin working in parallel, based on the agreed-upon example.

--- a/_posts/01_postman/03_collections/2017-05-04-using_markdown_for_descriptions.md
+++ b/_posts/01_postman/03_collections/2017-05-04-using_markdown_for_descriptions.md
@@ -7,7 +7,7 @@ page_id: "using_markdown_for_descriptions"
 warning: false
 ---
 
-Postman supports [Markdown](/docs/postman/api_documentation/how_to_document_using_markdown) as a way to style text descriptions for requests, collections, and folders within collections. You can even embed screenshots and other images for more descriptive flair.
+Postman supports [Markdown](/docs/postman/api_documentation/how_to_document_using_markdown) as a way to style text descriptions for requests, [collections](/docs/postman/collections/creating_collections), and [folders](/docs/postman/collections/managing_collections) within collections. You can even embed screenshots and other images for more descriptive flair.
 
 Review [reference for using Markdown](https://documenter.getpostman.com/view/33232/markdown-in-api-documentation/JsGc){:target="_blank"} in API documentation. 
 
@@ -19,5 +19,27 @@ In the request builder, the request description can be styled with markdown.
 The collections details view can be styled with markdown in the descriptions for collections and folders.  
 [![collection details view](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564112.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564112.png)
 
-For either public or internal API documentation, automatically generated API descriptions (Pro feature) will be styled beautifully and precisely with markdown.  
+For either public or internal [API documentation](/docs/postman/api_documentation/intro_to_api_documentation), automatically generated API descriptions will be styled beautifully and precisely with markdown.  
 [![automatically generated documentation](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564156.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564156.png)
+
+### Descriptions for request attributes
+
+The description column in the [data editor](/docs/postman/launching_postman/navigating_postman) makes your requests easier to understand. You can add comments and details for each of your query parameters, path variables, headers, and body (form-data and urlencoded) - all from right within the Postman app.
+
+For example, specify if an element is required or optional, indicate the accepted data type, or use alternative terminology to provide additional clarification for developers who are working with your requests.
+
+[![data editor parameters](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/data-editor-params.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/data-editor-params.png)
+
+For Postman Pro users publishing internal or public API documentation, these descriptions are displayed in the [automatically generated documentation](/docs/postman/api_documentation/intro_to_api_documentation) for that collection.
+
+[![parameters in automatically generated docs](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/auto-generated-docs-params.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/auto-generated-docs-params.gif)
+
+*Note: Descriptions for path variables and URL params are currently NOT shown in the documentation.*
+
+You can hide and show the value and description column in the data editor by clicking on the ellipsis (...) in the top right corner of the editor, and unchecking the columns that you want to hide.
+
+[![uncheck parameters](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/uncheck-parameters.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/uncheck-parameters.gif)
+
+*Note: Descriptions are metadata for a request and are **NOT** sent with your HTTP request. This reminder is displayed when you mouse over the title of the description column.*
+
+[![mouseover params](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/mouseover-params.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/mouseover-params.png)

--- a/_posts/01_postman/04_scripts/2017-05-04-postman_sandbox_api_reference.md
+++ b/_posts/01_postman/04_scripts/2017-05-04-postman_sandbox_api_reference.md
@@ -102,7 +102,7 @@ warning: false
                                         class="java plain">arrayOfStrings,</code><br/><code
                                         class="java spaces">    </code><code
                                         class="java plain">base64Strings;</code><br/> <br/> <br/><code
-                                        class="java plain">arrayOfStrings =  = [</code><code class="java string">'string1'</code><code
+                                        class="java plain">arrayOfStrings = [</code><code class="java string">'string1'</code><code
                                         class="java plain">, </code><code class="java string">'string2'</code><code
                                         class="java plain">];</code><br/> <br/> <br/><code class="java plain">base64Strings
                                     = _.map(arrayOfStrings, atob);</code><br/> <br/> <br/><code class="java plain">console.log(base64Strings);</code>

--- a/_posts/03_enterprise/2017-05-04-apply_for_beta_access.md
+++ b/_posts/03_enterprise/2017-05-04-apply_for_beta_access.md
@@ -8,4 +8,4 @@ tags:
 warning: false
 ---
 
-Postman's Enterprise offering is currently in beta. If you would like to apply for beta access, email us at [help@getpostman.com](mailto:help@getpostman.com). 
+Postman's Enterprise offering is now available. If you would like to learn more about Postman Enterprise, email us at [help@getpostman.com](mailto:help@getpostman.com). 


### PR DESCRIPTION
- add examples page
- add descriptions for request attributes to markdown descriptions page
- fix typo on API sandbox reference page
- remove beta language on apply for enterprise beta page

@godfrzero  @madebysid could you please review?