### PR TITLE
100k

### DIFF
--- a/_data/doc_map.json
+++ b/_data/doc_map.json
@@ -323,6 +323,11 @@
             "title": "Adding and verifying custom domains",
             "href": "/docs/postman/api_documentation/adding_and_verifying_custom_domains",
             "external": false
+          },
+          {
+            "title": "Adding team name and logo",
+            "href": "/docs/postman/api_documentation/adding_team_name_and_logo",
+            "external": false
           }
         ]
       },

--- a/_data/doc_map.json
+++ b/_data/doc_map.json
@@ -521,9 +521,9 @@
     "url_prefix": "enterprise",
     "children": [
       {
-        "title": "Apply for beta access",
-        "url_prefix": "apply_for_beta_access",
-        "href":"/docs/enterprise/apply_for_beta_access",
+        "title": "Intro to Enterprise",
+        "url_prefix": "intro_to_enterprise",
+        "href":"/docs/enterprise/intro_to_enterprise",
         "external": false
       },
       {

--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -3,24 +3,39 @@
     <div class="row">
       <div class="col-lg-9 col-sm-12">
         <ul class="footer-links clearfix col-sm-3">
-          <li><a href="{{site.pm.root}}/pricing">Pricing</a></li>
-          <li><a href="{{site.pm.root}}/products">Product Comparison</a></li>
-          <li><a href="{{site.pm.root}}/products">Product Features</a></li>
+          <li class="category-title title-1">Products</li>
+          <li><a href="{{site.pm.root}}/postman" class="#{current.source === 'postman' ? 'active' : ''}">Postman</a></li>
+          <li><a href="{{site.pm.root}}/pro" class="#{current.source === 'pro' ? 'active' : ''}">Postman Pro</a></li>
+          <li><a href="{{site.pm.root}}/enterprise" class="#{current.source === 'enterprise' ? 'active' : ''}">Enterprise</a></li>
+          <li><a href="{{site.pm.root}}/publishers" class="#{current.source === 'publishers' ? 'active' : ''}">Publishers</a></li>
+          <li><a href="{{site.pm.root}}/apps" class="#{current.source === 'apps' ? 'active' : ''}">Download the app</a></li>
         </ul>
         <ul class="footer-links clearfix col-sm-3">
-          <li><a href="{{site.pm.root}}/apps">Apps</a></li>
-          <li><a href="{{site.pm.root}}/security">Security</a></li>
-          <li><a href="{{site.pm.root}}/support">Support</a></li>
+          <li>&nbsp;</li>
+          <li><a href="{{site.pm.root}}/docs" class="#{current.source === 'docs' ? 'active' : ''}">Docs</a></li>
+          <li><a href="{{site.pm.root}}/monitoring" class="#{current.source === 'monitoring' ? 'active' : ''}">Monitoring</a></li>
+          <li><a href="{{site.pm.root}}/integrations" class="#{current.source === 'integrations' ? 'active' : ''}">Integrations</a></li>
+          <li><a href="{{site.pm.root}}/apps">Release Notes</a></li>
         </ul>
         <ul class="footer-links clearfix col-sm-3">
-          <li><a href="{{site.pm.root}}/community">Community Resources</a></li>
-          <li><a href="{{site.pm.blog}}">Blog</a></li>
-          <li><a href="{{site.pm.blog}}/case-studies">Case Studies</a></li>
+          <li class="category-title title-2">Company</li>
+          <li><a href="{{site.pm.root}}/company" class="#{current.source === 'company' ? 'active' : ''}">About</a></li>
+          <li><a href="{{site.pm.root}}/jobs/" class="#{current.path[0] === 'jobs' ? 'active' : ''}">Jobs</a></li>
+          <li><a href="{{site.pm.root}}/press" class="#{current.source === 'press' ? 'active' : ''}">Press</a></li>
+          <li><a href="{{site.pm.root}}/contact" class="#{current.source === 'contact' ? 'active' : ''}">Contact</a></li>
         </ul>
         <ul class="footer-links clearfix col-sm-3">
-          <li><a href="{{site.pm.root}}/contact-us">Contact Us</a></li>
-          <li><a href="{{site.pm.root}}/about-us">About Postman</a></li>
-          <li><a href="{{site.pm.root}}/jobs">Careers</a></li>
+          <li class="category-title title-3">Resources</li>
+          <li><a href="{{site.pm.root}}/community" class="#{current.source === 'community' ? 'active' : ''}">Community</a></li>
+          <li><a href="{{site.pm.root}}/community#support">Support</a></li>
+          <li><a href="http://blog.getpostman.com" target="_blank">Blog</a></li>
+          <li><a href="{{site.pm.root}}/security" target="_blank">Security</a></li>
+          <li><a href="{{site.pm.root}}/licenses/privacy" class="#{current.path[0] === 'licenses' ? 'active' : ''}">Privacy and Terms</a></li>
+        </ul>
+        <ul class="footer-links clearfix col-sm-3">
+          <li>&nbsp;</li>
+          <li><a href="http://pages.getpostman.com/Sticker-Landing-Page.html">Want stickers?</a></li>
+          <li><a href="https://teespring.com/stores/postman-store">Get Postman Swag!</a></li>
         </ul>
       </div>
 
@@ -40,9 +55,8 @@
           <a class="pm-btn pm-btn-sm pm-btn-primary sign-in-button hide-if-signedin" href="{{site.pm.gs}}/signup?redirect=web">Sign in</a>
           <a class="pm-btn pm-btn-sm pm-btn-primary sign-in-button hide-if-signedout" href="{{site.pm.gs}}/">Dashboard</a>
 
-          <span>&copy; 2016 Postdot Technologies, Inc.</span>
+          <span>&copy; 2017 Postdot Technologies, Inc.</span>
           <span>All Rights Reserved </span>
-          <span><a href="/licenses/privacy">Privacy and Terms</a></span>
         </div>
       </div>
     </div>

--- a/_includes/_header.html
+++ b/_includes/_header.html
@@ -4,12 +4,134 @@
 
     <div class="navigation-container">
         <ul>
-            <li><a href="{{site.pm.root}}/products" class="pm-btn pm-btn-transparent">Products</a></li>
-            <li><a href="{{site.pm.root}}/pricing" class="pm-btn pm-btn-transparent">Pricing</a></li>
-            <li><a href="{{site.pm.root}}/docs/" class="active pm-btn pm-btn-transparent">Documentation</a></li>
-            <li><a href="{{site.pm.root}}/community" class="pm-btn pm-btn-transparent">Community</a></li>
+            <!--<li><a href="{{site.pm.root}}/products" class="pm-btn pm-btn-transparent">Products</a></li>-->
+            <!--<li><a href="{{site.pm.root}}/pricing" class="pm-btn pm-btn-transparent">Pricing</a></li>-->
+            <!--<li><a href="{{site.pm.root}}/docs/" class="active pm-btn pm-btn-transparent">Documentation</a></li>-->
+            <!--<li><a href="{{site.pm.root}}/community" class="pm-btn pm-btn-transparent">Community</a></li>-->
+            <!--<li><a href="{{site.pm.gs}}/signup?redirect=web" class="pm-btn pm-btn-primary pm-btn-sm sign-in-button hide-if-signedin">Sign in</a></li>-->
+            <!--<li><a href="{{site.pm.gs}}/" class="pm-btn pm-btn-primary pm-btn-sm sign-in-button hide-if-signedout">Dashboard</a></li>-->
+
+            <li>
+                <div class='pm-btn pm-btn-transparent'>
+                    Products
+                    <ul class='pm-btn-submenu'>
+                        <li>
+                            <a href='{{site.pm.root}}/products'>
+                                <div class='submenu__title'>
+                                    All Products
+                                </div>
+                                <div class='submenu__desc'>
+                                    An overview of the Postman Products
+                                </div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href='{{site.pm.root}}/postman'>
+                                <div class='submenu__title'>
+                                    Postman
+                                </div>
+                                <div class='submenu__desc'>
+                                    A complete API Development Environment
+                                </div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href='{{site.pm.root}}/pro'>
+                                <div class='submenu__title'>
+                                    Postman Pro
+                                </div>
+                                <div class='submenu__desc'>
+                                    Extended features for developers &amp; teams
+                                </div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href='{{site.pm.root}}/enterprise'>
+                                <div class='submenu__title'>
+                                    Postman Enterprise
+                                </div>
+                                <div class='submenu__desc'>
+                                    Enterprise level features &amp; support
+                                </div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href='{{site.pm.root}}/publishers'>
+                                <div class='submenu__title'>
+                                    Postman for Publishers
+                                </div>
+                                <div class='submenu__desc'>
+                                    Onboard developers to your API
+                                </div>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+            <li><a href="{{site.pm.root}}/pricing" class="<%- current.source == 'pricing' ? 'active' : '' %> pm-btn pm-btn-transparent">Pricing</a></li>
+            <li><a href="{{site.pm.root}}/docs/" class="<%- current.path[0] == 'docs' ? 'active' : '' %> pm-btn pm-btn-transparent">Docs</a></li>
+            <li><a href="{{site.pm.root}}/community" class="<%- current.path[0] == 'community' ? 'active' : '' %> pm-btn pm-btn-transparent">Community</a></li>
+            <li>
+                <div class='pm-btn pm-btn-transparent'>
+                    About
+                    <ul class='pm-btn-submenu'>
+                        <li>
+                            <a href='{{site.pm.root}}/company'>
+                                <div class='submenu__title'>
+                                    Company
+                                </div>
+                                <div class='submenu__desc'>
+                                    Our Mission + History
+                                </div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href='{{site.pm.root}}/team'>
+                                <div class='submenu__title'>
+                                    Who We Are
+                                </div>
+                                <div class='submenu__desc'>
+                                    Meet our team
+                                </div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href='{{site.pm.root}}/jobs/'>
+                                <div class='submenu__title'>
+                                    We're Hiring
+                                </div>
+                                <div class='submenu__desc'>
+                                    Join our growing team!
+                                </div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href='{{site.pm.root}}/press'>
+                                <div class='submenu__title'>
+                                    What People Say
+                                </div>
+                                <div class='submenu__desc'>
+                                    All of the Postman Press
+                                </div>
+                            </a>
+                        </li>
+                        <li>
+                            <a href='{{site.pm.root}}/contact'>
+                                <div class='submenu__title'>
+                                    Contact Us
+                                </div>
+                                <div class='submenu__desc'>
+                                    Get in touch with Postman
+                                </div>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </li>
             <li><a href="{{site.pm.gs}}/signup?redirect=web" class="pm-btn pm-btn-primary pm-btn-sm sign-in-button hide-if-signedin">Sign in</a></li>
             <li><a href="{{site.pm.gs}}/" class="pm-btn pm-btn-primary pm-btn-sm sign-in-button hide-if-signedout">Dashboard</a></li>
+
+
         </ul>
     </div>
 </div>

--- a/_layouts/home.md
+++ b/_layouts/home.md
@@ -17,7 +17,7 @@
               <ul id="popular-topics">
                 <li><a href="/docs/postman/launching_postman/installation_and_updates">Installing the native app</a></li>
                 <li><a href="/docs/postman/collection_runs/command_line_integration_with_newman">Newman - Running collections in the command line</a></li>
-                <li><a href="/docs/postman/collection_runs/starting_a_collection_run">Level up with Postman Pro</a></li>
+                <li><a href="/docs/pro/what_is_pro">Level up with Postman Pro</a></li>
                 <li><a href="/docs/postman/collections/creating_collections">Getting started with collections</a></li>
                 <li><a href="/docs/postman/environments_and_globals/variables">Setting up an environment with variables</a></li>
                 <li><a href="/docs/postman/scripts/test_scripts">Writing tests</a></li>

--- a/_posts/01_postman/02_sending_api_requests/2017-05-04-history.md
+++ b/_posts/01_postman/02_sending_api_requests/2017-05-04-history.md
@@ -11,7 +11,7 @@ warning: false
 
 All requests you send using Postman are stored in the history which you can access using the left sidebar. The history lets you experiment with variations of requests quickly without wasting time building a request from scratch. You can load a previous request by clicking on the request name.
 
-If you create an account and sign in to Postman, your history will be synced with our server, backed up in realtime, and retrievable across your devices. If you sign out of your Postman account, and then log back in, the last 10 requests will remain in your history. Postman Pro users will have access to the last 100 requests.  The same policy holds for collection runs. Remember that you can always save as many requests in [collections](/docs/postman/collections/creating_collections) as you want.
+If you create an account and sign in to Postman, your history will be synced with our server, backed up in realtime, and retrievable across your devices. If you sign out of your Postman account, and then log back in, the last 10 requests will remain in your history. Postman Pro and Enterprise users will have access to the last 100 requests.  The same policy holds for collection runs. Remember that you can always save as many requests in [collections](/docs/postman/collections/creating_collections) as you want.
 
 [![history sidebar](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59135435.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59135435.png)
 

--- a/_posts/01_postman/03_collections/2017-05-04-data_formats.md
+++ b/_posts/01_postman/03_collections/2017-05-04-data_formats.md
@@ -16,7 +16,7 @@ Postman can export and import the following formats as a file or generated URL.Â
 
 ##### **Collections**
 
-[![export collection](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59163827.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59163827.png)
+[![export collection](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/exportDropdown.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/exportDropdown.png)
 
 Postman can export collections in two formats - v1 and v2\. Both Collection v1 and v2 download as JSON files; v2 is more versatile and the most-used choice. Learn more about the [v1 and v2 formats](http://blog.getpostman.com/2015/06/05/travelogue-of-postman-collection-format-v2/){:target="_blank"}.Â 
 

--- a/_posts/01_postman/03_collections/2017-05-04-managing_collections.md
+++ b/_posts/01_postman/03_collections/2017-05-04-managing_collections.md
@@ -58,11 +58,15 @@ Learn more about [sharing collections](/docs/postman/collections/sharing_collect
 
 ##### **Reorder requests**
 
-Within a collection or folder, you can reorder requests using drag and drop.  The order of folders inside a collection, however, is alphabetical and cannot currently be changed.  
+Within a collection or folder, you can reorder requests using drag and drop. You can also reorder folders within a collection using drag and drop. 
 
 ##### **Save responses** 
 
 Requests can also store [sample responses](/docs/postman/sending_api_requests/responses) when saved in a collection.
+
+##### **Use examples** 
+
+With [examples](/docs/postman/collections/examples), you can mock raw responses and save them to a collection. Then, you’ll be able to generate a mock endpoint for each of them using Postman’s [mock service](/docs/postman/mock_servers). 
 
 ##### **Add scripts**
 

--- a/_posts/01_postman/03_collections/2017-05-04-managing_collections.md
+++ b/_posts/01_postman/03_collections/2017-05-04-managing_collections.md
@@ -58,7 +58,7 @@ Learn more about [sharing collections](/docs/postman/collections/sharing_collect
 
 ##### **Reorder requests**
 
-Within a collection or folder, you can reorder requests using drag and drop. You can also reorder folders within a collection using drag and drop. 
+Within a collection or folder, you can reorder requests using drag and drop. In the latest Canary builds available for download on OSX ([x64](https://dl.pstmn.io/download/channel/canary/osx_64)) / Windows ([x86](https://dl.pstmn.io/download/channel/canary/windows_32) or [x64](https://dl.pstmn.io/download/channel/canary/windows_64)) / Linux ([x86](https://dl.pstmn.io/download/channel/canary/linux_32) or [x64](https://dl.pstmn.io/download/channel/canary/linux_64)) / [Chrome](https://chrome.google.com/webstore/detail/postman/loddepljkabcghihdkbkfknabkinanff), you can also reorder folders within a collection using drag and drop. 
 
 ##### **Save responses** 
 
@@ -82,6 +82,6 @@ Add a name and description to the folder. Folders are initially ordered alphabe
 
 [![add folder modal](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59183817.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59183817.png)
 
-You can add deeper levels of nesting for folders. Drag and drop the folders to reorder them to create the ultimate customized folder structure.
+In the latest Canary builds available for download on OSX ([x64](https://dl.pstmn.io/download/channel/canary/osx_64)) / Windows ([x86](https://dl.pstmn.io/download/channel/canary/windows_32) or [x64](https://dl.pstmn.io/download/channel/canary/windows_64)) / Linux ([x86](https://dl.pstmn.io/download/channel/canary/linux_32) or [x64](https://dl.pstmn.io/download/channel/canary/linux_64)) / [Chrome](https://chrome.google.com/webstore/detail/postman/loddepljkabcghihdkbkfknabkinanff), you can add deeper levels of nesting for folders. Drag and drop the folders to reorder them to create the ultimate customized folder structure.
 
 [![multi-level folders](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/multiLevelFolders.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/multiLevelFolders.png)

--- a/_posts/01_postman/03_collections/2017-05-04-managing_collections.md
+++ b/_posts/01_postman/03_collections/2017-05-04-managing_collections.md
@@ -74,6 +74,10 @@ Folders are a way to organize your API endpoints within a collection into intuit
 
 [![add folder from dropdown](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59183806.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59183806.png)
 
-Add a name and description to the folder. Folders are ordered alphabetically by name, and the folder name and description will be reflected in your API documentation.
+Add a name and description to the folder. Folders are initially ordered alphabetically by name, and the folder name and description will be reflected in your API documentation.
 
 [![add folder modal](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59183817.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59183817.png)
+
+You can add deeper levels of nesting for folders. Drag and drop the folders to reorder them to create the ultimate customized folder structure.
+
+[![multi-level folders](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/multiLevelFolders.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/multiLevelFolders.png)

--- a/_posts/01_postman/03_collections/2017-05-04-managing_collections.md
+++ b/_posts/01_postman/03_collections/2017-05-04-managing_collections.md
@@ -18,7 +18,7 @@ Click on a collection to show or hide the requests that comprise the collection.
 
 Expand the right angle bracket (**>**) to show the details view for the collection. Collapse the left angle bracket (**<**) to hide the details view. You can add metadata like name and description so that all the information a developer needs to use your API is available easily. 
 
-[![collection details view](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59154277.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59154277.png)
+[![collection details view](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/collectionDetailsView.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/collectionDetailsView.png)
 
 ##### **Create a new collection**
 
@@ -76,7 +76,7 @@ Requests stored inside a collection can contain [scripts](/docs/postman/scripts/
 
 Folders are a way to organize your API endpoints within a collection into intuitive and logical groups to mirror your workflow. Next to the collection to which you want to add a folder, click on the ellipses (...) and select "Add Folder".
 
-[![add folder from dropdown](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59183806.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59183806.png)
+[![add folder from dropdown](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addFolderDropdown.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addFolderDropdown.png)
 
 Add a name and description to the folder. Folders are initially ordered alphabetically by name, and the folder name and description will be reflected in your API documentation.
 

--- a/_posts/01_postman/03_collections/2017-05-04-sharing_collections.md
+++ b/_posts/01_postman/03_collections/2017-05-04-sharing_collections.md
@@ -10,7 +10,7 @@ warning: false
 
 You must be signed in to your [Postman account](/docs/postman/launching_postman/postman_account) to upload or share a collection.  Click on the ellipses (**...**) next to the collection you wish to share. Select "Share" to open the **SHARE COLLECTION** modal which will contain most of ways that you can share a collection.
 
-[![share collection from dropdown](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564542.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564542.png)
+[![share collection from dropdown](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/shareCollectionDropdown.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/shareCollectionDropdown.png)
 
 ### Sharing a collection with your team (Pro feature)
 

--- a/_posts/01_postman/03_collections/2017-05-04-sharing_collections.md
+++ b/_posts/01_postman/03_collections/2017-05-04-sharing_collections.md
@@ -14,7 +14,7 @@ You must be signed in to your [Postman account](/docs/postman/launching_postman/
 
 ### Sharing a collection with your team (Pro feature)
 
-If you are a member of a team using Postman Pro, you can share a collection with the rest of your team. Under the **Team Sharing** tab of the **SHARE COLLECTION** modal, you can designate view or edit permissions for your team.  You can also choose to share the collection with your whole team or assign individual permissions for team members. 
+If you are a member of a team using Postman Pro or Enterprise, you can [share a collection with the rest of your team](/docs/postman/team_library/sharing#sharing-collections). Under the **Team Sharing** tab of the **SHARE COLLECTION** modal, you can designate view or edit permissions for your team.  You can also choose to share the collection with your whole team or assign individual permissions for team members. 
 
 [![share collection modal](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59137211.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59137211.png)
 

--- a/_posts/01_postman/03_collections/2017-05-04-using_markdown_for_descriptions.md
+++ b/_posts/01_postman/03_collections/2017-05-04-using_markdown_for_descriptions.md
@@ -30,7 +30,7 @@ For example, specify if an element is required or optional, indicate the accepte
 
 [![data editor parameters](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/data-editor-params.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/data-editor-params.png)
 
-For Postman Pro users publishing internal or public API documentation, these descriptions are displayed in the [automatically generated documentation](/docs/postman/api_documentation/intro_to_api_documentation) for that collection.
+For Postman users publishing internal or public API documentation, these descriptions are displayed in the [automatically generated documentation](/docs/postman/api_documentation/intro_to_api_documentation) for that collection.
 
 [![parameters in automatically generated docs](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/auto-generated-docs-params.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/auto-generated-docs-params.gif)
 

--- a/_posts/01_postman/03_collections/2017-05-04-using_markdown_for_descriptions.md
+++ b/_posts/01_postman/03_collections/2017-05-04-using_markdown_for_descriptions.md
@@ -14,10 +14,10 @@ Review [reference for using Markdown](https://documenter.getpostman.com/view/332
 Postman renders this markdown in the following places:
 
 In the request builder, the request description can be styled with markdown.  
-[![request description](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564068.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564068.png)
+[![request description](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/spaceRequestDescription.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/spaceRequestDescription.png)
 
 The collections details view can be styled with markdown in the descriptions for collections and folders.  
-[![collection details view](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564112.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564112.png)
+[![collection details view](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/spaceCollectionDetailsView.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/spaceCollectionDetailsView.png)
 
 For either public or internal [API documentation](/docs/postman/api_documentation/intro_to_api_documentation), automatically generated API descriptions will be styled beautifully and precisely with markdown.  
 [![automatically generated documentation](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564156.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564156.png)

--- a/_posts/01_postman/05_environments_and_globals/2017-05-04-manage_environments.md
+++ b/_posts/01_postman/05_environments_and_globals/2017-05-04-manage_environments.md
@@ -47,4 +47,4 @@ Click the gear icon in the upper right corner of the Postman app and select "Man
 
 It's a best practice to create a duplicate, remove any sensitive values like passwords and access tokens before downloading the copy to share with someone else.  When someone else imports the environment, or accesses the shared template, they can input their own personal information within their own version of the template.
 
-For Postman Pro users, learn how to [share environment templates](/docs/postman/team_library/sharing) with team members.
+For Postman Pro and Enterprise users, learn how to [share environment templates](/docs/postman/team_library/sharing) with team members.

--- a/_posts/01_postman/07_team_library/2017-05-04-activity_feed_and_restoring_collections.md
+++ b/_posts/01_postman/07_team_library/2017-05-04-activity_feed_and_restoring_collections.md
@@ -7,7 +7,7 @@ page_id: "activity_feed_and_restoring_collections"
 warning: false
 ---
 
-An activity feed is a list of events, displaying to the user in an interactive interface, updates to their Postman Data. It is useful to keep track of changes made to your private and team collections by different users across the team. The activity feed also lets you rollback a collection, and restore it to any previous point in time. 
+An activity feed is a list of events, displaying to the user in an interactive interface, updates to their Postman data. It is useful to keep track of changes made to your private and team collections by different users across the team. The activity feed also lets you rollback a collection, and restore it to any previous point in time. 
 
 ### Types of activity feed
 
@@ -43,7 +43,7 @@ A consolidated update to a request, for example, looks like the screenshot above
 
 ### Restoring collections
 
-Postman Pro users also have the ability within the collection-level activity feed to restore their collections to a point in time.
+Postman Pro and Enterprise users also have the ability within the collection-level activity feed to restore their collections to a point in time.
 
 [![restore collections](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59058662.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59058662.png)
 
@@ -57,7 +57,7 @@ And now the top of the activity feed displays the confirmation of restoring the 
 
 ### Connecting to Slack, HipChat and other platforms
 
-Postman Pro users can pipe the team's activity feed to a communication channel of your choosing with the following integrations
+Postman Pro and Enterprise users can pipe the team's activity feed to a communication channel of your choosing with the following integrations
 
    *   [Postman Pro to Slack integration](/docs/pro/integrations/slack)
    *   [Postman Pro to Slack integration](/docs/pro/integrations/hipchat)
@@ -65,4 +65,4 @@ Postman Pro users can pipe the team's activity feed to a communication channel o
 
 ### Upcoming additions to the activity feed
 
-The activity feed will become even more powerful in the near future. It'll integrate with all our Postman Pro products → Mock Servers, Monitors, Documentation, and other features in the pipeline. We're also going to soon add **Tagging** support. You'll be able to tag collections at a point in time, allowing easier referencing and ability to rollback, while also allowing you set up Monitors and Documentation on tagged versions of the collection. These version control constructs will allow your team even more flexibility with your API code development within Postman Pro.
+The activity feed will become even more powerful in the near future.  It’ll integrate with all our Postman Pro and Enterprise products and other features in the pipeline. We're going to soon add **Tagging** support. You'll be able to tag collections at a point in time, allowing easier referencing and ability to rollback, while also allowing you to set up Monitors and Documentation on tagged versions of the collection. These version control constructs will allow your team even more flexibility with your API code development within Postman Pro.

--- a/_posts/01_postman/07_team_library/2017-05-04-activity_feed_and_restoring_collections.md
+++ b/_posts/01_postman/07_team_library/2017-05-04-activity_feed_and_restoring_collections.md
@@ -21,7 +21,7 @@ To review the activity feed at the collection level, expand the angle bracket (
 
 ##### **Team**
 
-To review the activity feed at the team level, go to the **Activity Feed** tab within the **Team Library** view. Review a chronological listing of activities affecting all collections shared with the team. Like the feed at the collection level, the team activity feed displays who made changes, to what, and when it was completed.
+To review the activity feed at the Postman Pro or Enterprise team level, go to the **Activity Feed** tab within the **Team Library** view. Review a chronological listing of activities affecting all collections shared with the team. Like the feed at the collection level, the team activity feed displays who made changes, to what, and when it was completed.
 
 [![team library feed](http://blog.getpostman.com/wp-content/uploads/2016/10/840x459xScreenshot-2016-10-17-20.05.08-1024x560.png,qx38712.pagespeed.ic.1EV4RiRLH4.jp)](http://blog.getpostman.com/wp-content/uploads/2016/10/840x459xScreenshot-2016-10-17-20.05.08-1024x560.png,qx38712.pagespeed.ic.1EV4RiRLH4.jp)
 
@@ -39,7 +39,7 @@ The activity feed captures different updates that are made to collections. This 
 
 A consolidated update to a request, for example, looks like the screenshot above providing you with a diff view to pinpoint the exact changes. 
 
-**Note**: Postman Pro users can view diffs. Other users will be able to track the "who" and "when" in the activity feeds, but not the "what" at this level of detail. 
+**Note**: Postman Pro and Enterprise users can view diffs. Other users will be able to track the "who" and "when" in the activity feeds, but not the "what" at this level of detail. 
 
 ### Restoring collections
 
@@ -57,7 +57,7 @@ And now the top of the activity feed displays the confirmation of restoring the 
 
 ### Connecting to Slack, HipChat and other platforms
 
-Postman Pro and Enterprise users can pipe the team's activity feed to a communication channel of your choosing with the following integrations
+Postman Pro and Enterprise users can pipe the team's activity feed to a communication channel of your choosing with the following integrations:
 
    *   [Postman Pro to Slack integration](/docs/pro/integrations/slack)
    *   [Postman Pro to Slack integration](/docs/pro/integrations/hipchat)
@@ -65,4 +65,4 @@ Postman Pro and Enterprise users can pipe the team's activity feed to a communic
 
 ### Upcoming additions to the activity feed
 
-The activity feed will become even more powerful in the near future.  It’ll integrate with all our Postman Pro and Enterprise products and other features in the pipeline. We're going to soon add **Tagging** support. You'll be able to tag collections at a point in time, allowing easier referencing and ability to rollback, while also allowing you to set up Monitors and Documentation on tagged versions of the collection. These version control constructs will allow your team even more flexibility with your API code development within Postman Pro.
+The activity feed will become even more powerful in the near future.  It’ll integrate with all our Postman Pro and Enterprise products and other features in the pipeline. We're going to soon add **Tagging** support. You'll be able to tag collections at a point in time, allowing easier referencing and ability to rollback, while also allowing you to set up Monitors and Documentation on tagged versions of the collection. These version control constructs will allow your team even more flexibility with your API code development within Postman Pro or Enterprise.

--- a/_posts/01_postman/07_team_library/2017-05-04-sharing.md
+++ b/_posts/01_postman/07_team_library/2017-05-04-sharing.md
@@ -4,11 +4,13 @@ categories:
   - "team_library"
 title: "Sharing"
 page_id: "sharing"
+tags: 
+  - "pro"
+  - "enterprise"
 warning: false
 ---
 
-
-Your Postman Pro Team Library lets you collaborate faster with your teammates. Team members can share collections and environment templates and see the activity feed in the Team Library. You can think of the Team Library as a way to organize your API infrastructure and make finding API documentation, workflows, and test suites easy.
+Postman Pro and Enterprise users have access to a Team Library which lets you collaborate faster with your teammates. Team members can share collections and environment templates and see the activity feed in the Team Library. You can think of the Team Library as a way to organize your API infrastructure and make finding API documentation, workflows, and test suites easy.
 
 Your Team Library should be the single source of truth about your APIs. It will let you see the state of your APIs in real time, or review historical versions and the latest updates.
 
@@ -20,6 +22,8 @@ Environment templates work slightly differently. Through an environment template
 
 ### Sharing Collections
 
+In addition to the [standard ways to share a collection](/docs/postman/collections/sharing_collections), Postman Pro and Enterprise users can also share collections with their team or specific team members.
+
 1.  From the Collections tab in the sidebar, click on the ellipses (**...**) next to the collection you would like to share, and select "Share".
 2.  Specify the team permissions by selecting "Can View" or "Can Edit" in the dropdown.  
     [![edit team permissions](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58787441.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58787441.png)
@@ -29,6 +33,8 @@ Environment templates work slightly differently. Through an environment template
 5.  Go to the Team Library to view the full list of team collections.
 
 ### Sharing environments
+
+In addition to the [standard way to share an environment](/docs/postman/environments_and_globals/manage_environments#share-an-environment), Postman Pro and Enterprise users can also share an environment template with their team.
 
 1.  From the gear icon in the upper right corner of the Postman app, select "Manage Environments", and click the orange **Share** button next to the environment you want to share. 
 2.  You will have one last opportunity to hide any sensitive values like passwords and access tokens before sharing the environment template.  When someone else imports the environment, or accesses the shared template, they can input their own personal information within their own version of the template.  

--- a/_posts/01_postman/08_api_documentation/2017-05-04-adding_and_verifying_custom_domains.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-adding_and_verifying_custom_domains.md
@@ -7,7 +7,7 @@ page_id: "adding_and_verifying_custom_domains"
 warning: false
 ---
 
-Postman Pro users with public documentation have the capability to publish documentation on their own custom domain.
+Postman users with public documentation have the capability to publish documentation on their own custom domain.
 
 ### Add a custom domain
 

--- a/_posts/01_postman/08_api_documentation/2017-05-04-adding_and_verifying_custom_domains.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-adding_and_verifying_custom_domains.md
@@ -4,8 +4,6 @@ categories:
   - "api_documentation"
 title: "Adding and verifying custom domains"
 page_id: "adding_and_verifying_custom_domains"
-tags: 
-  - "pro"
 warning: false
 ---
 

--- a/_posts/01_postman/08_api_documentation/2017-05-04-adding_team_name_and_logo.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-adding_team_name_and_logo.md
@@ -1,0 +1,40 @@
+---
+categories:
+  - "postman"
+  - "api_documentation"
+title: "Adding team name and logo"
+page_id: "adding_team_name_and_logo"
+tags: 
+  - "pro"
+warning: false
+---
+
+Postman users with the **Admin** member role can add a team name and logo to their Postman team account directly from the [Edit Team Details page](https://app.getpostman.com/dashboard/teams/edit).
+
+### Update your team name
+
+You can see your current team name on the [team page](https://app.getpostman.com/dashboard/teams) of the Postman web view.
+
+[![team name](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/teamName.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/teamName.png)
+
+If you didn’t enter a team name when you first created your Postman Pro or Enterprise team, you can update that now. From the [team page](https://app.getpostman.com/dashboard/teams), click the gear icon in the top right, and select “Edit team” to update your team name.
+
+[![edit team details page](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/editTeamDetails.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/editTeamDetails.png)
+
+### Update your team logo
+
+From the [team page](https://app.getpostman.com/dashboard/teams), click the gear icon in the top right, and select “Edit team” to add or update your team logo.
+
+[![update logo](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/teamLogo.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/teamLogo.png)
+
+This uploaded image will be displayed in the header of your team's [published documentation](/docs/postman/api_documentation/intro_to_api_documentation) instead of the Postman logo. It may take up to 5 minutes for the logo to update.
+
+### Custom team URLs
+
+At Postman, we believe our product should have a clean and accessible URL design. Custom team URLs are available for Postman Pro and Enterprise users. This makes Postman features easier to access and streamlines the sign in process. 
+
+Team URLs to access Postman are derived from your team name. With a custom team URL, you can access the Postman web view by typing `<your-team-name>.postman.co` into your browser. 
+
+For example, if my team name is “postmanlabs”, my custom team URL will now be `postmanlabs.postman.co`, and all features will be predictably accessible by appending `/docs`, `/monitors`, or any other Postman features.
+
+[![urls in browser](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/urlsInBrowser.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/urlsInBrowser.png)

--- a/_posts/01_postman/08_api_documentation/2017-05-04-adding_team_name_and_logo.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-adding_team_name_and_logo.md
@@ -6,6 +6,7 @@ title: "Adding team name and logo"
 page_id: "adding_team_name_and_logo"
 tags: 
   - "pro"
+  - "enterprise"
 warning: false
 ---
 

--- a/_posts/01_postman/08_api_documentation/2017-05-04-environments_and_environment_templates.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-environments_and_environment_templates.md
@@ -4,8 +4,6 @@ categories:
   - "api_documentation"
 title: "Environments and environment templates"
 page_id: "environments_and_environment_templates"
-tags: 
-  - "pro"
 warning: false
 ---
 

--- a/_posts/01_postman/08_api_documentation/2017-05-04-how_to_document_using_markdown.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-how_to_document_using_markdown.md
@@ -4,8 +4,6 @@ categories:
   - "api_documentation"
 title: "How to document using Markdown"
 page_id: "how_to_document_using_markdown"
-tags: 
-  - "pro"
 warning: false
 ---
 

--- a/_posts/01_postman/08_api_documentation/2017-05-04-intro_to_api_documentation.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-intro_to_api_documentation.md
@@ -10,7 +10,7 @@ warning: false
 
 Postman's API documentation feature allows you to share public or private API documentation, beautifully viewable via a web page. 
 
-Postman Pro generates and hosts browser-based API documentation for your collections automatically in real-time. Each collection has a private and public documentation view, generated in real-time using the data synced to our servers. In order to [access the private view](/docs/postman/api_documentation/viewing_documentation), click "View in web" in the Postman app or in the "Team Library". The public view is accessible via the public link, generated when you [publish your documentation](/docs/postman/api_documentation/publishing_public_docs). This link will be displayed right after your documentation is published, and is also accessible via the "Published" dropdown in the private documentation view.
+Postman generates and hosts browser-based API documentation for your collections automatically in real-time. Each collection has a private and public documentation view, generated in real-time using the data synced to our servers. In order to [access the private view](/docs/postman/api_documentation/viewing_documentation), click "View in web" in the Postman app or in the "Team Library". The public view is accessible via the public link, generated when you [publish your documentation](/docs/postman/api_documentation/publishing_public_docs). This link will be displayed right after your documentation is published, and is also accessible via the "Published" dropdown in the private documentation view.
 
 ### What gets automatically generated?
 

--- a/_posts/01_postman/08_api_documentation/2017-05-04-intro_to_api_documentation.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-intro_to_api_documentation.md
@@ -4,8 +4,6 @@ categories:
   - "api_documentation"
 title: "Intro to API documentation"
 page_id: "intro_to_api_documentation"
-tags: 
-  - "pro"
 warning: false
 
 ---

--- a/_posts/01_postman/08_api_documentation/2017-05-04-publishing_public_docs.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-publishing_public_docs.md
@@ -4,8 +4,6 @@ categories:
   - "api_documentation"
 title: "Publishing public docs"
 page_id: "publishing_public_docs"
-tags: 
-  - "pro"
 warning: false
 ---
 

--- a/_posts/01_postman/08_api_documentation/2017-05-04-publishing_public_docs.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-publishing_public_docs.md
@@ -15,9 +15,13 @@ You can only publish documentation for collections that you created or for which
 
 [![publish button](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59116421.png) ](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59116421.png)  
 
-If you are signed in to Postman, you can select a corresponding environment with which to publish the collection. Any references to variables like {% raw %}`{{url}}`{% endraw %} in the collection will be replaced with the correct value from the environment. The public URL field in the screenshot below contains the URL that you can share with the outside world. For example, if you’re publishing your primary collection, you might want to select the “Production” environment, so that your documentation is immediately usable for new visitors. 
+If you are signed in to Postman, you can select a corresponding environment with which to publish the collection. Any references to variables like {% raw %}`{{url}}`{% endraw %} in the collection will be replaced with the correct value from the environment. 
 
-[![publish collection settings](https://www.getpostman.com/img/v1/docs/publishing_docs/Docs4.png)](https://www.getpostman.com/img/v1/docs/publishing_docs/Docs4.png)
+[![publish collection settings](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/publishCollectionSettings.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/publishCollectionSettings.png)
+
+The public URL field in the screenshot below contains the URL that you can share with the outside world. For example, if you’re publishing your primary collection, you might want to select the “Production” environment, so that your documentation is immediately usable for new visitors. 
+
+[![published collection settings](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/publishedCollection.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/publishedCollection.png)
 
 > **IMPORTANT:**  Any confidential info in your environment, such as **passwords and access tokens**, might be visible publicly. Ensure that all such information is removed from the environment before you publish documentation with an environment.
 
@@ -37,6 +41,10 @@ Optionally, you can pick from a list of verified [custom domains](/docs/postman/
 
 ### Custom styling options
 
-Postman allows you to customize the appearance of your published documentation pages. Add your team logo and update the color theme to align with your brand. Your team logo can be uploaded from the Team Settings section in the dashboard.
+Postman allows you to customize the appearance of your published documentation pages. Add your [team logo](/docs/postman/api_documentation/adding_team_name_and_logo) and update the color theme to align with your brand. 
+
+You can update the custom styling options either before or after you publish your documentation. Click the **Show Custom Styling Options** link to expand the section and update your color palette.
+
+[![before publishing](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/customStylingOptions.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/customStylingOptions.png)
 
 [![custom styling options](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59016798.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59016798.png)

--- a/_posts/01_postman/08_api_documentation/2017-05-04-viewing_documentation.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-viewing_documentation.md
@@ -4,8 +4,6 @@ categories:
   - "api_documentation"
 title: "Viewing documentation"
 page_id: "viewing_documentation"
-tags: 
-  - "pro"
 warning: false
 
 ---

--- a/_posts/01_postman/08_api_documentation/2017-05-04-viewing_documentation.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-viewing_documentation.md
@@ -12,7 +12,7 @@ Each collection has a private and public documentation view, generated in real-t
 
 ### Viewing Private Documentation
 
-In order to access the private view, which is only available to your team, click "View Docs" in the Postman app or in the [Postman web view](https://app.getpostman.com/dashboard/collections/team){:target="_blank"}. 
+In order to view private documentation, which is only accessible to you and your Postman Pro team, click "View Docs" in the Postman app or in the [Postman web view](https://app.getpostman.com/dashboard/collections/team){:target="_blank"}. 
 
 Private documentation is available to all Postman users. To view private documentation for a collection, make sure you’re signed in to the Postman app. When signed in, your username will be displayed in the top-right corner.
 

--- a/_posts/01_postman/08_api_documentation/2017-05-04-viewing_documentation.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-viewing_documentation.md
@@ -12,7 +12,7 @@ Each collection has a private and public documentation view, generated in real-t
 
 ### Viewing Private Documentation
 
-In order to view private documentation, which is only accessible to you and your Postman Pro team, click "View Docs" in the Postman app or in the [Postman web view](https://app.getpostman.com/dashboard/collections/team){:target="_blank"}. 
+In order to view private documentation, which is only accessible to you and your Postman Pro or Enterprise team, click "View Docs" in the Postman app or in the [Postman web view](https://app.getpostman.com/dashboard/collections/team){:target="_blank"}. 
 
 Private documentation is available to all Postman users. To view private documentation for a collection, make sure you’re signed in to the Postman app. When signed in, your username will be displayed in the top-right corner.
 
@@ -30,7 +30,7 @@ Clicking this button will open the documentation for that collection in your bro
 
 [![view documentation](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59032512.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59032512.png)
 
-Keep in mind that this view is restricted to users in your Postman Pro Team. This link will not work for anyone who does not have access to the collection itself. If the collection is shared with your team, anyone in the team can view the private documentation for this collection. If your collection is not shared, only you can view the private documentation for this collection.
+Keep in mind that this view is restricted to users in your Postman Pro and Enterprise team. This link will not work for anyone who does not have access to the collection itself. If the collection is shared with your team, anyone in the team can view the private documentation for this collection. If your collection is not shared, only you can view the private documentation for this collection.
 
 To make this documentation available to other users, perhaps as a link on your website, you’ll need to [publish the documentation](https://app.getpostman.com/dashboard/collections/team){:target="_blank"}.
 

--- a/_posts/01_postman/09_monitors/2017-05-04-faqs_monitors.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-faqs_monitors.md
@@ -4,8 +4,6 @@ categories:
   - "monitors"
 title: "FAQs for monitors"
 page_id: "faqs_monitors"
-tags: 
-  - "pro"
 warning: false
 ---
 

--- a/_posts/01_postman/09_monitors/2017-05-04-faqs_monitors.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-faqs_monitors.md
@@ -41,7 +41,7 @@ You can view the full console output for every monitor run, including any errors
 
 ##### **Who can see my Monitors?**
 
-Monitors have the same permissions as Postman Collections. By default, your collections are private, so only you can see the collection and its monitors. If you share a collection, then other members of your team will be able to see the collection and its monitors. If you grant ``View & Edit`` permissions, then your team members will also be able to add monitors to your collection.
+Monitors have the same permissions as Postman Collections. By default, your collections are private, so only you can see the collection and its monitors. If you share a collection, then other members of your Postman Pro or Enterprise team will be able to see the collection and its monitors. If you grant ``View & Edit`` permissions, then your team members will also be able to add monitors to your collection.
 
 Each collection can have different permissions, so you can choose to have some private, some shared but view-only, and some shared and editable.
 

--- a/_posts/01_postman/09_monitors/2017-05-04-integrations_for_alerts.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-integrations_for_alerts.md
@@ -6,6 +6,7 @@ title: "Set up integrations to receive alerts"
 page_id: "integrations_for_alerts"
 tags: 
   - "pro"
+  - "enterprise"
 warning: false
 ---
 

--- a/_posts/01_postman/09_monitors/2017-05-04-intro_monitors.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-intro_monitors.md
@@ -14,7 +14,7 @@ A monitor lets you run a [collection](/docs/postman/collections/creating_collec
 
 When you set up a monitor, Postman servers will hit the endpoints in your collection according to the specified frequency. You can also select a corresponding [environment](/docs/postman/environments_and_globals/manage_environments) to use and store variables. If you have written [tests](/docs/postman/scripts/test_scripts) for your requests , the monitor would run these tests to validate the response and notify you when a test fails. You can configure how to receive the alerts from a wide number of [integrations](/docs/pro/integrations/intro_integrations) available.
 
-Each Postman user gets 1,000 monitoring calls for free per month. Each Postman Pro team gets 10,000 free monthly requests, and it takes only 2 minutes to set up a monitor. Learn more about [monitor pricing](/docs/postman/monitors/pricing_monitors) and [getting started with monitors](/docs/postman/monitors/setting_up_monitor).
+Each Postman user gets 1,000 monitoring calls for free per month. Each Postman Pro and Enterprise team gets 10,000 free monthly requests, and it takes only 2 minutes to set up a monitor. Learn more about [monitor pricing](/docs/postman/monitors/pricing_monitors) and [getting started with monitors](/docs/postman/monitors/setting_up_monitor).
 
 ### Differences between Monitors and the Postman app
 

--- a/_posts/01_postman/09_monitors/2017-05-04-intro_monitors.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-intro_monitors.md
@@ -4,8 +4,6 @@ categories:
   - "monitors"
 title: "Intro to Monitors"
 page_id: "intro_monitors"
-tags: 
-  - "pro"
 warning: false
 
 ---

--- a/_posts/01_postman/09_monitors/2017-05-04-intro_monitors.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-intro_monitors.md
@@ -14,7 +14,7 @@ A monitor lets you run a [collection](/docs/postman/collections/creating_collec
 
 When you set up a monitor, Postman servers will hit the endpoints in your collection according to the specified frequency. You can also select a corresponding [environment](/docs/postman/environments_and_globals/manage_environments) to use and store variables. If you have written [tests](/docs/postman/scripts/test_scripts) for your requests , the monitor would run these tests to validate the response and notify you when a test fails. You can configure how to receive the alerts from a wide number of [integrations](/docs/pro/integrations/intro_integrations) available.
 
-Each Postman Pro team gets 10,000 free monthly requests, and it takes only 2 minutes to set up a monitor. Learn more about [monitor pricing](/docs/postman/monitors/pricing_monitors) and [getting started with monitors](/docs/postman/monitors/setting_up_monitor).
+Each Postman user gets 1,000 monitoring calls for free per month. Each Postman Pro team gets 10,000 free monthly requests, and it takes only 2 minutes to set up a monitor. Learn more about [monitor pricing](/docs/postman/monitors/pricing_monitors) and [getting started with monitors](/docs/postman/monitors/setting_up_monitor).
 
 ### Differences between Monitors and the Postman app
 

--- a/_posts/01_postman/09_monitors/2017-05-04-monitoring_apis_websites.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-monitoring_apis_websites.md
@@ -4,8 +4,6 @@ categories:
   - "monitors"
 title: "Monitoring APIs and websites"
 page_id: "monitoring_apis_websites"
-tags: 
-  - "pro"
 warning: false
 ---
 

--- a/_posts/01_postman/09_monitors/2017-05-04-pricing_monitors.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-pricing_monitors.md
@@ -11,7 +11,7 @@ warning: false
 
 Usage of Postman Monitors is billed on a per-request basis. A request is any HTTP request needed to run your collection. If your collection has 5 requests, but you've used `postman.setNextRequest()` to skip some requests, or run requests multiple times, you'll be billed according to the number of requests actually made, not the number of requests in your collection. Any requests needed for the auth helpers (Digest Auth, OAuth, etc.) will also be included in your usage count.
 
-Each Pro/Enterprise team gets 10,000 free requests per month. The first month starts the day you send your first monitoring request, or when you set up a monthly block for your team.
+Each Postman user gets 1,000 monitoring calls for free per month. Each Postman Pro or Enterprise team gets 10,000 free requests per month. The first month starts the day you send your first monitoring request, or when you set up a monthly block for your team.
 
 Teams on the free Pro trial cannot go beyond this limit. If you are on the free trial, you will have to wait for the next monitoring billing cycle to get another 10,000 requests.
 

--- a/_posts/01_postman/09_monitors/2017-05-04-pricing_monitors.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-pricing_monitors.md
@@ -6,6 +6,7 @@ title: "Pricing for monitors"
 page_id: "pricing_monitors"
 tags: 
   - "pro"
+  - "enterprise"
 warning: false
 ---
 

--- a/_posts/01_postman/09_monitors/2017-05-04-setting_up_monitor.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-setting_up_monitor.md
@@ -4,8 +4,6 @@ categories:
   - "monitors"
 title: "Setting up a monitor"
 page_id: "setting_up_monitor"
-tags: 
-  - "pro"
 warning: false
 ---
 

--- a/_posts/01_postman/09_monitors/2017-05-04-troubleshooting_monitors.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-troubleshooting_monitors.md
@@ -4,8 +4,6 @@ categories:
   - "monitors"
 title: "Troubleshooting monitors"
 page_id: "troubleshooting_monitors"
-tags: 
-  - "pro"
 warning: false
 ---
 

--- a/_posts/01_postman/09_monitors/2017-05-04-viewing_monitor_results.md
+++ b/_posts/01_postman/09_monitors/2017-05-04-viewing_monitor_results.md
@@ -4,8 +4,6 @@ categories:
   - "monitors"
 title: "Viewing monitor results"
 page_id: "viewing_monitor_results"
-tags: 
-  - "pro"
 warning: false
 ---
 

--- a/_posts/01_postman/2017-05-04-mock_servers.md
+++ b/_posts/01_postman/2017-05-04-mock_servers.md
@@ -6,11 +6,11 @@ page_id: "mock_servers"
 warning: false
 ---
 
-### Simulate a back end with Postman Pro's mock servers
+### Simulate a back end with Postman's mock servers
 
 Throughout the development process, delays on the front end or back end can hold up dependent teams from completing their work efficiently.  
 
-Using Postman Pro's mock servers, front-end developers can simulate each endpoint in a Postman Collection (and corresponding environment) to view the potential responses, without actually spinning up a back end.
+Using Postman's mock servers, front-end developers can simulate each endpoint in a Postman Collection (and corresponding environment) to view the potential responses, without actually spinning up a back end.
 
 Front-end, back-end and API teams can now work in parallel, freeing up developers who were previously delayed as a result of these dependencies. Let’s walk through this step by step.
 

--- a/_posts/01_postman/2017-05-04-mock_servers.md
+++ b/_posts/01_postman/2017-05-04-mock_servers.md
@@ -3,8 +3,6 @@ categories:
   - "postman"
 title: "Mock Servers"
 page_id: "mock_servers"
-tags: 
-  - "pro"
 warning: false
 ---
 

--- a/_posts/01_postman/2017-05-04-mock_servers.md
+++ b/_posts/01_postman/2017-05-04-mock_servers.md
@@ -20,6 +20,8 @@ In this example, we have a Collection `testAPI` with corresponding environmen
 
 Navigate to every request in the Collection `testAPI` that you would like to include in this simulation, and [save responses](/docs/postman/sending_api_requests/responses) with details about the response body, header or status codes that you would like to see returned by that endpoint. In this example, we will save 2 responses with status codes of 200 and 401 for this particular request.  Once you save the desired responses, the Collection is ready for mocking.
 
+**Note**: In addition to mocking a collection with a saved response, you can also [mock a request and response using examples](/docs/postman/collections/examples).
+
 [![saved responses](http://blog.getpostman.com/wp-content/uploads/2017/03/Screen-Shot-2017-03-15-at-3.44.27-PM-1024x726.png)](http://blog.getpostman.com/wp-content/uploads/2017/03/Screen-Shot-2017-03-15-at-3.44.27-PM.png)
 
 ### Retrieve information needed for mock creation
@@ -67,6 +69,10 @@ https://{{mockId}}.mock.pstmn.io/{{mockPath}}
    *   Mock requests also accept another optional header, `x-mock-response-code`, which specifies which integer response code your returned response should match.  For example, 500 will return only a 500 response. If this header is not provided, the closest match of any response code will be returned.
 
 [![request headers](http://blog.getpostman.com/wp-content/uploads/2017/03/Screen-Shot-2017-03-15-at-4.27.58-PM-1024x615.png)](http://blog.getpostman.com/wp-content/uploads/2017/03/Screen-Shot-2017-03-15-at-4.27.58-PM.png)
+
+### Mock requests and responses with examples
+
+In the previous example, we used a saved response to mock our collection. You can also [mock a request and response using examples](/docs/postman/collections/examples) in Postman before sending the actual request or setting up a single endpoint to return the response. With examples, you can mock raw responses and save them. Then, you’ll be able to generate a mock endpoint for each of them using Postman’s mock service. 
 
 ### Free mock server calls with your Postman account
 

--- a/_posts/01_postman/2017-05-04-notifications.md
+++ b/_posts/01_postman/2017-05-04-notifications.md
@@ -3,8 +3,6 @@ categories:
   - "postman"
 title: "Notifications"
 page_id: "notifications"
-tags:
-  - "pro"
 warning: false
 ---
 

--- a/_posts/02_pro/01_managing_pro/2017-05-04-activating_trial.md
+++ b/_posts/02_pro/01_managing_pro/2017-05-04-activating_trial.md
@@ -14,9 +14,9 @@ A Postman account is required to activate your Postman Pro trial.
 ### If you have a Postman account
 
    *   Sign in to your Postman account from the Postman [home page](https://www.getpostman.com/){:target="_blank"}. 
-   *   On the [team plans page](https://app.getpostman.com/dashboard/team-plans){:target="_blank"}, click **Activate 30 day free trial**.
+   *   On the [team plans page](https://app.getpostman.com/dashboard/team-plans){:target="_blank"}, click **Activate 7 day free trial**.
         [![team plans page](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/trial_prompt.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/trial_prompt.png)  
-   *   You will be redirected to the Postman [pricing page](https://www.getpostman.com/pricing#cloud-free-trial-30){:target="_blank"}. Click the **ACTIVATE TRIAL** button.  
+   *   You will be redirected to the Postman [dashboard](https://www.getpostman.com/pricing#cloud-free-trial-30){:target="_blank"}. Click the **ACTIVATE TRIAL** button.  
         [![activate trial](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58764185.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58764185.png)
 
 ### If you don't already have a Postman account

--- a/_posts/02_pro/02_pro_api/2017-05-04-intro_api.md
+++ b/_posts/02_pro/02_pro_api/2017-05-04-intro_api.md
@@ -48,4 +48,4 @@ API access rate limits are applied at a per-key basis in unit time. Access to th
 
 ### Free API calls with your Postman account
 
-Your Postman account gives you a limited number of free API calls per month. You can check your usage limits through the API itself or the [account usage page](https://go.pstmn.io/postman-account-limits).
+Your Postman account gives you a limited number of free Postman Pro API calls per month. You can check your usage limits through the [Postman Pro API](https://docs.api.getpostman.com) itself or the [account usage page](https://go.pstmn.io/postman-account-limits).

--- a/_posts/02_pro/2015-05-04-what_is_pro.md
+++ b/_posts/02_pro/2015-05-04-what_is_pro.md
@@ -21,6 +21,6 @@ Postman Pro offers solutions that satisfy each of the questions above. 
 
 *   Team [collaboration](/docs/postman/team_library/sharing) for the single source of truth about your API, or review historical versions and the latest updates.
 *   API [documentation](/docs/postman/api_documentation/intro_to_api_documentation) to share public or private documentation, beautifully viewable via a web page.
-*   [Mock servers](/docs/postman/mock_servers) to simulate the real API and decouple teams
+*   Powerful [mock servers](/docs/postman/mock_servers) to simulate the real API and decouple teams.
 *   Collection [monitoring](/docs/postman/monitors/intro_monitors) to check for the performance, uptime and correctness of your API.
-*   [Pre-built integrations](/docs/pro/integrations/intro_integrations) and the [Postman API](/docs/pro/pro_api/intro_api) to connect your different tools.
+*   [Out-of-the-box integrations](/docs/pro/integrations/intro_integrations) and the [Postman Pro API](/docs/pro/pro_api/intro_api) to connect your different tools.

--- a/_posts/03_enterprise/2017-05-04-intro_to_enterprise.md
+++ b/_posts/03_enterprise/2017-05-04-intro_to_enterprise.md
@@ -1,0 +1,13 @@
+---
+categories:
+  - "enterprise"
+title: "Intro to Enterprise"
+page_id: "intro_to_enterprise"
+tags: 
+  - "enterprise"
+warning: false
+---
+
+Enterprise features in support, billing and administration, combined with the power of the complete Postman API platform.
+
+If you would like to learn more about Postman Enterprise, email us at [help@getpostman.com](mailto:help@getpostman.com). 

--- a/_posts/04_postman_for_publishers/01_run_button/2017-05-04-creating_run_button.md
+++ b/_posts/04_postman_for_publishers/01_run_button/2017-05-04-creating_run_button.md
@@ -18,7 +18,7 @@ To create the Run in Postman button, start in the Postman app. Make sure you are
 
 1.  Click on the ellipses **(...)** next to the collection you would like to embed and select "Share". 
 
-    [![share collection](https://cloud.githubusercontent.com/assets/681190/18237865/29682800-7354-11e6-8991-29f1ed75c5a8.png)](https://cloud.githubusercontent.com/assets/681190/18237865/29682800-7354-11e6-8991-29f1ed75c5a8.png)
+    [![share collection](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/shareCollectionDropdown.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/shareCollectionDropdown.png)
 
 2.  Under the **Embed Button** tab, click the **Generate Code** button to upload the collection to the Postman servers.
 

--- a/_posts/04_postman_for_publishers/2017-05-04-public_api_docs.md
+++ b/_posts/04_postman_for_publishers/2017-05-04-public_api_docs.md
@@ -3,8 +3,6 @@ categories:
   - "postman_for_publishers"
 title: "Public API documentation"
 page_id: "public_api_docs"
-tags: 
-  - "pro"
 warning: false
 
 ---

--- a/_posts/09_managing_collections/2016-07-11-collections.md
+++ b/_posts/09_managing_collections/2016-07-11-collections.md
@@ -52,7 +52,7 @@ Editing a collection is quite simple. Hover over the collection name and click o
 
 Collections can be downloaded as a JSON file which you can share with others or shared through your Postman account. You can also share collections anonymously but it is strongly recommended to create a Postman account when uploading collections. This will let you update your existing collection, make it public or delete it later.
 
-If you are a member of a team using Postman Pro, you can share a collection with your whole team or a sub section of it in this modal. You can also make it view-only versus editable.
+If you are a member of a team using Postman Pro or Enterprise, you can share a collection with your whole team or a sub section of it in this modal. You can also make it view-only versus editable.
 
 #### Deleting a collection
 

--- a/_posts/12_api_testing_and_collection_runner/2016-07-11-schedule_cloud_runs.md
+++ b/_posts/12_api_testing_and_collection_runner/2016-07-11-schedule_cloud_runs.md
@@ -10,7 +10,7 @@ warning: false
 
 ### Monitoring Docs
 
-Postman Monitors let you schedule your collections to run automatically! All Postman Pro teams have access - just head to https://monitor.getpostman.com/ to get started.
+Postman Monitors let you schedule your collections to run automatically! All Postman Pro and Enterprise teams have access - just head to https://monitor.getpostman.com/ to get started.
 
 ![](https://cloud.githubusercontent.com/assets/681190/21090390/792944e2-c065-11e6-8937-39c18fe888ad.png)
 


### PR DESCRIPTION
- 100K copy changes related to limits and access, Pro and Enterprise tags, screenshots
- update navigation to mirror marketing website
- update mock server page with examples cross links and blurbs
- add multi-level folders and folder reordering, with canary tag
- fix level up with postman pro link on popular topics
- add custom team name and logo page
- add enterprise intro page - still need server side redirect

@godfrzero please review