### PR TITLE
Fix "Managing user accounts" to more accurately reflect current process

### DIFF
--- a/v6/enterprise/sso/admin_sso.md
+++ b/v6/enterprise/sso/admin_sso.md
@@ -34,20 +34,18 @@ You can either click the **Configure Later** button to complete the configuratio
 
 To add an end user, create an account for the user in the Identity Provider (IdP).
 
-The first time a new user logs in to Postman through the IdP, a Postman account will be created only if the team has slots available and the **Allow Signups** box is checked while configuring the SSO. 
+The first time a new user logs in to Postman through the IdP, a Postman account will be created if the team has seats available and the **Allow Signups** box was checked during SSO configuration. 
 
-The user will be automatically associated to the team with a **member** role and will have access to team resources.
+The user will be automatically associated to the team with a **user** role and have access to team resources.
 
 ##### **Existing user account**
 
-If a Postman user logs in to Postman through IdP, the user will be associated to the team if:
+If a Postman user logs in to Postman through a team's IdP, they will be automatically added to the team if **one of the following** is true:
+   
+   *   The team has available slots and **Allow Signups** enabled.
+   *   An admin has invited the user to join the team.
 
-   *   A team invitation exists for the user.
-   *   The team has available slots and the **Allow Signups** box was checked while the admin configured the SSO.
+##### **Removing team access**
 
-##### **Removing IdP access**
-
-Removing an end user from the IdP will prevent the user from being able to log in to the corresponding Postman account, but will not remove the account from Postman. 
-
-To prevent access to team resources, we recommend removing the end user’s account from the Postman Team associated with the IdP.
+An admin must remove users from their **Postman team** in order to prevent access to shared resources.
 


### PR DESCRIPTION
Current documentation for "Managing user accounts", found within [Single Sign-On for Admins](https://www.getpostman.com/docs/v6/enterprise/sso/admin_sso), is unclear and contains contradictory information regarding what is required for adding users to a team.

* Reworded flow for adding new users to a team.
* Fixed incorrect role.
* Fixed formatting for adding existing user accounts.
* Fixed inaccurate user removal flow.