### PR TITLE
Add trailing slashes to the some docs routes to avoid undesirable redirection

### DIFF
--- a/_data/v5_map.json
+++ b/_data/v5_map.json
@@ -717,6 +717,27 @@
         ]
       }
     ]
+  },
+  {
+    "title": "Videos",
+    "url_prefix": "videos",
+    "children": [
+      {
+        "title": "Videos",
+        "href":"/docs/v5/videos/",
+        "external": false
+      }
+    ]
+  },
+  {
+    "title": "Reference",
+    "url_prefix": "reference",
+    "children": [
+      {
+        "title": "Reference",
+        "href":"/docs/v5/reference/",
+        "external": false
+      }
+    ]
   }
 ]
-  

--- a/_data/v6_map.json
+++ b/_data/v6_map.json
@@ -692,6 +692,27 @@
         ]
       }
     ]
-  } 
+  },
+  {
+    "title": "Videos",
+    "url_prefix": "videos",
+    "children": [
+      {
+        "title": "Videos",
+        "href":"/docs/v6/videos/",
+        "external": false
+      }
+    ]
+  },
+  {
+    "title": "Reference",
+    "url_prefix": "reference",
+    "children": [
+      {
+        "title": "Reference",
+        "href":"/docs/v6/reference/",
+        "external": false
+      }
+    ]
+  }
 ]
- 


### PR DESCRIPTION
Adds the References and Videos links back, with additional trailing slash to avoid 301 from GH pages. 