### PR TITLE
Removed line that says 'Folders are ordered alphabetically'

### DIFF
--- a/v6/postman/collections/managing_collections.md
+++ b/v6/postman/collections/managing_collections.md
@@ -105,7 +105,7 @@ Folders are a way to organize your API endpoints within a collection into intuit
 
 [![add folder from dropdown](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-addFolderDropdown.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-addFolderDropdown.png)
 
-Add a name and description to the folder. Folders are initially ordered alphabetically by name and folder name. The description is reflected in your API documentation.
+Add a name and description to the folder. The description is reflected in your API documentation.
 
 You can add deeper levels of nesting for folders. Drag and drop the folders to reorder them to create the ultimate customized folder structure.
 


### PR DESCRIPTION
The change in prod looks like this:

![image](https://user-images.githubusercontent.com/41474824/46059250-152a4f80-c17c-11e8-8970-d1b6018d5040.png)
