### PR TITLE
Update pricing_monitors.md

### DIFF
--- a/v6/postman/monitors/pricing_monitors.md
+++ b/v6/postman/monitors/pricing_monitors.md
@@ -13,22 +13,22 @@ If your collection has 5 requests, but you've used `postman.setNextRequest()` to
 
 Any requests needed for the auth helpers (Digest Auth, OAuth, and so on.) will be included in your count.
 
-Each Postman user gets 1,000 monitoring calls for free per month. Each Postman Pro or Enterprise team gets 10,000 free requests per month. The first month starts the day you send your first monitoring request, or when you set up a monthly block for your team.
+Postman users get 1,000 monitoring calls for free each month. Postman Pro teams get 10,000 free requests per month, while Postman Enterprise teams get 100,000 free requests per month. The first month starts the day you send your first monitoring request or when you set up a monthly block for your team.
 
 Teams on the free Pro trial cannot go beyond this limit. 
 
 ### For paid teams
 
-If you're part of a paid team, you have two options for using monitoring beyond 10,000 requests:
+If you're part of a paid team, you have two options for using monitoring beyond the number of calls included in your plan:
 
 * You can pre-purchase block of monitoring calls, at $200.00 for a month's limit of 500,000 calls, or 
-* You can pay-as-you go, at $0.75 for every 1,00 requests beyond the 10,000 free. 
+* You can pay-as-you go, at $0.75 for every 1,000 requests beyond the 10,000 free. 
 
 Buying pre-purchased blocks is both more cost-effective and allows for a more predictable billing pattern.
 
 *   You'll be charged for pre-purchased blocks + pay-as-you-go requests at the end of the monitoring billing cycle. We'll attempt to charge your card if one is saved under your account. If there's none, or we're unable to charge your card, we'll send you an invoice at your registered billing email, payable within 30 days.
 
-### Request blocks for paid Pro teams
+### Request blocks for Pro and Enterprise teams
 
 On the [billing page](https://app.getpostman.com/pay/billing){:target="_blank"}, paid teams can configure "blocks" of requests to save on monitoring charges. Each request block gives you 500,000 requests at $200, and is auto-renewed each month. If you set up monitoring blocks before sending your first monitoring request, your monitoring billing cycle will start from the day you set up the blocks. You may increase or decrease your block count at any time during the billing cycle, but the cost of extra blocks will not be prorated.
 


### PR DESCRIPTION
Current documentation for "Pricing for monitors" contains typo and outdated number for monthly monitoring calls included in Postman Enterprise plan.

- Fixed typo "1,00" instead of "1,000".
- Updated number of monthly calls included in Postman Enterprise plans.
- Added "Enterprise" to header for monitoring blocks.