### PR TITLE
break out custom team urls to separate page

### DIFF
--- a/_data/doc_map.json
+++ b/_data/doc_map.json
@@ -439,6 +439,11 @@
             "title": "Inviting and managing",
             "href":"/docs/pro/managing_pro/inviting_and_managing",
             "external": false
+          },
+          {
+            "title": "Team settings",
+            "href":"/docs/pro/managing_pro/team_settings",
+            "external": false
           }
         ]
       },

--- a/_posts/01_postman/08_api_documentation/2017-05-04-adding_team_name_and_logo.md
+++ b/_posts/01_postman/08_api_documentation/2017-05-04-adding_team_name_and_logo.md
@@ -29,13 +29,3 @@ From the [team page](https://app.getpostman.com/dashboard/teams), click the gear
 [![update logo](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/teamLogo.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/teamLogo.png)
 
 This uploaded image will be displayed in the header of your team's [published documentation](/docs/postman/api_documentation/intro_to_api_documentation) instead of the Postman logo. It may take up to 5 minutes for the logo to update.
-
-### Custom team URLs
-
-At Postman, we believe our product should have a clean and accessible URL design. Custom team URLs are available for Postman Pro and Enterprise users. This makes Postman features easier to access and streamlines the sign in process. 
-
-Your team URL is shown on the [team page](https://app.getpostman.com/dashboard/teams). With a custom team URL, you can access the Postman web view by typing `<your-team-domain>.postman.co` into your browser. 
-
-For example, if my team domain is “postmanlabs”, my custom team URL will now be `postmanlabs.postman.co`, and all features will be predictably accessible by appending `/docs`, `/monitors`, or any other Postman features.
-
-[![urls in browser](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/urlsInBrowser.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/urlsInBrowser.png)

--- a/_posts/02_pro/01_managing_pro/2017-05-04-team_settings.md
+++ b/_posts/02_pro/01_managing_pro/2017-05-04-team_settings.md
@@ -1,0 +1,23 @@
+---
+categories:
+  - "pro"
+  - "managing_pro"
+title: "Team settings"
+page_id: "team_settings"
+tags: 
+  - "pro"
+warning: false
+
+---
+
+Postman's web [dashboard](https://app.getpostman.com/dashboard/teams){:target="_blank"} provides a number of ways to [manage your team](/docs/pro/managing_pro/inviting_and_managing). Postman Pro and Enterprise users can [add a team name and logo](/docs/postman/api_documentation/adding_team_name_and_logo) to their Postman team account.
+
+### Custom team URLs
+
+At Postman, we believe our product should have a clean and accessible URL design. Custom team URLs are available for Postman Pro and Enterprise users. This makes Postman features easier to access and streamlines the sign in process. 
+
+Your team URL is shown on the [team page](https://app.getpostman.com/dashboard/teams). With a custom team URL, you can access the Postman web view by typing `<your-team-domain>.postman.co` into your browser. 
+
+For example, if my team domain is “postmanlabs”, my custom team URL will now be `postmanlabs.postman.co`, and all features will be predictably accessible by appending `/docs`, `/monitors`, or any other Postman features.
+
+[![urls in browser](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/urlsInBrowser.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/urlsInBrowser.png)

--- a/_posts/03_enterprise/2017-05-04-intro_to_enterprise.md
+++ b/_posts/03_enterprise/2017-05-04-intro_to_enterprise.md
@@ -11,3 +11,5 @@ warning: false
 As an Enterprise customer, you’ll have exclusive access to single sign-on, priority support from our dedicated Enterprise Support Team, banded group pricing, and flexible billing. 
 
 If you would like to learn more about Postman Enterprise, email us at [{{site.pm.enterprise_email}}](mailto:{{site.pm.enterprise_email}}). 
+
+Postman Pro and Enterprise users can [add a team name and logo](/docs/postman/api_documentation/adding_team_name_and_logo) to their Postman team account and [use a custom URL](/docs/pro/managing_pro/team_settings#custom-team-url) to predictably access Postman features.


### PR DESCRIPTION
move custom team urls out of `API documentation` section, and add as section under new page `Team Settings` in Postman Pro, with cross links to API documentation adding team name and logo, intro to enterprise, and Managing pro inviting and managing.