### PR TITLE
Removing {:target=“_blank”}

### DIFF
--- a/v6/enterprise/intro_to_enterprise.md
+++ b/v6/enterprise/intro_to_enterprise.md
@@ -20,19 +20,19 @@ Postman provides Enterprise users with:
 
 In addition to SSO, audit logs, static IP, and extended support and billing, the Enterprise plan shares Postman Pro features, such as:
 
-* [Dedicated IP addresses](/docs/v6/postman/monitors/intro_monitors#monitoring-resources-in-multiple-regions){:target="_blank"} for API monitoring.
+* [Dedicated IP addresses](/docs/v6/postman/monitors/intro_monitors#monitoring-resources-in-multiple-regions) for API monitoring.
 
-* Team [collaboration](/docs/v6/postman/workspaces/creating_workspaces){:target="_blank"} to keep data in sync for the team.
+* Team [collaboration](/docs/v6/postman/workspaces/creating_workspaces) to keep data in sync for the team.
 
-* [API documentation](/docs/v6/postman/api_documentation/intro_to_api_documentation){:target="_blank"} to share public or private documentation in a web page.
+* [API documentation](/docs/v6/postman/api_documentation/intro_to_api_documentation) to share public or private documentation in a web page.
 
 * [Monitoring](/docs/v6/postman/monitors/intro_monitors) to check the performance of your API. Postman monitoring lets you run a collection periodically to check for its performance and response. You can set up a monitor to run as frequently as 5 minutes. 
 
-* [Mock servers](/docs/v6/postman/mock_servers){:target="_blank"} to simulate the real API and decouple teams collection [monitoring](/docs/v6/postman/monitors/intro_monitors) to check the performance of your API. Decoupling enables different members of your development team to work in parallel rather than having to wait on different pieces to be built before moving forward.
+* [Mock servers](/docs/v6/postman/mock_servers) to simulate the real API and decouple teams collection [monitoring](/docs/v6/postman/monitors/intro_monitors) to check the performance of your API. Decoupling enables different members of your development team to work in parallel rather than having to wait on different pieces to be built before moving forward.
 
-* [Out-of-the-box integrations](/docs/v6/pro/integrations/intro_integrations){:target="_blank"} and the [Postman API](/docs/v6/pro/pro_api/intro_api){:target="_blank"} to connect your different tools.
+* [Out-of-the-box integrations](/docs/v6/pro/integrations/intro_integrations) and the [Postman API](/docs/v6/pro/pro_api/intro_api) to connect your different tools.
 
 
-For more information about Postman Enterprise, contact our [Enterprise support team](http://pages.getpostman.com/Enterprise-Sales_Contact-Us.html){:target="_blank"}. 
+For more information about Postman Enterprise, contact our [Enterprise support team](http://pages.getpostman.com/Enterprise-Sales_Contact-Us.html). 
 
 

--- a/v6/enterprise/purchasing_enterprise.md
+++ b/v6/enterprise/purchasing_enterprise.md
@@ -6,13 +6,13 @@ tags:
 warning: false
 ---
 
-The instructions below are for paying via credit card. If you need to pay via purchase order, contact our [Enterprise support team](http://pages.getpostman.com/Enterprise-Sales_Contact-Us.html){:target="_blank"}.
+The instructions below are for paying via credit card. If you need to pay via purchase order, contact our [Enterprise support team](http://pages.getpostman.com/Enterprise-Sales_Contact-Us.html).
 
 ### Upgrade your plan
 
 To upgrade your plan to a Postman Enterprise subscription, you will need a [Postman account](/docs/v6/postman/launching_postman/postman_account). 
 
-Log in to your Postman account, and go to the [billing page]({{site.pm.gs}}/pay/billing){:target="_blank"}. Next to your current plan, click the **Upgrade** button. For existing Postman Pro users, click the ellipses *(...)* next to the **Upgrade** button and select the "Change plan" option. 
+Log in to your Postman account, and go to the [billing page]({{site.pm.gs}}/pay/billing). Next to your current plan, click the **Upgrade** button. For existing Postman Pro users, click the ellipses *(...)* next to the **Upgrade** button and select the "Change plan" option. 
 
 [![Billing page](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/enterprise-upgrade.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/enterprise-upgrade.png)
 

--- a/v6/enterprise/using_static_IPs_to_monitor.md
+++ b/v6/enterprise/using_static_IPs_to_monitor.md
@@ -10,7 +10,7 @@ By default, Postman Monitors access APIs from dynamic IP addresses. For Enterpri
 
 By whitelisting a single static IP address, customers can monitor their APIs using Postman’s monitoring service, while conforming to company security policies. 
 
-Enterprise users can request the static IP option from our [Enterprise support team](http://pages.getpostman.com/Enterprise-Sales_Contact-Us.html){:target="_blank"}.  Note that monitoring APIs using a static IP address is available for all Postman Enterprise customers. However, the static IP is a US address.
+Enterprise users can request the static IP option from our [Enterprise support team](http://pages.getpostman.com/Enterprise-Sales_Contact-Us.html).  Note that monitoring APIs using a static IP address is available for all Postman Enterprise customers. However, the static IP is a US address.
 
 When the static IP option is enabled, Enterprise users can create a new monitor or change an existing monitor to run using a static IP address.
 

--- a/v6/postman/api_documentation/intro_to_api_documentation.md
+++ b/v6/postman/api_documentation/intro_to_api_documentation.md
@@ -90,4 +90,4 @@ Click Comments to bring up the 'Add comment' dialog, as illustrated above. Write
 
 ### Free documentation views with your Postman account
  
-Public and private documentation each receive 1000 free views per month. You can check your usage limits through the [Postman API](https://docs.api.getpostman.com){:target="_blank"} or the [account usage page](https://go.pstmn.io/postman-account-limits).
+Public and private documentation each receive 1000 free views per month. You can check your usage limits through the [Postman API](https://docs.api.getpostman.com) or the [account usage page](https://go.pstmn.io/postman-account-limits).

--- a/v6/postman/collection_runs/integration_with_travis.md
+++ b/v6/postman/collection_runs/integration_with_travis.md
@@ -17,7 +17,7 @@ In general, integrating your [Postman tests](/docs/v6/postman/scripts/test_scrip
 
 You will set up your CI configuration to run a shell command upon starting your build. The command is a [Newman script that runs your collection](/docs/v6/postman/collection_runs/command_line_integration_with_newman) with the tests, returning a pass or fail exit code that’s logged in your CI system.
 
-In this example, we’ll walk through how to integrate Postman with [Travis CI](https://travis-ci.org/){:target="_blank"}, a continuous integration service that builds and tests projects on GitHub. 
+In this example, we’ll walk through how to integrate Postman with [Travis CI](https://travis-ci.org/), a continuous integration service that builds and tests projects on GitHub. 
 
 Travis CI runs your tests every time you commit to your GitHub repo. Then it submits a pull request, or some other specified configuration.
 

--- a/v6/postman/team_library/activity_feed_and_restoring_collections.md
+++ b/v6/postman/team_library/activity_feed_and_restoring_collections.md
@@ -36,7 +36,7 @@ You can review a chronological list of activities about all collections shared w
 
 You can also review the activity feed from the Dashboard. 
 
-In the [Postman website](https://www.getpostman.com/){:target="_blank"}, click the **Dashboard** button to open your [Workspace](https://app.getpostman.com){:target="_blank"}.
+In the [Postman website](https://www.getpostman.com/), click the **Dashboard** button to open your [Workspace](https://app.getpostman.com).
 
 To see the activity feed, click a collection. Then under the header bar, click "Activity".
 
@@ -74,6 +74,6 @@ At the top of the activity feed a confirmation indicates the collection has been
 
 Postman Pro and Enterprise users can pipe the team's activity feed to a communication channel of your choice with the following integrations:
 
-   *   [Postman Pro to Slack integration](/docs/v6/pro/integrations/slack){:target="_blank"}
-   *   [Postman Pro to HipChat integration](/docs/v6/pro/integrations/hipchat){:target="_blank"}
-   *   [Postman Pro to Microsoft Teams integration](/docs/v6/pro/integrations/microsoft_teams){:target="_blank"}  
+   *   [Postman Pro to Slack integration](/docs/v6/pro/integrations/slack)
+   *   [Postman Pro to HipChat integration](/docs/v6/pro/integrations/hipchat)
+   *   [Postman Pro to Microsoft Teams integration](/docs/v6/pro/integrations/microsoft_teams)  

--- a/v6/postman/team_library/searching.md
+++ b/v6/postman/team_library/searching.md
@@ -94,4 +94,4 @@ You can re-order collections in the Team Library by "Name", "Last Modified", "Ow
 
 <h3 id="search">Search with the Slack Bot</h3>
 
-You can integrate the Postman Pro Search Slack bot and get more detailed search results too. This feature will be available in the Team Library soon. Read more about the [Slack Bot](http://blog.getpostman.com/2015/09/24/api-integrations-using-postman-building-a-slack-channel-bot/){:target="_blank"}.
+You can integrate the Postman Pro Search Slack bot and get more detailed search results too. This feature will be available in the Team Library soon. Read more about the [Slack Bot](http://blog.getpostman.com/2015/09/24/api-integrations-using-postman-building-a-slack-channel-bot/).

--- a/v6/postman/team_library/sharing.md
+++ b/v6/postman/team_library/sharing.md
@@ -19,7 +19,7 @@ The Team Library allows team members to subscribe to shared collections. When so
 
 Shared environments work slightly differently. Through a shared environment, you can create and share a snapshot of a local environment. Users may have different environment variable values, so updates to these values are not synced between shared environments.
 
-There are a number of enhancements coming up soon on [Postman's product roadmap](https://trello.com/b/4N7PnHAz/postman-roadmap-for-developers){:target="_blank"} that will impact workflows for teams wishing to 'sync' updates to their shared environment. In the meantime, here are some workarounds that rely on collections as the single source of truth for your APIs:
+There are a number of enhancements coming up soon on [Postman's product roadmap](https://trello.com/b/4N7PnHAz/postman-roadmap-for-developers) that will impact workflows for teams wishing to 'sync' updates to their shared environment. In the meantime, here are some workarounds that rely on collections as the single source of truth for your APIs:
 
 1. Run a pre-request script to validate the correctness of required environment keys and values. If any are missing, stop the workflow and throw an error.
 2. Set environment variables in the first request of the collection, or a pre-request script.

--- a/v6/pro/managing_pro/managing_your_billing.md
+++ b/v6/pro/managing_pro/managing_your_billing.md
@@ -87,8 +87,8 @@ A print dialogue will open up where you can save this invoice or print it direct
 
 For more information on Billing, see:
 
-* [Change your plan (Pro Monthly)](/docs/pro/managing_pro/changing_your_plan){:target="_blank"}
-* [Add user slots to your plan (Pro Annual)](/docs/pro/managing_pro/changing_your_plan){:target="_blank"}
-* [Set instructions for next billing cycle](/docs/pro/managing_pro/changing_your_plan){:target="_blank"}
-* [Cancel your plan](/docs/pro/managing_pro/changing_your_plan){:target="_blank"}
+* [Change your plan (Pro Monthly)](/docs/pro/managing_pro/changing_your_plan)
+* [Add user slots to your plan (Pro Annual)](/docs/pro/managing_pro/changing_your_plan)
+* [Set instructions for next billing cycle](/docs/pro/managing_pro/changing_your_plan)
+* [Cancel your plan](/docs/pro/managing_pro/changing_your_plan)
 

--- a/v6/reference/index.md
+++ b/v6/reference/index.md
@@ -4,13 +4,13 @@ page_id: "reference"
 warning: false
 ---
 
-*   [Postman Pro API](https://docs.api.getpostman.com){:target="_blank"}
-*   [Postman Echo](https://docs.postman-echo.com/){:target="_blank"}
-*   [Postman Runtime](https://github.com/postmanlabs/postman-runtime/){:target="_blank"}
-*   [Newman command line options](https://github.com/postmanlabs/newman#command-line-options){:target="_blank"}
-*   [Newman changelog](https://github.com/postmanlabs/newman/blob/develop/CHANGELOG.md#newman-changelog){:target="_blank"}
-*   [Collection v2 Format](http://schema.getpostman.com/){:target="_blank"}
-*   [Collection SDK (API Reference)](http://www.postmanlabs.com/postman-collection/){:target="_blank"}
+*   [Postman Pro API](https://docs.api.getpostman.com)
+*   [Postman Echo](https://docs.postman-echo.com/)
+*   [Postman Runtime](https://github.com/postmanlabs/postman-runtime/)
+*   [Newman command line options](https://github.com/postmanlabs/newman#command-line-options)
+*   [Newman changelog](https://github.com/postmanlabs/newman/blob/develop/CHANGELOG.md#newman-changelog)
+*   [Collection v2 Format](http://schema.getpostman.com/)
+*   [Collection SDK (API Reference)](http://www.postmanlabs.com/postman-collection/)
 *   [Postman settings](/docs/postman/launching_postman/settings)
 *   [Keyboard shortcuts](/docs/postman/launching_postman/settings)
-*   [Markdown reference](https://documenter.getpostman.com/view/33232/markdown-in-api-documentation/JsGc){:target="_blank"}
+*   [Markdown reference](https://documenter.getpostman.com/view/33232/markdown-in-api-documentation/JsGc)

--- a/v6/videos/index.md
+++ b/v6/videos/index.md
@@ -32,16 +32,16 @@ warning: false
 
 *   Postman "How To" Playlist (2017)
 
-    * [Intro to Postman & Postman Collections](https://www.youtube.com/watch?v=ptvV_Fc3hd8&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=1){:target="_blank"}
-    * [How to use global variables in Postman](https://www.youtube.com/watch?v=TU1i1CgjVR8&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=2){:target="_blank"} 
-    * [How to add tests to a Postman Collection](https://www.youtube.com/watch?v=ElJBJIeJ90o&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=3){:target="_blank"} 
-    * [How to use code snippets in postman](https://www.youtube.com/watch?v=fhfuQGvLPj0&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=4){:target="_blank"} 
-    * [How to use Environments in Postman](https://www.youtube.com/watch?v=wArvaHYdw2I&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=5){:target="_blank"}
-    * [How to add an environment variable using code snippets](https://www.youtube.com/watch?v=jzJT_o3_t1Q&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=6){:target="_blank"} 
-    * [How to use the Postman collection Runner](https://www.youtube.com/watch?v=6XjOtI-FPHg&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=7){:target="_blank"}
+    * [Intro to Postman & Postman Collections](https://www.youtube.com/watch?v=ptvV_Fc3hd8&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=1)
+    * [How to use global variables in Postman](https://www.youtube.com/watch?v=TU1i1CgjVR8&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=2) 
+    * [How to add tests to a Postman Collection](https://www.youtube.com/watch?v=ElJBJIeJ90o&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=3) 
+    * [How to use code snippets in postman](https://www.youtube.com/watch?v=fhfuQGvLPj0&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=4) 
+    * [How to use Environments in Postman](https://www.youtube.com/watch?v=wArvaHYdw2I&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=5)
+    * [How to add an environment variable using code snippets](https://www.youtube.com/watch?v=jzJT_o3_t1Q&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=6) 
+    * [How to use the Postman collection Runner](https://www.youtube.com/watch?v=6XjOtI-FPHg&list=PLM-7VG-sgbtCJYpjQfmLCcJZ6Yd74oytQ&index=7)
 
 *   Postman Pro Playlist (2017)
 
-    * [Intro to Postman Pro - Collaboration](https://www.youtube.com/watch?v=1_7IVWySh2A&index=1&list=PLM-7VG-sgbtCr3URSt3ySIs_nyW9niiyn){:target="_blank"} 
-    * [Intro to Postman Pro - Document & Publish](https://www.youtube.com/watch?v=ERk8RkfqxM4&list=PLM-7VG-sgbtCr3URSt3ySIs_nyW9niiyn&index=2){:target="_blank"} 
-    * [Intro to Postman Pro - Monitoring](https://www.youtube.com/watch?v=xiRx81jlYOQ&t=3s&list=PLM-7VG-sgbtCr3URSt3ySIs_nyW9niiyn&index=3){:target="_blank"}
+    * [Intro to Postman Pro - Collaboration](https://www.youtube.com/watch?v=1_7IVWySh2A&index=1&list=PLM-7VG-sgbtCr3URSt3ySIs_nyW9niiyn) 
+    * [Intro to Postman Pro - Document & Publish](https://www.youtube.com/watch?v=ERk8RkfqxM4&list=PLM-7VG-sgbtCr3URSt3ySIs_nyW9niiyn&index=2) 
+    * [Intro to Postman Pro - Monitoring](https://www.youtube.com/watch?v=xiRx81jlYOQ&t=3s&list=PLM-7VG-sgbtCr3URSt3ySIs_nyW9niiyn&index=3)


### PR DESCRIPTION
With the new Learning Center we can no longer process {:target=“_blank”} like what was done with previous docs setup. However, any external link will have target and relationship attributes applied to it with a Markdown transforming plugin.

We are also fully migrating from getpostman.com/docs over to learning.getpostman.com over the next several days.