### PR TITLE
Update mock_with_api.md

### DIFF
--- a/v6/postman/mock_servers/matching_algorithm.md
+++ b/v6/postman/mock_servers/matching_algorithm.md
@@ -24,8 +24,6 @@ Now that the mock service has all the saved examples for the current collection,
 
 The incoming request can have several configurable variables, such as `requestMethod` and `mockPath`. The `requestMethod` variable corresponds to any valid HTTP request method (e.g. `GET`, `POST`,`PUT`, `PATCH`, `DELETE`, etc.), and the `mockPath` refers to any valid string path (e.g. `/`, `/test`, `/test/path`, `/test/path/1`).
 
-If the mock was specified to be available only privately, the request will require an authentication header `x-api-key` corresponding to the [Postman API Key](https://app.getpostman.com/dashboard/integrations/pm_pro_api/list){:target="_blank"}, and optionally accepts a header `x-mock-response-code` corresponding to the desired response code of the mock request. For example, you could request a `200`, `400`, `404`, or `500` response for a particular endpoint. 
-
 Other optional headers like `x-mock-response-name` or `x-mock-response-id` allow you to further specify the example to be returned by the name or by the uid of the saved example respectively. You can get the example response uid by using the Postman API to [GET a Single Collection](https://docs.api.getpostman.com/#647806d5-492a-eded-1df6-6529b5dc685c){:target="_blank"} and searching for your example in the response. The uid has the syntax `<user_id>-<response_id>`.
 
 [![mock configurable](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/mock_configurable.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/mock_configurable.png)

--- a/v6/postman/mock_servers/mock_with_api.md
+++ b/v6/postman/mock_servers/mock_with_api.md
@@ -59,7 +59,6 @@ https://{{mockId}}.mock.pstmn.io/{{mockPath}}
 
 **Add the request header(s):**
 
-   *   Requests made to a private mock require one mandatory header, `x-api-key`, which is your Postman API key for authentication. Don't have a Postman API key? [Create one here](https://app.getpostman.com/dashboard/integrations/pm_pro_api/list){:target="_blank"}. The default public mocks do not require this header.
    *   Mock requests also accept another optional header, `x-mock-response-code`, which specifies which integer response code your returned response should match.  For example, 500 will return only a 500 response. If this header is not provided, the closest match of any response code will be returned.
    *   Similarly, other optional headers like `x-mock-response-name` or `x-mock-response-id` allow you further specify the exact response you want by the name or by the uid of the saved example respectively. You can get the example response uid by using the Postman API to [GET a Single Collection](https://docs.api.getpostman.com/#647806d5-492a-eded-1df6-6529b5dc685c){:target="_blank"} and searching for your example in the response. The uid has the syntax `<user_id>-<response_id>`. Without these optional headers, the mock will follow a [matching algorithm](/docs/postman/mock_servers/matching_algorithm) to decide which example to return.
 

--- a/v6/postman/mock_servers/mocking_with_examples.md
+++ b/v6/postman/mock_servers/mocking_with_examples.md
@@ -78,8 +78,6 @@ In the previous steps, we prepared the collection, request, and example response
 
   Now that we have created our mock `M1`, let's try sending a request to this mock endpoint. Copy the mock URL from the mock we created in the previous step, and paste it into a new request, with an undefined path in this case `https://b75a340e-4268-4b20-8f5f-3cfc8f37cec6.mock.pstmn.io`. 
   
-  For private mocks, an additional step is required. Under the **Headers** tab of this new request, add the `x-api-key` header, with the value of your [Postman API key](https://app.getpostman.com/dashboard/integrations/pm_pro_api/list){:target="_blank"}.
-  
   [![send a request to mock server](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock8-1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock8-1.png)
   
   Sending a request to this mock endpoint with an undefined path returns an error. As you can see, there is no matching saved example with the path `''` and the request method `GET`. Responses returned by the mock service are entirely dependent on your saved examples and the included URL and request method type. 


### PR DESCRIPTION
Removed references of API key in the following mock server files: "Mock with API", "Matching Algorithms" and "Mocking with examples" per [CON-116](https://postmanlabs.atlassian.net/browse/CON-116)