### PR TITLE
Update 2018-01-22-using_workspaces.md

### DIFF
--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -170,7 +170,8 @@ To share a Workspace, go to the status bar at the bottom of the screen and click
 Select "Browse" and click the Share button to share a collection, environment, monitor, mock, or integration to share.
 
 
-### Sharing collections and environments in Workspaces
+
+Sharing collections and environments in Workspaces
 
 You can only share Postman collections and environments with other Workspaces. In this example, we share a collection to a Workspace. You also create new monitors and mocks other Workspaces.
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -88,6 +88,8 @@ Click the ***Ellipsis (...)*** button in the element you want to remove and sele
 
 When you delete an element, you erase its existence in Postman. 
 
+**Deleting elements in the Dashboard**
+
 To delete a Workspace, go to the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"} and select a Workspace. In this example, we select a team Workspace to delete.
 
 Click the ***Ellipsis (...)*** button for the element you want to delete and select "Delete".
@@ -97,6 +99,14 @@ Click the ***Ellipsis (...)*** button for the element you want to delete and sel
 In "Delete Workspace", click the **Delete** button. Remember when you delete a Workspace, it is gone forever!
 
 [![delete workspace](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-delete_WS.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-delete_WS.png)
+
+**Deleting elements in the Postman app**
+
+In the status bar at the bottom of the screen, click the "Build" menu and select "Browse".
+
+[![build menu](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-build-menu.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-build-menu.png)
+
+Select a Workspace and follow the steps outlined in "Deleting elements in the Dashboard" above.
 
 ### Joining Workspaces
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -38,7 +38,7 @@ Here you'll learn how to perform actions on Workspaces and how to use Workspaces
 
 * [Removing elements from Workspaces](#removing-elements-from-workspaces)
 
-* [Sharing collections and other elements in Workspaces](#sharing-collections-and-other-elements-in-Workspaces)
+
 
 
 
@@ -288,7 +288,7 @@ In "Delete Workspace", click the **Leave workspace** button.  You can no longer 
 
 [![leave workspaces](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-leave-WS-team.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-leave-WS-team.png)
 
-### Editing descriptions of Workspaces
+### Editing descriptions in Workspaces
 
 You can edit descriptions for personal and team Workspaces. In this example, we use a personal Workspace.
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -36,9 +36,9 @@ Here you'll learn how to perform actions on Workspaces and how to use Workspaces
 * [Adding collections and environments from another Workspace](#adding-collections-and-environments-from-another-workspace)  
 * [Publishing collections](#publishing-collections)
 
-* [Sharing collections and environments in Workspaces](#sharing-collections-and-environments-in-Workspaces)
-
 * [Removing elements from Workspaces](#removing-elements-from-workspaces)
+
+* [Sharing collections and environments in Workspaces](#sharing-collections-and-environments-in-Workspaces)
 
 
 
@@ -171,14 +171,13 @@ To share a Workspace, go to the status bar at the bottom of the screen and click
 Select "Browse" and click the Share button to share a collection, environment, monitor, mock, or integration to share.
 
 
-
 ### Sharing collections and environments in Workspaces 
 
 You can only share Postman collections and environments with other Workspaces. In this example, we share a collection to a Workspace. You also create new monitors and mocks other Workspaces.
 
 Postman enables you to share your collections in Workspaces from the Postman app and the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}. 
 
-**Sharing collections in the sidebar**
+#### Sharing collections in the sidebar
 
 In the Postman app, select a collection in the sidebar and click the ***Ellipsis (...)*** button.
 
@@ -190,7 +189,9 @@ Select "Share Collection". The **SHARE COLLECTION** modal appears. It offers thr
 
 Select this option to add a collection to a team Workspace. The collection is visible to the team.
 
-[![share collections](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-collections-in+WS.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-collections-in+WS.png)
+In the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}, select a collection and then clcik the **Share** button. The collection is visible in your target Workspace.
+
+[![share collections](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-collection-dashboard.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-collection-dashboard.png)
 
 **Sharing collections with the Embed or Run In Postman button**
 
@@ -207,6 +208,37 @@ The **Run in Postman** button shares the collection directly from Postman, so th
 Select this option to generate a shareable link for others to access your collections. You can manage a complete list of your collection links from your [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}.
 
 [![share get link](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-getLink-collections.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-getLink-collections.png)
+
+#### Sharing collections in the app
+
+In the Postman app, click the **Build** menu in the status bar at the bottom of the screen.
+
+Select "Browse", and then select a collection. 
+
+Click the **Share** button.
+
+#### Sharing collections in the dashboard
+
+In the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}, select "Browse", and then select a collection. 
+
+Click the **Share** button.
+
+#### Sharing environments in the app
+
+In the Postman app, click the **Build** menu in the status bar at the bottom of the screen.
+
+Select "Browse", and then select an environment. 
+
+Click the **Share** button.
+
+
+#### Sharing environments in the dashboard
+
+In the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}, select "Browse", and then select an environment. 
+
+Click the **Share** button.
+
+
 
 **Sharing environments to Workspaces**
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -39,7 +39,7 @@ Here you'll learn how to perform actions on Workspaces and how to use Workspaces
 
 * [Removing elements from Workspaces](#removing-elements-from-workspaces)
 
-* [Sharing collections in Workspaces](#sharing-collections-in-workspaces)
+* [Sharing collections and other elements in Workspaces](#sharing-collections-and-other-elements-in-Workspaces)
 
 * [Sharing elements to Workspaces](#sharing-elements-to-workspaces)
 
@@ -111,6 +111,7 @@ Click the ***Ellipsis (...)*** button for the Workspace element you want to dele
 
 To delete an element in a Workspace, go to the status bar at the bottom of the screen and click the "Build" menu.
 
+
 [![build menu](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-build-menu1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-build-menu1.png)
 
 Select "Browse" and select an element view: Collections, Environments, Monitors, Mocks, or Integrations view. The Collection view appears by default.
@@ -170,7 +171,7 @@ To share a Workspace, go to the status bar at the bottom of the screen and click
 Select "Browse" and click the Share button to share a collection, environment, monitor, mock, or integration to share.
 
 
-### Sharing collections and elements in Workspaces
+### Sharing collections and other elements in Workspaces
 
 Postman enables you to share your collections in Workspaces from the Postman app and the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}. 
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -177,7 +177,7 @@ Postman enables you to share your collections and environments in Workspaces fro
 
 #### Sharing collections in the app
 
-**Sharing collections in the sidebar**
+##### Sharing collections in the sidebar
 
 In the Postman app, select a collection in the sidebar and click the ***Ellipsis (...)*** button.
 
@@ -209,7 +209,7 @@ Select this option to generate a shareable link for others to access your collec
 
 [![share get link](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-getLink-collections.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-getLink-collections.png)
 
-#### Sharing collections in the app
+###### Sharing collections from the Build menu
 
 In the Postman app, click the **Build** menu in the status bar at the bottom of the screen.
 
@@ -224,6 +224,8 @@ In the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_bl
 Click the **Share** button.
 
 #### Sharing environments in the app
+
+###### Sharing environments from the Build menu
 
 In the Postman app, click the **Build** menu in the status bar at the bottom of the screen.
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -36,9 +36,10 @@ Here you'll learn how to perform actions on Workspaces and how to use Workspaces
 * [Adding collections and environments from another Workspace](#adding-collections-and-environments-from-another-workspace)  
 * [Publishing collections](#publishing-collections)
 
+* [Sharing collections and environments in Workspaces](#sharing-collections-and-environments-in-Workspaces)
+
 * [Removing elements from Workspaces](#removing-elements-from-workspaces)
 
-* [Sharing collections and environments in Workspaces](#sharing-collections-and-environments-in-Workspaces)
 
 
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -185,7 +185,7 @@ Select "Share Collection". The **SHARE COLLECTION** modal appears. It offers thr
 
 [![share sidebar](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-collection-sidebar.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-collection-sidebar.png)
 
-**Sharing collections in another Workspace**
+* Sharing collections in another Workspace
 
 Select this option to add a collection to a team Workspace. The collection is visible to the team.
 
@@ -193,7 +193,7 @@ In the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_bl
 
 [![share collections](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-collection-dashboard.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-collection-dashboard.png)
 
-**Sharing collections with the Embed or Run In Postman button**
+* Sharing collections with the Embed or Run In Postman button
 
 Select this option to embed a **[Run in Postman](/docs/postman_for_publishers/run_button/creating_run_button){:target="_blank"}** button in your collection for your API documentation, website, or Github readme. 
 
@@ -203,7 +203,7 @@ The **Run in Postman** button shares the collection directly from Postman, so th
 
 [![share embed-rip](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-embed-a-collection.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-embed-a-collection.png)
 
-**Sharing collections with a link**
+* Sharing collections with a link
 
 Select this option to generate a shareable link for others to access your collections. You can manage a complete list of your collection links from your [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}.
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -38,7 +38,7 @@ Here you'll learn how to perform actions on Workspaces and how to use Workspaces
 
 * [Removing elements from Workspaces](#removing-elements-from-workspaces)
 
-* [Sharing collections and other elements in Workspaces](#sharing-collections-and-other-elements-in-Workspaces)
+* [Sharing collections and other elements in Workspaces](#sharing-collections-and-other-elements-in-Workspaces)]
 
 
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -111,7 +111,7 @@ Click the ***Ellipsis (...)*** button for the Workspace element you want to dele
 
 To delete an element in a Workspace, go to the status bar at the bottom of the screen and click the "Build" menu.
 
-[![build menu](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-build-menu.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-build-menu.png)
+[![build menu](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-build-menu1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-build-menu1.png)
 
 Select "Browse" and select an element view: Collections, Environments, Monitors, Mocks, or Integrations view. The Collection view appears by default.
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -173,11 +173,11 @@ Select "Browse" and click the Share button to share a collection, environment, m
 
 ### Sharing collections and environments in Workspaces 
 
-You can only share Postman collections and environments with other Workspaces. In this example, we share a collection to a Workspace. You also create new monitors and mocks other Workspaces.
+Postman enables you to share your collections and environments in Workspaces from the Postman app and the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}. 
 
-Postman enables you to share your collections in Workspaces from the Postman app and the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}. 
+#### Sharing collections in the app
 
-#### Sharing collections in the sidebar
+**Sharing collections in the sidebar**
 
 In the Postman app, select a collection in the sidebar and click the ***Ellipsis (...)*** button.
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -38,6 +38,8 @@ Here you'll learn how to perform actions on Workspaces and how to use Workspaces
 
 * [Removing elements from Workspaces](#removing-elements-from-workspaces)
 
+* [Sharing collections and environments in Workspaces](#sharing-collections-and-environments-in-Workspaces)
+
 
 
 
@@ -168,7 +170,9 @@ To share a Workspace, go to the status bar at the bottom of the screen and click
 Select "Browse" and click the Share button to share a collection, environment, monitor, mock, or integration to share.
 
 
-### Sharing collections and other elements in Workspaces
+### Sharing collections and environments in Workspaces
+
+You can only share Postman collections and environments with other Workspaces. In this example, we share a collection to a Workspace. You also create new monitors and mocks other Workspaces.
 
 Postman enables you to share your collections in Workspaces from the Postman app and the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}. 
 
@@ -202,9 +206,7 @@ Select this option to generate a shareable link for others to access your collec
 
 [![share get link](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-getLink-collections.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-getLink-collections.png)
 
-**Sharing elements to Workspaces**
-
-You can only share Postman collections and environments with other Workspaces. In this example, we share a collection to a Workspace. You also create new monitors and mocks other Workspaces.
+**Sharing environments to Workspaces**
 
 In the Collections view, select the collection you want to share, and click the **Share** button.
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -170,7 +170,7 @@ To share a Workspace, go to the status bar at the bottom of the screen and click
 Select "Browse" and click the Share button to share a collection, environment, monitor, mock, or integration to share.
 
 
-### Sharing collections and other elements in Workspace
+### Sharing collections and other elements in Workspaces
 
 Postman enables you to share your collections in Workspaces from the Postman app and the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}. 
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -35,7 +35,7 @@ Here you'll learn how to perform actions on Workspaces and how to use Workspaces
 
 * [Adding collections and environments from another Workspace](#adding-collections-and-environments-from-another-workspace)  
 
-* [Publishing Workspaces](#publishing-workspaces)
+* [Publishing collections](#publishing-collections)
 
 * [Removing elements from Workspaces](#removing-elements-from-workspaces)
 
@@ -113,7 +113,6 @@ In the Collections view, click the **Join** button.
 [![join two](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-join-second-step.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-join-second-step.png)
 
 
-
 In the confirmation message, click the **Start Building** button to complete the process.
 
 [![join three](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-join-third-step1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-join-third-step1.png)
@@ -132,7 +131,7 @@ In "Share a personal workspace", select the users with whom you want to share th
 
 Click the **Share this workplace** button.  Your shared Workspace appears in team Workspaces.
 
-### Sharing collections in Workspaces
+### Sharing collections and elements in Workspaces
 
 Postman enables you to share your collections in Workspaces from the Postman app and the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}. 
 
@@ -165,6 +164,18 @@ The **Run in Postman** button shares the collection directly from Postman, so th
 Select this option to generate a shareable link for others to access your collections. You can manage a complete list of your collection links from your [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}.
 
 [![share get link](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-getLink-collections.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-getLink-collections.png)
+
+**Sharing elements to Workspaces**
+
+You can only share Postman collections and environments with other Workspaces. In this example, we share a collection to a Workspace. You also create new monitors and mocks other Workspaces.
+
+In the Collections view, select the collection you want to share, and click the **Share** button.
+
+[![share elements](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-elements-dashboard.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-elements-dashboard.png)
+
+In "Share this collection", select the Workspace of which you want to share this collection, and click the **Share** button.
+
+[![share elements-collections](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-elements-collection.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-elements-collection.png)
 
 ### Viewing details in Workspaces
 
@@ -204,19 +215,7 @@ To rename your team Workspaces, select "Rename" from the ***Ellipsis (...)*** bu
 
 [![rename team](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-edit-WS-details-team.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-edit-WS-details-team.png)
 
-### Sharing elements to Workspaces
-
-You can share Postman elements (collections, environments, monitors, mocks, and integrations ) with other Workspaces. In this example, we share a collection to a Workspace.
-
-In the Collections view, select the collection you want to share, and click the **Share** button.
-
-[![share elements](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-elements-dashboard.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-elements-dashboard.png)
-
-In "Share this collection", select the Workspace of which you want to share this collection, and click the **Share** button.
-
-[![share elements-collections](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-elements-collection.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-elements-collection.png)
-
-### Publishing Workspaces
+### Publishing collections
 
 Postman enables you to [publish your collection](/docs/postman/api_documentation/intro_to_api_documentation){:target="_blank"} and make it availabe to anyone with the published link.
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -40,8 +40,6 @@ Here you'll learn how to perform actions on Workspaces and how to use Workspaces
 
 * [Sharing collections and other elements in Workspaces](#sharing-collections-and-other-elements-in-Workspaces)
 
-* [Sharing elements to Workspaces](#sharing-elements-to-workspaces)
-
 
 
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -38,7 +38,7 @@ Here you'll learn how to perform actions on Workspaces and how to use Workspaces
 
 * [Removing elements from Workspaces](#removing-elements-from-workspaces)
 
-* [Sharing collections and other elements in Workspaces](#sharing-collections-and-other-elements-in-Workspaces)]
+* [Sharing collections and other elements in Workspaces](#sharing-collections-and-other-elements-in-Workspaces)
 
 
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -170,7 +170,7 @@ To share a Workspace, go to the status bar at the bottom of the screen and click
 Select "Browse" and click the Share button to share a collection, environment, monitor, mock, or integration to share.
 
 
-### Sharing collections and other elements in Workspaces
+### Sharing collections and other elements in Workspace
 
 Postman enables you to share your collections in Workspaces from the Postman app and the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}. 
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -171,7 +171,7 @@ Select "Browse" and click the Share button to share a collection, environment, m
 
 
 
-Sharing collections and environments in Workspaces
+### Sharing collections and environments in Workspaces 
 
 You can only share Postman collections and environments with other Workspaces. In this example, we share a collection to a Workspace. You also create new monitors and mocks other Workspaces.
 

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -28,13 +28,12 @@ Here you'll learn how to perform actions on Workspaces and how to use Workspaces
 
 * [Sharing Workspaces](#sharing-workspaces)
 
-* [Viewing details in Workspaces](#viewing-details-in-workspaces)
+* [Viewing details of Workspaces](#viewing-details-of-workspaces)
 
 
 **Using Workspaces with Postman elements**
 
 * [Adding collections and environments from another Workspace](#adding-collections-and-environments-from-another-workspace)  
-
 * [Publishing collections](#publishing-collections)
 
 * [Removing elements from Workspaces](#removing-elements-from-workspaces)

--- a/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
+++ b/_posts/01_postman/12_workspaces/2018-01-22-using_workspaces.md
@@ -84,15 +84,15 @@ Click the ***Ellipsis (...)*** button in the element you want to remove and sele
 
 [![remove dashboard](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-publish-or-removepWS.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-publish-or-removepWS.png)
 
-### Deleting Workspaces
+### Deleting Workspaces 
 
-When you delete an element, you erase its existence in Postman. 
+When you delete a Workspace or a Workspace element, you erase its existence in Postman. 
 
-**Deleting elements in the Dashboard**
+**Deleting Workspaces in the Dashboard**
 
-To delete a Workspace, go to the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"} and select a Workspace. In this example, we select a team Workspace to delete.
+To delete a Workspace, go to the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"} and select a personal or team Workspace. In this example, we select a team Workspace to delete.
 
-Click the ***Ellipsis (...)*** button for the element you want to delete and select "Delete".
+Click the ***Ellipsis (...)*** button for the Workspace you want to delete and select "Delete".
 
 [![delete workspace menu](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-elipsis-menu-team.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-elipsis-menu-team.png)
 
@@ -100,17 +100,29 @@ In "Delete Workspace", click the **Delete** button. Remember when you delete a W
 
 [![delete workspace](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-delete_WS.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-delete_WS.png)
 
+**Deleting elements in the Dashboard**
+
+To delete a Workspace element, go to the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"} and click a personal or team Workspace. 
+
+Click the ***Ellipsis (...)*** button for the Workspace element you want to delete and select "Delete".
+
+
 **Deleting elements in the Postman app**
 
-In the status bar at the bottom of the screen, click the "Build" menu and select "Browse".
+To delete an element in a Workspace, go to the status bar at the bottom of the screen and click the "Build" menu.
 
 [![build menu](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-build-menu.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-build-menu.png)
 
-Select a Workspace and follow the steps outlined in "Deleting elements in the Dashboard" above.
+Select "Browse" and select an element view: Collections, Environments, Monitors, Mocks, or Integrations view. The Collection view appears by default.
+
+Click the ***Ellipsis (...)*** button for the Workspace element you want to delete and select "Delete".
+
 
 ### Joining Workspaces
 
 A user can join a Workspace to work on collections, environments, monitors, mocks, and integrations. Let's see how.
+
+**Joining Workspaces from the Postman app**
 
 In the Postman app, click a Workspace in the header bar, which is "Neutrino level dectection" in this example.
 
@@ -122,14 +134,24 @@ In the Collections view, click the **Join** button.
 
 [![join two](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-join-second-step.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-join-second-step.png)
 
-
 In the confirmation message, click the **Start Building** button to complete the process.
 
 [![join three](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-join-third-step1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-join-third-step1.png)
 
+**Joining Workspaces from the Dashboard**
+
+You can join a Workspace from the Dashboard.
+
+Go to the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"} and select team Workspaces.
+
+Scroll down to "Workspaces you can join" and click the **Join** button next to the Workspace you want to join.
+
+
 ### Sharing Workspaces
 
 Postman lets you share your personal Workspaces with other users.
+
+**Sharing Workspaces in the Dashboard**
 
 In the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_blank"}, select a personal Workspace you want to share. Next, click the ***Ellipsis (...)*** button and select "Share".
 
@@ -140,6 +162,13 @@ In "Share a personal workspace", select the users with whom you want to share th
 [![share personal](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-personal-WS.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-personal-WS.png)
 
 Click the **Share this workplace** button.  Your shared Workspace appears in team Workspaces.
+
+**Sharing Workspaces from the Postman app**
+
+To share a Workspace, go to the status bar at the bottom of the screen and click the "Build" menu.
+
+Select "Browse" and click the Share button to share a collection, environment, monitor, mock, or integration to share.
+
 
 ### Sharing collections and elements in Workspaces
 
@@ -187,7 +216,7 @@ In "Share this collection", select the Workspace of which you want to share this
 
 [![share elements-collections](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-elements-collection.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-elements-collection.png)
 
-### Viewing details in Workspaces
+### Viewing details of Workspaces
 
 You can view the details of your personal or team Workspaces.
 
@@ -195,13 +224,13 @@ In the [Workspaces dashboard](https://app.getpostman.com/dashboard){:target="_bl
 
 [![view details](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-elipsis-menu-team.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-elipsis-menu-team.png)
 
-#### Viewing details for personal Workspaces
+#### Viewing details of personal Workspaces
 
 To view the details of your personal Workspaces, select "View Details" from the ***Ellipsis (...)*** button menu.
 
 [![details personal](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-view-details-personal.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-view-details-personal.png)
 
-#### Viewing details for team Workspaces 
+#### Viewing details of team Workspaces 
 
 To view the details of your team Workspaces, select "View Details" from the ***Ellipsis (...)*** button menu.
 
@@ -261,7 +290,7 @@ In "Delete Workspace", click the **Leave workspace** button.  You can no longer 
 
 [![leave workspaces](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-leave-WS-team.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-leave-WS-team.png)
 
-### Editing descriptions in Workspaces
+### Editing descriptions of Workspaces
 
 You can edit descriptions for personal and team Workspaces. In this example, we use a personal Workspace.
 
@@ -282,7 +311,7 @@ When you need to manage the members of your team Workspace, go the [Workspaces d
 
 Click the ***Ellipsis (...)*** button and select "Manage Members".
 
-In "Edit workspace details", add or delete team members in the "Members" dropdown menu and save your changes.
+In "Edit workspace details", add or remove team members in the "Members" dropdown menu and save your changes.
 
 [![edit descr team](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-edit-WS-details-team.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-edit-WS-details-team.png)
 


### PR DESCRIPTION
- In using workspaces, title of publish action should be "Publishing Collections" not workspaces
-Sharing collections in workspaces and sharing elements in workspaces can be merged into a single section
- In "Sharing elements to workspaces", only collections and environments can be "shared" in workspaces as of now. Monitors / mocks have to be created anew in another workspace.