### PR TITLE
Update searching_apis.md

### DIFF
--- a/v6/pro/api_search/searching_apis.md
+++ b/v6/pro/api_search/searching_apis.md
@@ -6,7 +6,7 @@ warning: false
 
 ---
 
-API search lets you search not only across collections, but also across folders, requests, and responses. This improved search returns a richer set of results because it searches through all of your Postman data.
+API search, available only for Postman Pro and Enterprise users, lets you search across collections, folders, requests, and responses. This improved search returns a richer set of results because it searches through all of your Postman data.
 
 Currently you only can access this feature in the Postman Dashboard. If you search from within the app, you'll get results from your local app, which may not be synced to all of your Postman data, if you are not signed into Postman.  
 


### PR DESCRIPTION
Added the following: API search is only available for Postman Pro and Enterprise users.