### PR TITLE
Update managing_collections.md

### DIFF
--- a/v6/postman/collections/managing_collections.md
+++ b/v6/postman/collections/managing_collections.md
@@ -14,6 +14,7 @@ This topic describes the tasks you can perform from the Collections tab in the
 * [Favoriting a collection](#favoriting-a-collection)
 * [Filter collections](#filter-collections)
 * [Delete a collection](#delete-a-collection)
+* [Recover a collection](#recover-a-collection)
 * [Share a collection](#share-a-collection) 
 * [Other collection features](#other-collection-features)
 * [Adding folders](#adding-folders)
@@ -59,6 +60,14 @@ If you have a lot of collections, filter collections in the sidebar using the se
 Click the ellipsis (...)next to a collection, and select "Delete". If you didn't intend to delete the collection, you can click the **Undo** link in the notification that appears at the top of the Postman app.
 
 [![confirmation message](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-delete-collections+copy.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-delete-collections+copy.png)
+
+### Recover a collection
+
+Collections deleted within the past 90 days can be recovered via your [web dashboard](https://app.getpostman.com/){:target="_blank"} by clicking your avatar icon in the upper-right corner, then selecting `Trash` from the drop-down menu. Locate the desired collection, hover your cursor over its row, then click `Restore`. 
+
+If the collection was deleted within the past 90 days and is not listed as recoverable, it is possible it was removed from a workspace rather than deleted. To check, navigate back to the main page of the web dashboard, then click `View all collections`. If listed, you can click on its share icon to move it back into a personal or shared workspace.
+
+If you'd like to revert your collection to a previous state, you can do so by leveraging the collection's in-app [activity feed](/docs/v6/postman/team_library/activity_feed_and_restoring_collections){:target="_blank"}.
 
 ### Share a collection
 


### PR DESCRIPTION
Current documentation for "Managing collections" does not include information about new `Trash` recovery feature.

- Added section on how to utilize `Trash`.
- Noted common scenario where collections are removed from workspaces rather than deleted and how to resolve this.
- Noted activity feed revert to previous version option.
- Added quick link to section from top menu.