### PR TITLE
Updated Main UI with callouts

### DIFF
--- a/v6/postman/launching_postman/navigating_postman.md
+++ b/v6/postman/launching_postman/navigating_postman.md
@@ -63,7 +63,7 @@ The status bar at the bottom of the Postman interface gives you a convenient way
 * Open the keyboard [shortcuts.](https://www.getpostman.com/docs/postman/launching_postman/navigating_postman#keyboard-shortcuts)
 * Get help or provide feedback.
 
-[![status bar](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-status-bar.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-status-bar.png)
+[![status bar](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Postman_Main_UI.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Postman_Main_UI.png)
 
 When you click the **Help & Feedback** icon, you can summon a menu that provides access to the latest release notes, [documentation](/docs), [security,](https://www.getpostman.com/security) [support,](https://www.getpostman.com/support) and [social media.](https://twitter.com/postmanclient)
 


### PR DESCRIPTION
The snapshot was outdated in navigating_postman.md chapter. The new one's here:

![image](https://user-images.githubusercontent.com/41474824/46203842-ae05ca00-c338-11e8-91dc-c838d77a96c7.png)

