### PR TITLE
Remove references to "environment template"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 defaults:
   -
-    values:
+    values:Q
       layout: "default"
 
 permalink: /:categories/:title
@@ -36,7 +36,7 @@ algolia:
   application_id: 'SDZ6C0ROMM'
   index_name: 'blog'
   read_only_api_key: 'e83c353e0b538a05ad8ea1d70c32b0dd'
-  excluded_files:
+  files_to_exclude:
     - 404.html
     - index.html
     - _site/account.html
@@ -142,4 +142,5 @@ algolia:
     - _posts/01_postman/2017-05-04-mock_servers.md
     - _posts/03_enterprise/2017-05-04-apply_for_beta_access.md
     - _site/v5/
+    - ./v5
 

--- a/v6/postman/api_documentation/environments_and_environment_templates.md
+++ b/v6/postman/api_documentation/environments_and_environment_templates.md
@@ -1,28 +1,28 @@
 ---
-title: "Environments and environment templates"
+title: "Local environments and shared environments"
 page_id: "environments_and_environment_templates"
 warning: false
 ---
 
-You can access environments and environment templates in your private and public API documentation. 
+You can access local environments and shared environments in your private and public API documentation. 
 
 Selecting an environment in private or public documentation assigns those environment variables within the documentation. For example, if you select an environment that has a `foo` variable with the value `bar`, then all occurrences of {{foo}} in the request will be replaced with `bar` within the documentation.
 
