### PR TITLE
fix next page link

### DIFF
--- a/_includes/_related_links.html
+++ b/_includes/_related_links.html
@@ -55,7 +55,7 @@
 
         {% if hrefArray[nextIndex] %}
         <div class="doc-next-link clearfix visible-xs">
-            <a href="{{hrefArray[nextIndex]}}" {% if externalArray[nextIndex] == true %}target="_blank"{% endif %} class="col-xs-12 next-article pull-right">
+            <a href="{{newNextHref}}" {% if externalArray[nextIndex] == true %}target="_blank"{% endif %} class="col-xs-12 next-article pull-right">
                 {{titleArray[nextIndex]}}
             </a>
         </div>


### PR DESCRIPTION
Reported by deepakpathania, and I confirmed, the next page btn on mobile lead to 404
for example this page. 
https://www.getpostman.com/docs/postman/launching_postman/sending_the_first_request
If you open it in a mobile browser, then ‘Creating first collection’ at bottom of page leads to a 404 (https://www.getpostman.com/postman/launching_postman/creating_the_first_collection)