### PR TITLE
Fixed Newman global variable CLI option

### DIFF
--- a/v6/postman/collection_runs/command_line_integration_with_newman.md
+++ b/v6/postman/collection_runs/command_line_integration_with_newman.md
@@ -56,7 +56,7 @@ Basic setup:
 --folder [folderName]           Specify a single folder to run from a collection.
 -e, --environment [file|URL]    Specify a Postman environment as a JSON [file]
 -d, --data [file]               Specify a data file to use either json or csv
--g, --global [file]             Specify a Postman globals file as JSON [file]
+-g, --globals [file]            Specify a Postman globals file as JSON [file]
 -n, --iteration-count [number]  Define the number of iterations to run
 
 Request options:


### PR DESCRIPTION
It was incorrectly specified as `--global`, instead of `--globals`:
https://github.com/postmanlabs/newman#newman-run-collection-file-source-options

cc @joyous-joyce 