-Environments and environment templates are automatically synced. In addition, they are [encrypted during storage](https://www.getpostman.com/security){:target="_blank"}.
+Local environments and shared environments are automatically synced. In addition, they are [encrypted during storage](https://www.getpostman.com/security){:target="_blank"}.
 
 #### Environments in private documentation
 
-The environments drop down menu contains all of your environments and environment templates. 
+The environments drop down menu contains all of your local environments and shared environments. 
 
-All of your environments and environment templates will be available to you with environment templates that are shared in your team Workspace.
+All of your local environments and shared environments will be available to you in your team Workspace.
 
 [![environments dropdown for private viewing](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-docs-private-environment2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-docs-private-environment2.png)
 
 #### Environments in public documentation
 
-An environment template you select while publishing documentation will be available to all documentation viewers.
+An environment that you select while publishing documentation will be available to all documentation viewers.
 
-If your public documentation is published on a custom domain, only the environment template will be available in the published page, even if the user is signed into their Postman account.
+If your public documentation is published on a custom domain, only the selected environment will be available in the published page, even if the user is signed into their Postman account.
 
 [![environmnets dropdown for public documentation](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-docs-public-environMenu010718.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-docs-public-environMenu010718.png)
 

--- a/v6/postman/environments_and_globals/manage_environments.md
+++ b/v6/postman/environments_and_globals/manage_environments.md
@@ -7,7 +7,7 @@ warning: false
 
 ### **What is an environment?**
 
-An environment is a set of key-value pairs. The key represents the name of the variable. You can use a [data editor](/docs/postman/launching_postman/navigating_postman){:target="_blank"} to modify an environment.
+An environment is a set of key-value pairs. The key represents the name of the variable. You can use a [data editor](/docs/v6/postman/launching_postman/navigating_postman){:target="_blank"} to modify an environment.
 
 
 While working with APIs, you often need different setups for your local machine, the development server, or the production API. Environments let you customize requests using variables so you can easily switch between different setups without changing your requests. 
@@ -89,4 +89,4 @@ It's a best practice to create a duplicate, remove any sensitive values (such as
 
 When others import the environment, or access the shared template, they can input their own personal information in their own version of the template.
 
-For Postman Pro and Enterprise users, learn how to [share environments](/docs/postman/team_library/sharing){:target="_blank"} with team members.
+For Postman Pro and Enterprise users, learn how to [share environments](/docs/v6/postman/team_library/sharing){:target="_blank"} with team members.

--- a/v6/postman/environments_and_globals/manage_environments.md
+++ b/v6/postman/environments_and_globals/manage_environments.md
@@ -89,4 +89,4 @@ It's a best practice to create a duplicate, remove any sensitive values (such as
 
 When others import the environment, or access the shared template, they can input their own personal information in their own version of the template.
 
-For Postman Pro and Enterprise users, learn how to [share environment templates](/docs/postman/team_library/sharing){:target="_blank"} with team members.
+For Postman Pro and Enterprise users, learn how to [share environments](/docs/postman/team_library/sharing){:target="_blank"} with team members.

--- a/v6/postman/environments_and_globals/variables.md
+++ b/v6/postman/environments_and_globals/variables.md
@@ -55,7 +55,7 @@ Variables can also be used in pre-request and test scripts. Since these sections
   2.  Fetching a pre-defined variable: 
         *  Once a variable has been set, use the `pm.variables.get()` method or, alternatively, use the `pm.environment.get()` or `pm.globals.get()` method depending on the appropriate scope to fetch the variable. The method requires the variable name as a parameter to retrieve the stored value in a script.
   3.  Setting a variable in a scope: 
-        *  Environment variables can be accessed with the corresponding environment template. Collection variables can be accessed from a request within the collection. Global variables can be accessed broadly regardless of the selected environment.
+        *  Environment variables can be accessed with the corresponding environments. Collection variables can be accessed from a request within the collection. Global variables can be accessed broadly regardless of the selected environment.
 
 [![variables used in script](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-var-scripts.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-var-scripts.png)
 

--- a/v6/postman/environments_and_globals/variables.md
+++ b/v6/postman/environments_and_globals/variables.md
@@ -11,7 +11,7 @@ Variables are symbols that can take different values. You might be familiar with
 
 ### Why use variables?
 
-Variables allow you to reuse values in multiple places so you can keep your code DRY (Don't Repeat Yourself).  Also, if you want to change the value, you can change the variable once with the impact cascading through the rest of your code.
+Variables allow you to reuse values in multiple places so you can keep your code DRY (Don't Repeat Yourself). Also, if you want to change the value, you can change the variable once with the impact cascading through the rest of your code.
 
 Let's say you have 3 API endpoints that use the same domain - `your-domain.com`. You can save this domain as a variable and instead of repeating the value, you can use *`{% raw %}{{domain}}/endpoint1{% endraw %}`* and *`{% raw %}{{domain}}/endpoint2{% endraw %}`* in the request builder. Now, if your domain changes to `another-domain.com`, you just have to change this value once. 
 
@@ -36,13 +36,13 @@ Scopes can be viewed as different kinds of buckets in which values reside. If a 
 
 [![nested variable scopes](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/scopes.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/scopes.png)
 
-If a variable from the currently active environment shares its name with a global variable, the environment variable will take priority. In other words, global variables are overridden by environment variables, which are overridden by [data variables](http://blog.getpostman.com/index.php/2014/10/28/using-csv-and-json-files-in-the-postman-collection-runner/){:target="_blank"} (only available in the [collection runner](/docs/postman/collection_runs/starting_a_collection_run)).
+If a variable from the currently active environment shares its name with a global variable, the environment variable will take priority. In other words, global variables are overridden by environment variables, which are overridden by [data variables](http://blog.getpostman.com/index.php/2014/10/28/using-csv-and-json-files-in-the-postman-collection-runner/){:target="_blank"} (only available in the [collection runner](/docs/v6/postman/collection_runs/starting_a_collection_run){:target="_blank"}).
 
 ### Accessing variables in the request builder
 
 Variables can be used in the following form in the Postman user interface - {% raw %} `{{variableName}}` {% endraw %}. The string {% raw %} {{variableName}} {% endraw %} will be replaced with its corresponding value when Postman resolves the variable. For example, for an environment variable `url` with the value `http://localhost` , you will have to use {% raw %} `{{url}}` {% endraw %} in the request URL field. {% raw %}`{{url}}`{% endraw %} will be replaced by `http://localhost` when the request is sent.
 
-Since variables in the request builder are accessed using string substitution, they can be used everywhere in the request builder where you can add text. This includes the URL, URL parameters, headers, authorization, request body and header presets. Postman evaluates the variables according to scoping rules as discussed in the Variable Scopes section and sends them to the server.
+Since variables in the request builder are accessed using string substitution, they can be used everywhere in the request builder where you can add text. This includes the URL, URL parameters, headers, authorization, request body and header presets. Postman evaluates the variables according to scoping rules as discussed in the [Variable Scopes](/docs/v6/postman/environments_and_globals/variables#variable-scopes) section and sends them to the server.
 
 [![variables used in request builder](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-var-request-builder.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-var-request-builder.png)
 
@@ -51,7 +51,7 @@ Since variables in the request builder are accessed using string substitution, t
 Variables can also be used in pre-request and test scripts. Since these sections for scripts are written in JavaScript, you will initialize and retrieve these variables in a different manner. You can initialize variables in scripts and put them in a particular scope. 
 
   1.  Defining an environment or global variable in a script: 
-        *  To set a variable in a script, use the `pm.environment.set()` method or `pm.globals.set()` method depending on the desired scope. The method requires the variable key and value as parameters to set the variable.  When you send the request, the script will be evaluated and the value will be stored as the variable. Note that [defining a collection variable](/docs/postman/environments_and_globals/variables#defining-collection-variables) is a little different and can be done by editing the collection details.
+        *  To set a variable in a script, use the `pm.environment.set()` method or `pm.globals.set()` method depending on the desired scope. The method requires the variable key and value as parameters to set the variable.  When you send the request, the script will be evaluated and the value will be stored as the variable. Note that [defining a collection variable](/docs/v6/postman/environments_and_globals/variables#defining-collection-variables) is a little different and can be done by editing the collection details.
   2.  Fetching a pre-defined variable: 
         *  Once a variable has been set, use the `pm.variables.get()` method or, alternatively, use the `pm.environment.get()` or `pm.globals.get()` method depending on the appropriate scope to fetch the variable. The method requires the variable name as a parameter to retrieve the stored value in a script.
   3.  Setting a variable in a scope: 
@@ -61,11 +61,11 @@ Variables can also be used in pre-request and test scripts. Since these sections
 
 ### Defining collection variables
 
-Collection variables can be defined by editing the collection details. Click on the ellipses (...) next to the collection name, and select “Edit” to open the **EDIT COLLECTION** modal. Select the **Variables** tab to add and edit collection variables. You can also define collection variables when creating the collection.  
+Collection variables can be defined by editing the collection details. Click on the ellipsis *(...)* next to the collection name, and select “Edit” to open the **EDIT COLLECTION** modal. Select the **Variables** tab to add and edit collection variables. You can also define collection variables when creating the collection.  
 
 ### Logging variables
 
-Often while using variables in scripts, you will need to see the values they obtain. You can use the [Postman Console](/docs/postman/sending_api_requests/debugging_and_logs) to do this easily. From the application menu, select "View" and then "Show Postman Console".  To log the value of a variable, you can use `console.log(foo);` in your script. When you send a request, the script will be evaluated and the value of the variable will be logged in the Postman Console.
+Often while using variables in scripts, you will need to see the values they obtain. You can use the [Postman Console](/docs/v6/postman/sending_api_requests/debugging_and_logs) to do this easily. From the application menu, select "View" and then "Show Postman Console".  To log the value of a variable, you can use `console.log(foo);` in your script. When you send a request, the script will be evaluated and the value of the variable will be logged in the Postman Console.
 
 [![variables logged](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/var_logging.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/var_logging.png)
 
@@ -85,7 +85,7 @@ Inside pre-request and test scripts, the `pm.iterationData.get("username")` me
 
 [![data variables in scripts](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-var-data.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-var-data.png)
 
-Learn more about [working with data files](/docs/postman/collection_runs/working_with_data_files). 
+Learn more about [working with data files](/docs/v6/postman/collection_runs/working_with_data_files). 
 
 ### Dynamic variables
 
@@ -111,10 +111,10 @@ Postman variables are very powerful, and two features - autocomplete and tool ti
 
 [![autocomplete for variables](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-autocomplete.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-autocomplete.gif)  
 
-Type an open curly bracket to bring up the autocomplete menu. For the pre-request and test scripts section, which [uses the data editor](/docs/postman/launching_postman/navigating_postman), entering the first letter of a variable triggers the autocomplete. The menu contains a list of all the variables in the current environment, followed by globals. Navigating through the list also shows the current value and scope for each variable, along with a feedback for overridden variables. 
+Type an open curly bracket to bring up the autocomplete menu. For the pre-request and test scripts section, which [uses the data editor](/docs/v6/postman/launching_postman/navigating_postman), entering the first letter of a variable triggers the autocomplete. The menu contains a list of all the variables in the current environment, followed by globals. Navigating through the list also shows the current value and scope for each variable, along with a feedback for overridden variables. 
 
 ##### **Variable highlighting and tooltip on hover**
 
 [![variable highlighting and tooltips](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-variable-toolTip.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-variable-toolTip.gif)
 
-Variables are highlighted in orange, with unresolved variables shown in red colour. Hovering over a variable shows its current value and the scope. If a variable is unresolved - i.e., no value in the current environment - the tooltip shows the appropriate feedback.
+Variables are highlighted in orange, with unresolved variables shown in red. Hovering over a variable shows its current value and the scope. If a variable is unresolved - i.e., no value in the current environment - the tooltip shows the appropriate feedback.

--- a/v6/postman/mock_servers.md
+++ b/v6/postman/mock_servers.md
@@ -36,7 +36,7 @@ https://documenter.getpostman.com/collection/view/{{collectionId}}
 ``` 
 {% endraw %}
 
-As an optional step, you can include an environment template as a part of your simulation by retrieving the `environmentId` of `testAPIEnv` using the [Postman API](https://api.getpostman.com/){:target="_blank"}. Get a list of all your environments using the [GET All Environments endpoint](https://docs.api.getpostman.com/#d26bd079-e3e1-aa08-7e21-66f55df99351){:target="_blank"}. Search for the name of your environment and retrieve the `uid` from the results, which will be used as the `environmentId` in the next step.
+As an optional step, you can include an environment as a part of your simulation by retrieving the `environmentId` of `testAPIEnv` using the [Postman API](https://api.getpostman.com/){:target="_blank"}. Get a list of all your environments using the [GET All Environments endpoint](https://docs.api.getpostman.com/#d26bd079-e3e1-aa08-7e21-66f55df99351){:target="_blank"}. Search for the name of your environment and retrieve the `uid` from the results, which will be used as the `environmentId` in the next step.
 
 [![get environment id](http://blog.getpostman.com/wp-content/uploads/2017/03/Screen-Shot-2017-03-15-at-3.59.04-PM-1024x431.png)](http://blog.getpostman.com/wp-content/uploads/2017/03/Screen-Shot-2017-03-15-at-3.59.04-PM.png)
 

--- a/v6/postman/mock_servers.md
+++ b/v6/postman/mock_servers.md
@@ -16,9 +16,9 @@ Front-end, back-end and API teams can now work in parallel, freeing up develope
 
 In this example, we have a Collection `testAPI` with corresponding environment `testAPIEnv`.  Let's set up a mock service to enable your front-end team to simulate each endpoint in `testAPI` and view the various responses.
 
-Navigate to every request in the Collection `testAPI` that you would like to include in this simulation, and [save responses](/docs/postman/sending_api_requests/responses) with details about the response body, header or status codes that you would like to see returned by that endpoint. In this example, we will save 2 responses with status codes of 200 and 401 for this particular request.  Once you save the desired responses, the Collection is ready for mocking.
+Navigate to every request in the Collection `testAPI` that you would like to include in this simulation, and [save responses](/docs/v6/postman/sending_api_requests/responses) with details about the response body, header or status codes that you would like to see returned by that endpoint. In this example, we will save 2 responses with status codes of 200 and 401 for this particular request.  Once you save the desired responses, the Collection is ready for mocking.
 
-**Note**: In addition to mocking a collection with a saved response, you can also [mock a request and response using examples](/docs/postman/collections/examples).
+**Note**: In addition to mocking a collection with a saved response, you can also [mock a request and response using examples](/docs/v6/postman/collections/examples){:target="_blank"}.
 
 [![saved responses](http://blog.getpostman.com/wp-content/uploads/2017/03/Screen-Shot-2017-03-15-at-3.44.27-PM-1024x726.png)](http://blog.getpostman.com/wp-content/uploads/2017/03/Screen-Shot-2017-03-15-at-3.44.27-PM.png)
 
@@ -70,8 +70,8 @@ https://{{mockId}}.mock.pstmn.io/{{mockPath}}
 
 ### Mock requests and responses with examples
 
-In the previous example, we used a saved response to mock our collection. You can also [mock a request and response using examples](/docs/postman/collections/examples) in Postman before sending the actual request or setting up a single endpoint to return the response. With examples, you can mock raw responses and save them. Then, you’ll be able to generate a mock endpoint for each of them using Postman’s mock service. 
+In the previous example, we used a saved response to mock our collection. You can also [mock a request and response using examples](/docs/v6/postman/collections/examples){:target="_blank"} in Postman before sending the actual request or setting up a single endpoint to return the response. With examples, you can mock raw responses and save them. Then, you’ll be able to generate a mock endpoint for each of them using Postman’s mock service. 
 
 ### Free mock server calls with your Postman account
 
-Your Postman account gives you a limited number of free mock server calls per month. You can check your usage limits through the [Postman API](https://docs.api.getpostman.com) or the [account usage page](https://go.pstmn.io/postman-account-limits).
+Your Postman account gives you a limited number of free mock server calls per month. You can check your usage limits through the [Postman API](https://docs.api.getpostman.com){:target="_blank"} or the [account usage page](https://go.pstmn.io/postman-account-limits){:target="_blank"}.

--- a/v6/postman/mock_servers/mock_with_api.md
+++ b/v6/postman/mock_servers/mock_with_api.md
@@ -4,15 +4,15 @@ page_id: "mock_with_api"
 warning: false
 ---
 
-You can [mock a collection](/docs/postman/mock_servers/setting_up_mock) directly from the Postman app. Additionally, you can create a mock using the Postman API. Let’s walk through this step by step.
+You can [mock a collection](/docs/v6/postman/mock_servers/setting_up_mock){:target="_blank"} directly from the Postman app. Additionally, you can create a mock using the Postman API. Let’s walk through this step by step.
 
 ### Set up a collection for mocking
 
 In this example, we have a Collection `testAPI` with corresponding environment `testAPIEnv`.  Let's set up a mock service to enable your front-end team to simulate each endpoint in `testAPI` and view the various responses.
 
-Navigate to every request in the Collection `testAPI` that you would like to include in this simulation, and [save responses](/docs/postman/sending_api_requests/responses) with details about the response body, header or status codes that you would like to see returned by that endpoint. In this example, we will save 2 responses with status codes of 200 and 401 for this particular request.  Once you save the desired responses, the Collection is ready for mocking.
+Navigate to every request in the Collection `testAPI` that you would like to include in this simulation, and [save responses](/docs/v6/postman/sending_api_requests/responses){:target="_blank"} with details about the response body, header or status codes that you would like to see returned by that endpoint. In this example, we will save 2 responses with status codes of 200 and 401 for this particular request.  Once you save the desired responses, the Collection is ready for mocking.
 
-**Note**: In addition to mocking a collection with a saved response, you can also [mock a request and response using examples](/docs/postman/collections/examples).
+**Note**: In addition to mocking a collection with a saved response, you can also [mock a request and response using examples](/docs/v6/postman/collections/examples){:target="_blank"}.
 
 [![saved responses](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-mock-PM-API67.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-mock-PM-API67.png)
 
@@ -60,10 +60,10 @@ https://{{mockId}}.mock.pstmn.io/{{mockPath}}
 **Add the request header(s):**
 
    *   Mock requests also accept another optional header, `x-mock-response-code`, which specifies which integer response code your returned response should match.  For example, 500 will return only a 500 response. If this header is not provided, the closest match of any response code will be returned.
-   *   Similarly, other optional headers like `x-mock-response-name` or `x-mock-response-id` allow you further specify the exact response you want by the name or by the uid of the saved example respectively. You can get the example response uid by using the Postman API to [GET a Single Collection](https://docs.api.getpostman.com/#647806d5-492a-eded-1df6-6529b5dc685c){:target="_blank"} and searching for your example in the response. The uid has the syntax `<user_id>-<response_id>`. Without these optional headers, the mock will follow a [matching algorithm](/docs/postman/mock_servers/matching_algorithm) to decide which example to return.
+   *   Similarly, other optional headers like `x-mock-response-name` or `x-mock-response-id` allow you further specify the exact response you want by the name or by the uid of the saved example respectively. You can get the example response uid by using the Postman API to [GET a Single Collection](https://docs.api.getpostman.com/#647806d5-492a-eded-1df6-6529b5dc685c){:target="_blank"} and searching for your example in the response. The uid has the syntax `<user_id>-<response_id>`. Without these optional headers, the mock will follow a [matching algorithm](/docs/v6/postman/mock_servers/matching_algorithm){:target="_blank"} to decide which example to return.
 
 [![request headers](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-run-mock40.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-run-mock40.png)
 
 ### Mock requests and responses with examples
 
-In the previous example, we used a saved response to mock our collection. You can also [mock a request and response using examples](/docs/postman/collections/examples) in Postman before sending the actual request or setting up a single endpoint to return the response. With examples, you can mock raw responses and save them. Then, you’ll be able to generate a mock endpoint for each of them using Postman’s mock service. 
+In the previous example, we used a saved response to mock our collection. You can also [mock a request and response using examples](/docs/v6/postman/collections/examples){:target="_blank"} in Postman before sending the actual request or setting up a single endpoint to return the response. With examples, you can mock raw responses and save them. Then, you’ll be able to generate a mock endpoint for each of them using Postman’s mock service. 

--- a/v6/postman/mock_servers/mock_with_api.md
+++ b/v6/postman/mock_servers/mock_with_api.md
@@ -30,7 +30,7 @@ https://documenter.getpostman.com/collection/view/{{collectionId}}
 ``` 
 {% endraw %}
 
-As an optional step, you can include an environment template as a part of your simulation by retrieving the `environmentId` of `testAPIEnv` using the [Postman API](https://api.getpostman.com/){:target="_blank"}. Get a list of all your environments using the [GET All Environments endpoint](https://docs.api.getpostman.com/#d26bd079-e3e1-aa08-7e21-66f55df99351){:target="_blank"}. Search for the name of your environment and retrieve the `uid` from the results, which will be used as the `environmentId` in the next step.
+As an optional step, you can include an environment as a part of your simulation by retrieving the `environmentId` of `testAPIEnv` using the [Postman API](https://api.getpostman.com/){:target="_blank"}. Get a list of all your environments using the [GET All Environments endpoint](https://docs.api.getpostman.com/#d26bd079-e3e1-aa08-7e21-66f55df99351){:target="_blank"}. Search for the name of your environment and retrieve the `uid` from the results, which will be used as the `environmentId` in the next step.
 
 [![get environment id](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-get-info-46.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-get-info-46.png)
 

--- a/v6/postman/team_library/setting_up_team_library.md
+++ b/v6/postman/team_library/setting_up_team_library.md
@@ -13,16 +13,16 @@ Postman Pro and Enterprise users can use the Team Library to enhance collaborati
 
 * **Share collections**
   
-  You can [share collections](/docs/postman/team_library/sharing#sharing-collections) with your team. Collections contain groups of API requests you can organize, add descriptions, attach test scripts, and build conditional workflows.
+  You can [share collections](/docs/v6/postman/team_library/sharing#sharing-collections){:target="_blank"} with your team. Collections contain groups of API requests you can organize, add descriptions, attach test scripts, and build conditional workflows.
 * **Share environments**
   
-  Teams can use [environments](/docs/postman/api_documentation/environments_and_environment_templates) to create and [share a snapshot of a local environment](/docs/postman/team_library/sharing#sharing-environments). Users might have different environment variable values, so updates to these values are not synced between shared environments.
+  Teams can use [environments](/docs/v6/postman/api_documentation/environments_and_environment_templates){:target="_blank"} to create and [share a snapshot of a local environment](/docs/v6/postman/team_library/sharing#sharing-environments){:target="_blank"}. Users might have different environment variable values, so updates to these values are not synced between shared environments.
 * **See the activity feed in the Team Library**
   
-  You can see changes to shared collections in the [activity feed](/docs/postman/team_library/activity_feed_and_restoring_collections).
+  You can see changes to shared collections in the [activity feed](/docs/v6/postman/team_library/activity_feed_and_restoring_collections){:target="_blank"}.
 * **Subscribe to shared collections**
   
-  When you [subscribe to a collection](/docs/postman/team_library/sharing), you get a synced copy of this collection in your Postman app. If you have edit permissions for the collection, you can make changes that other subscribers to the collection can see.
+  When you [subscribe to a collection](/docs/v6/postman/team_library/sharing){:target="_blank"}, you get a synced copy of this collection in your Postman app. If you have edit permissions for the collection, you can make changes that other subscribers to the collection can see.
 
 ### Setting up the Team Library
 
@@ -47,7 +47,7 @@ When you share your first collection, your 7-day Postman Pro trial is activated.
 
 #### Existing Postman Pro or Enterprise users
 
-If you are on a Postman [Pro](/docs/pro/what_is_pro) or [Enterprise](/docs/enterprise/intro_to_enterprise) team, or if you have activated your 7-day Postman Pro trial, you see this screen when you click the **Team Library** tab for the first time. 
+If you are on a Postman [Pro](/docs/v6/pro/what_is_pro){:target="_blank"} or [Enterprise](/docs/v6/enterprise/intro_to_enterprise){:target="_blank"} team, or if you have activated your 7-day Postman Pro trial, you see this screen when you click the **Team Library** tab for the first time. 
 
 [![team library first view for team](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/team_library_first_view_for_team.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/team_library_first_view_for_team.png)
 

--- a/v6/postman/team_library/setting_up_team_library.md
+++ b/v6/postman/team_library/setting_up_team_library.md
@@ -14,9 +14,9 @@ Postman Pro and Enterprise users can use the Team Library to enhance collaborati
 * **Share collections**
   
   You can [share collections](/docs/postman/team_library/sharing#sharing-collections) with your team. Collections contain groups of API requests you can organize, add descriptions, attach test scripts, and build conditional workflows.
-* **Share environment templates**
+* **Share environments**
   
-  Teams can use [environment templates](/docs/postman/api_documentation/environments_and_environment_templates) to create and [share a snapshot of a local environment](/docs/postman/team_library/sharing#sharing-environments). Users might have different environment variable values, so updates to these values are not synced between shared environments.
+  Teams can use [environments](/docs/postman/api_documentation/environments_and_environment_templates) to create and [share a snapshot of a local environment](/docs/postman/team_library/sharing#sharing-environments). Users might have different environment variable values, so updates to these values are not synced between shared environments.
 * **See the activity feed in the Team Library**
   
   You can see changes to shared collections in the [activity feed](/docs/postman/team_library/activity_feed_and_restoring_collections).

--- a/v6/postman/team_library/sharing.md
+++ b/v6/postman/team_library/sharing.md
@@ -9,7 +9,7 @@ warning: false
 
  **NOTE**: **Team Library is only available for versions 5.0 and below.**
 
-Postman Pro and Enterprise users have access to a Team Library which lets you collaborate faster with your teammates. Team members can share collections and environment templates and see the activity feed in the Team Library. You can think of the Team Library as a way to organize your API infrastructure and make finding API documentation, workflows, and test suites easy.
+Postman Pro and Enterprise users have access to a Team Library which lets you collaborate faster with your teammates. Team members can share collections and environments and see the activity feed in the Team Library. You can think of the Team Library as a way to organize your API infrastructure and make finding API documentation, workflows, and test suites easy.
 
 Your Team Library should be the single source of truth about your APIs. It will let you see the state of your APIs in real time, or review historical versions and the latest updates.
 
@@ -17,9 +17,9 @@ Your Team Library should be the single source of truth about your APIs. It will 
 
 The Team Library allows team members to subscribe to shared collections. When someone subscribes to a collection, they get a synced copy of this collection in their Postman app. If they have edit permissions for the collection, they can make changes which will be reflected in everyone else's collection copy too. Changes made to shared collections are visible under the [Activity Feed](/docs/postman/team_library/activity_feed_and_restoring_collections).
 
-Environment templates work slightly differently. Through an environment template, you can create and share a snapshot of a local environment. Users may have different environment variable values, so updates to these values are not synced between shared environments.
+Shared environments work slightly differently. Through a shared environment, you can create and share a snapshot of a local environment. Users may have different environment variable values, so updates to these values are not synced between shared environments.
 
-There are a number of enhancements coming up soon on [Postman's product roadmap](https://trello.com/b/4N7PnHAz/postman-roadmap-for-developers){:target="_blank"} that will impact workflows for teams wishing to 'sync' updates to their shared environment templates. In the meantime, here are some workarounds that rely on collections as the single source of truth for your APIs:
+There are a number of enhancements coming up soon on [Postman's product roadmap](https://trello.com/b/4N7PnHAz/postman-roadmap-for-developers){:target="_blank"} that will impact workflows for teams wishing to 'sync' updates to their shared environment. In the meantime, here are some workarounds that rely on collections as the single source of truth for your APIs:
 
 1. Run a pre-request script to validate the correctness of required environment keys and values. If any are missing, stop the workflow and throw an error.
 2. Set environment variables in the first request of the collection, or a pre-request script.
@@ -38,10 +38,10 @@ In addition to the [standard ways to share a collection](/docs/postman/collectio
 
 ### Sharing environments
 
-In addition to the [standard way to share an environment](/docs/postman/environments_and_globals/manage_environments#share-an-environment), Postman Pro and Enterprise users can also share an environment template with their team.
+In addition to the [standard way to share an environment](/docs/postman/environments_and_globals/manage_environments#share-an-environment), Postman Pro and Enterprise users can also share an environment with their team.
 
 1.  From the gear icon in the upper right corner of the Postman app, select "Manage Environments", and click the orange **Share** button next to the environment you want to share. 
-2.  You will have one last opportunity to hide any sensitive values like passwords and access tokens before sharing the environment template.  When someone else imports the environment, or accesses the shared template, they can input their own personal information within their own version of the template.  
-    [![environment template](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58787793.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58787793.png)
+2.  You will have one last opportunity to hide any sensitive values like passwords and access tokens before sharing the environment.  When someone else imports the environment, or accesses the shared template, they can input their own personal information within their own version of the template.  
+    [![environment](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58787793.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58787793.png)
 3.  Click the **Share** button to complete the process.
-4.  Go to the Team Library to view the full list of team environment templates.
+4.  Go to the Team Library to view the full list of team shared environments.

--- a/v6/postman/team_library/sharing.md
+++ b/v6/postman/team_library/sharing.md
@@ -15,7 +15,7 @@ Your Team Library should be the single source of truth about your APIs. It will 
 
 [![team library](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59167045.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59167045.png)
 
-The Team Library allows team members to subscribe to shared collections. When someone subscribes to a collection, they get a synced copy of this collection in their Postman app. If they have edit permissions for the collection, they can make changes which will be reflected in everyone else's collection copy too. Changes made to shared collections are visible under the [Activity Feed](/docs/postman/team_library/activity_feed_and_restoring_collections).
+The Team Library allows team members to subscribe to shared collections. When someone subscribes to a collection, they get a synced copy of this collection in their Postman app. If they have edit permissions for the collection, they can make changes which will be reflected in everyone else's collection copy too. Changes made to shared collections are visible under the [Activity Feed](/docs/v6/postman/team_library/activity_feed_and_restoring_collections){:target="_blank"}.
 
 Shared environments work slightly differently. Through a shared environment, you can create and share a snapshot of a local environment. Users may have different environment variable values, so updates to these values are not synced between shared environments.
 
@@ -26,9 +26,9 @@ There are a number of enhancements coming up soon on [Postman's product roadmap]
 
 ### Sharing Collections
 
-In addition to the [standard ways to share a collection](/docs/postman/collections/sharing_collections), Postman Pro and Enterprise users can also share collections with their team or specific team members.
+In addition to the [standard ways to share a collection](/docs/v6/postman/collections/sharing_collections){:target="_blank"}, Postman Pro and Enterprise users can also share collections with their team or specific team members.
 
-1.  From the Collections tab in the sidebar, click on the ellipses (**...**) next to the collection you would like to share, and select "Share".
+1.  From the Collections tab in the sidebar, click on the ellipsis **(...)** next to the collection you would like to share, and select "Share".
 2.  Specify the team permissions by selecting "Can View" or "Can Edit" in the dropdown.  
     [![edit team permissions](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58787441.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58787441.png)
 3.  Postman also lets you manage access to a collection at an individual level. To do this, click the **Add Individual Permissions** link. Select a team member from the dropdown, or enter the username or email of the person you want to share with. Specify the individual's permissions by selecting "Can View" or "Can Edit" in the dropdown. You can give permissions to multiple people.  
@@ -38,7 +38,7 @@ In addition to the [standard ways to share a collection](/docs/postman/collectio
 
 ### Sharing environments
 
-In addition to the [standard way to share an environment](/docs/postman/environments_and_globals/manage_environments#share-an-environment), Postman Pro and Enterprise users can also share an environment with their team.
+In addition to the [standard way to share an environment](/docs/v6/postman/environments_and_globals/manage_environments#share-an-environment){target="_blank"}, Postman Pro and Enterprise users can also share an environment with their team.
 
 1.  From the gear icon in the upper right corner of the Postman app, select "Manage Environments", and click the orange **Share** button next to the environment you want to share. 
 2.  You will have one last opportunity to hide any sensitive values like passwords and access tokens before sharing the environment.  When someone else imports the environment, or accesses the shared template, they can input their own personal information within their own version of the template.  

--- a/v6/postman_for_publishers/run_button/environments_run_button.md
+++ b/v6/postman_for_publishers/run_button/environments_run_button.md
@@ -5,7 +5,7 @@ warning: false
 
 ---
 
-Including an environment template with a shared collection can be useful in prompting users to input their own personal information with their own version of the template.  
+Including a shared environment with a shared collection can be useful in prompting users to input their own personal information with their own version of the template.  
 
 There are 2 ways to include an environment with the shared collection using the Run in Postman button.
 

--- a/v6/postman_for_publishers/run_button/environments_run_button.md
+++ b/v6/postman_for_publishers/run_button/environments_run_button.md
@@ -17,7 +17,7 @@ Select the environment name from the dropdown, as shown in the screenshot above.
 
 ### On page load using Run in Postman’s JavaScript API
 
-Postman also provides an API using the `_pm()` method to programmatically generate an environment client-side. Read more about the [Run button API](/docs/postman_for_publishers/run_button/run_button_API) and how to dynamically alter button behavior.
+Postman also provides an API using the `_pm()` method to programmatically generate an environment client-side. Read more about the [Run button API](/docs/v6/postman_for_publishers/run_button/run_button_API){target="_blank"} and how to dynamically alter button behavior.
 
 ```javascript
 _pm('env.create', 'Spotify', {


### PR DESCRIPTION
Before v6.0, we referred to "local environments" and "environment templates".
After v6.0, environments can now be synced, so we should refer to "local environments" and "shared environments". Even though it might be correct by English standards, refrain from using "template" in the context of environments and sharing.

@staysea 