### PR TITLE
Feature/remove site pm gs

### DIFF
--- a/v5/enterprise/sso/admin_sso.md
+++ b/v5/enterprise/sso/admin_sso.md
@@ -11,7 +11,7 @@ warning: false
 
 Only a team admin can configure SSO for a Postman Team.
 
-1.  Log in to Postman, and start on the [Postman Edit Team Details]({{site.pm.gs}}/dashboard/teams/edit) page. If the team is subscribed to an enterprise plan, the option to configure SSO will be displayed. 
+1.  Log in to Postman, and start on the [Postman Edit Team Details](https://go.postman.co/dashboard/teams/edit) page. If the team is subscribed to an enterprise plan, the option to configure SSO will be displayed. 
 
 [![edit team details](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58241978.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58241978.png)  
 

--- a/v5/enterprise/sso/saml_duo.md
+++ b/v5/enterprise/sso/saml_duo.md
@@ -17,7 +17,7 @@ warning: false
 2.   Search for "SAML - Service Provider" and click on the **Protect this Application** link.
      [![duo protect](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/duo_protect.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/duo_protect.png)
 
-3.   Enter `Postman` as the service provider. The service provider details can be found on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit). Other fields can either be left blank or set to the default value.
+3.   Enter `Postman` as the service provider. The service provider details can be found on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit). Other fields can either be left blank or set to the default value.
      [![duo provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/duo_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/duo_provider.png)
  
      | **Field** | **Value** |
@@ -35,4 +35,4 @@ warning: false
  
 6.   Duo requires your cloud application to be added to the Duo Access Gateway. Refer to this [guide for setting this up](https://duo.com/docs/dag-generic){:target="_blank"}.
 
-7.   Once the setup is complete, submit your Identity Provider's details to Postman. Collect the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer`, and `X.509 Certificate` from the Duo configuration page and fill these values in your Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **Duo Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
+7.   Once the setup is complete, submit your Identity Provider's details to Postman. Collect the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer`, and `X.509 Certificate` from the Duo configuration page and fill these values in your Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **Duo Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 

--- a/v5/enterprise/sso/saml_gsuite.md
+++ b/v5/enterprise/sso/saml_gsuite.md
@@ -23,13 +23,13 @@ warning: false
 4. Click "SETUP MY OWN CUSTOM APP".
    [![gsuite setup](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_setup.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_setup.png)
 
-5. Collect the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer` and `X.509 Certificate` from this window, and enter these values into your Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **GSuite Identity Provider Details** modal.
+5. Collect the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer` and `X.509 Certificate` from this window, and enter these values into your Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **GSuite Identity Provider Details** modal.
    [![gsuite google IdP](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_google_IdP.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_google_IdP.png)
 
 6. Enter an application name (e.g. Postman SAML App) and fill out any other optional fields.
    [![gsuite basic info](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_basic_info.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_basic_info.png)
 
-7. Enter the Postman service provider details which can be found on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **GSuite Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
+7. Enter the Postman service provider details which can be found on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **GSuite Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
    [![gsuite service provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_service_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_service_provider.png)
  
  | **Field** | **Value** |

--- a/v5/enterprise/sso/saml_okta.md
+++ b/v5/enterprise/sso/saml_okta.md
@@ -23,7 +23,7 @@ warning: false
 4.   Under the first step "General Settings", enter an application name and then click the **Next** button.
      [![okta app name](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_app_name.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_app_name.png)
 
-5.   Under the second step “Configure SAML”, section A “SAML Settings”, enter the Postman service provider details which can be found on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit). 
+5.   Under the second step “Configure SAML”, section A “SAML Settings”, enter the Postman service provider details which can be found on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit). 
      [![okta service provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_service_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_service_provider.png)
 
      | **Field** | **Value** |
@@ -32,7 +32,7 @@ warning: false
      | Audience URI (SP Entity ID) | Entity ID |
      | Name ID Format | EmailAddress |
  
-6.   Click the **Show Advanced Settings** link to configure advanced SAML assertion settings. Configure the options as shown in the image below. For the Encryption Certificate, download the `X.509 certificate` from the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) and upload it here. Click **Next** to continue.
+6.   Click the **Show Advanced Settings** link to configure advanced SAML assertion settings. Configure the options as shown in the image below. For the Encryption Certificate, download the `X.509 certificate` from the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) and upload it here. Click **Next** to continue.
      [![okta advanced](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_advanced.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_advanced.png)
   
 7.   Under the third step “Feedback”, select “I’m an Okta customer adding an internal app”, and check “This is an internal app that we have created”, and then click **Finish**.
@@ -41,5 +41,5 @@ warning: false
 8.   Move over to the **Sign On** tab, and click the **View Setup Instructions** button.
      [![okta sign on](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_sign_on.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_sign_on.png)
   
-9.   Copy the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer` and `X.509 Certificate` from here and update the SSO authentication method that you created on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **Okta Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
+9.   Copy the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer` and `X.509 Certificate` from here and update the SSO authentication method that you created on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **Okta Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
      [![okta identity provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_identity_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_identity_provider.png)

--- a/v5/enterprise/sso/saml_onelogin.md
+++ b/v5/enterprise/sso/saml_onelogin.md
@@ -20,8 +20,8 @@ warning: false
 3. Update the **Display Name**, and click **SAVE**.
    [![onelogin display name](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_display.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_display.png)
 
-4. Enter your Postman service provider details. These details can be found on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit). For the SAML Encryption, download the `X.509 certificate` from the Postman Edit Team Details page as well. Click **SAVE** to proceed.
+4. Enter your Postman service provider details. These details can be found on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit). For the SAML Encryption, download the `X.509 certificate` from the Postman Edit Team Details page as well. Click **SAVE** to proceed.
    [![onelogin service provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_service_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_service_provider.png)
 
-5. Copy the `Identity Provider Issuer URL`, `SAML 2.0 Endpoint (HTTP)`, and `X.509 Certificate` from here and update the SSO authentication method that you created at Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **Onelogin Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
+5. Copy the `Identity Provider Issuer URL`, `SAML 2.0 Endpoint (HTTP)`, and `X.509 Certificate` from here and update the SSO authentication method that you created at Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **Onelogin Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
    [![onelogin identity provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_identity_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_identity_provider.png)

--- a/v5/enterprise/sso/saml_ping.md
+++ b/v5/enterprise/sso/saml_ping.md
@@ -20,7 +20,7 @@ warning: false
 3. Fill in the required application details and continue to the next step.
    [![ping_details](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/ping_details)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/ping_details)
 
-4. Download the **SAML metadata** file, and enter your Postman service provider details. These details can be found on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit). 
+4. Download the **SAML metadata** file, and enter your Postman service provider details. These details can be found on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit). 
 
     | **Field** | **Value** |
     |---|---|
@@ -40,4 +40,4 @@ warning: false
 7. Once enabled, the status will show as **Active** for the application.
    [![ping active](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/ping_active)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/ping_active)
 
-7. Once the setup is completed, submit your Identity Provider's details to Postman. Copy the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer`, and `X.509 Certificate` from the downloaded **SAML metadata** file and enter these values on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **Ping Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
+7. Once the setup is completed, submit your Identity Provider's details to Postman. Copy the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer`, and `X.509 Certificate` from the downloaded **SAML metadata** file and enter these values on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **Ping Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 

--- a/v5/postman/api_documentation/adding_and_verifying_custom_domains.md
+++ b/v5/postman/api_documentation/adding_and_verifying_custom_domains.md
@@ -9,7 +9,7 @@ Postman users with public documentation can publish documentation on their own c
 
 ### Add a custom domain
 
-In the Postman dashboard, select [Team Settings]({{site.pm.gs}}/dashboard/teams/edit){:target="_blank"} in the Team tab.
+In the Postman dashboard, select [Team Settings](https://go.postman.co/dashboard/teams/edit){:target="_blank"} in the Team tab.
 
 [![edit view for team](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/docs-team-settings2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/docs-team-settings2.png)
 

--- a/v5/postman/api_documentation/adding_team_name_and_logo.md
+++ b/v5/postman/api_documentation/adding_team_name_and_logo.md
@@ -8,21 +8,21 @@ warning: false
 
 ---
 
-Postman users with the **Admin** member role can add a team name and logo to their Postman team account directly in the [Team Settings page]({{site.pm.gs}}/dashboard/teams/edit){:target="_blank"}.
+Postman users with the **Admin** member role can add a team name and logo to their Postman team account directly in the [Team Settings page](https://go.postman.co/dashboard/teams/edit){:target="_blank"}.
 
 ### Update your team name
 
-To see your current team name, go to the [Team page]({{site.pm.gs}}/dashboard/teams){:target="_blank"} in the Postman website.
+To see your current team name, go to the [Team page](https://go.postman.co/dashboard/teams){:target="_blank"} in the Postman website.
 
 [![team name](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/docs-team2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/docs-team2.png)
 
-If you didn’t enter a team name when you first created your Postman Pro or Enterprise team, you can add it in the [Team Settings]({{site.pm.gs}}/dashboard/teams/edit){:target="_blank"} page.
+If you didn’t enter a team name when you first created your Postman Pro or Enterprise team, you can add it in the [Team Settings](https://go.postman.co/dashboard/teams/edit){:target="_blank"} page.
 
 [![edit team details page](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/team-settings-plain.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/team-settings-plain.png)
 
 ### Update your team logo
 
-To update your logo, go to the [Team Settings]({{site.pm.gs}}/dashboard/teams/edit){:target="_blank"} page.
+To update your logo, go to the [Team Settings](https://go.postman.co/dashboard/teams/edit){:target="_blank"} page.
 
 Next hover over the logo under "Team Logo" in the "Style" section to see the **Pencil** (edit) and **Trash Can** (delete) icons.
 

--- a/v5/postman/collections/sharing_collections.md
+++ b/v5/postman/collections/sharing_collections.md
@@ -23,7 +23,7 @@ A team’s shared collections can be viewed in the [team library](/docs/postman/
 
 Generate a shareable link for others to access your collections. This is not the recommended method for sharing collections.  Collection links reflect the collection as a snapshot in time, and must be updated to refresh the changes to the collection.
 
-You can manage a complete list of collection links from the [dashboard]({{site.pm.gs}}/dashboard/collections/links){:target="_blank"}.
+You can manage a complete list of collection links from the [dashboard](https://go.postman.co/dashboard/collections/links){:target="_blank"}.
 
 [![share collection with a link](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564829.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58564829.png)
 

--- a/v5/postman/launching_postman/newbutton.md
+++ b/v5/postman/launching_postman/newbutton.md
@@ -159,7 +159,7 @@ A [mock server](/docs/postman/mock_servers/setting_up_mock){:target="_blank"} si
 * Select an environment (optional).
 * Indicate if you want to make this mock server private
 
-**Note**: The number of calls made to mock servers might be limited by your Postman account. Check your [usage limits]({{site.pm.gs}}/dashboard/usage){:target="_blank"}.
+**Note**: The number of calls made to mock servers might be limited by your Postman account. Check your [usage limits](https://go.postman.co/dashboard/usage){:target="_blank"}.
      
  [![configTab mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/mock-configureTab.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/mock-configureTab.png) 
      

--- a/v5/postman/launching_postman/postman_account.md
+++ b/v5/postman/launching_postman/postman_account.md
@@ -55,7 +55,7 @@ To switch back to your previous account, click on the account user name in the d
 
 #### How to switch accounts in the Postman web view
 
-1. When you sign in to the [Dashboard]({{site.pm.gs}}/dashboard){:target="_blank"}, you see your profile image on the top right hand corner of the screen.  
+1. When you sign in to the [Dashboard](https://go.postman.co/dashboard){:target="_blank"}, you see your profile image on the top right hand corner of the screen.  
 
 2. To sign in to another account, click the **Add A New Account** button at the bottom of the drop down menu.
 

--- a/v5/postman/launching_postman/syncing.md
+++ b/v5/postman/launching_postman/syncing.md
@@ -58,7 +58,7 @@ When you reload the app, Postman automatically retrieves the most recent and up-
 
 ### Deleting your Postman account
 
-If you have a Postman account, are not currently part of a paid Postman Pro or Enterprise team, and have never participated in a Postman Pro trial team, you can [delete your account]({{site.pm.gs}}/dashboard/profile){:target="_blank"}. 
+If you have a Postman account, are not currently part of a paid Postman Pro or Enterprise team, and have never participated in a Postman Pro trial team, you can [delete your account](https://go.postman.co/dashboard/profile){:target="_blank"}. 
 
 Otherwise, you can contact us at [{{site.pm.help_email}}](mailto:{{site.pm.help_email}}).
 

--- a/v5/postman/mock_servers/setting_up_mock.md
+++ b/v5/postman/mock_servers/setting_up_mock.md
@@ -54,7 +54,7 @@ The **Create New** tab appears.
 * Select an environment (optional).
 * Indicate if you want to make this mock server private
 
-**Note**: The number of calls made to mock servers might be limited by your Postman account. Check your [usage limits]({{site.pm.gs}}/dashboard/usage){:target="_blank"}.
+**Note**: The number of calls made to mock servers might be limited by your Postman account. Check your [usage limits](https://go.postman.co/dashboard/usage){:target="_blank"}.
      
  [![configTab mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/mock-configureTab.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/mock-configureTab.png) 
      

--- a/v5/postman/postman_api/continuous_integration.md
+++ b/v5/postman/postman_api/continuous_integration.md
@@ -12,7 +12,7 @@ Let's access collections using the Postman API to run inside your Continuous Int
 Before we get started:
 
 *   Ensure you have a CI system setup which can run shell commands and that you have access to modify the same.
-*   If you don't already have a [Postman API key](https://docs.api.getpostman.com/#authentication){:target="_blank"}, [get one now]({{site.pm.gs}}/dashboard/integrations){:target="_blank"}.
+*   If you don't already have a [Postman API key](https://docs.api.getpostman.com/#authentication){:target="_blank"}, [get one now](https://go.postman.co/dashboard/integrations){:target="_blank"}.
 *   Make sure you have a Postman Collection that tests your localhost server, and note the UID of the collection.
 
 ### Step 1: Install Node

--- a/v5/pro/integrations/apimatic.md
+++ b/v5/pro/integrations/apimatic.md
@@ -16,7 +16,7 @@ If you don't already have a [GitHub account](https://github.com/){:target="_blan
 
 ### Configuring APIMATIC Integration
 
-1. In the [Integrations page]({{site.pm.gs}}/dashboard/integrations){:target="_blank"}, find APIMATIC in the list of Postman’s 3rd party Integrations for Postman Pro users.
+1. In the [Integrations page](https://go.postman.co/dashboard/integrations){:target="_blank"}, find APIMATIC in the list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![select apimatic](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_APImatic.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_APImatic.png)
 

--- a/v5/pro/integrations/bigpanda.md
+++ b/v5/pro/integrations/bigpanda.md
@@ -45,7 +45,7 @@ The generated App Key displays.
 ### Configuring Postman monitors
 
 
-1. In the **[Integrations]({{site.pm.gs}}/dashboard/integrations){:target="_blank"}** page, find BigPanda from a list of Postman's 3rd party Integrations for Postman Pro users.
+1. In the **[Integrations](https://go.postman.co/dashboard/integrations){:target="_blank"}** page, find BigPanda from a list of Postman's 3rd party Integrations for Postman Pro users.
 
 2. Click the **View Details** button to see information about BigPanda and how it can provide real-time alerting based on the results of your Postman monitors. 
 

--- a/v5/pro/integrations/datadog.md
+++ b/v5/pro/integrations/datadog.md
@@ -23,7 +23,7 @@ Save the API Key to use later.
 
 ### Configuring Postman Monitors
 
-1. In the [Integrations]({{site.pm.gs}}/dashboard/integrations){:target="_blank"} page, find Datadog in the list of Postman’s 3rd party Integrations for Postman Pro users.
+1. In the [Integrations](https://go.postman.co/dashboard/integrations){:target="_blank"} page, find Datadog in the list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![datadog integrations page](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_datadog2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_datadog2.png)
 

--- a/v5/pro/integrations/dropbox.md
+++ b/v5/pro/integrations/dropbox.md
@@ -11,7 +11,7 @@ Backup and synchronize your Postman Collections on Dropbox for file sharing, sto
 
 ### Configuring Dropbox Integration
 
-1. In the [Integrations page]({{site.pm.gs}}/dashboard/integrations){:target="_blank"}, find Dropbox from a list of Postman's 3rd party Integrations for Postman Pro users.
+1. In the [Integrations page](https://go.postman.co/dashboard/integrations){:target="_blank"}, find Dropbox from a list of Postman's 3rd party Integrations for Postman Pro users.
 
 [![select dropbox integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_dropbox1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_dropbox1.png)
 

--- a/v5/pro/integrations/github.md
+++ b/v5/pro/integrations/github.md
@@ -11,7 +11,7 @@ Back up and synchronize your Postman Collections on GitHub, the largest host of 
 
 ### Configuring GitHub Integration
 
-1. In the **[Integrations]({{site.pm.gs}}/dashboard/integrations){:target="_blank"}** page, find Github from a list of Postman's 3rd party Integrations for Postman Pro users.
+1. In the **[Integrations](https://go.postman.co/dashboard/integrations){:target="_blank"}** page, find Github from a list of Postman's 3rd party Integrations for Postman Pro users.
 
 [![github integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-github1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-github1.png)
 

--- a/v5/pro/integrations/gitlab.md
+++ b/v5/pro/integrations/gitlab.md
@@ -26,7 +26,7 @@ Save the generated token to use later.
 <br>
 ### Configuring a backup for Postman Collections in GitLab
 
-1. In the [Integrations page]({{site.pm.gs}}/dashboard/integrations){:target="_blank"}, find GitLab from a list of Postman's 3rd party Integrations for Postman Pro users.
+1. In the [Integrations page](https://go.postman.co/dashboard/integrations){:target="_blank"}, find GitLab from a list of Postman's 3rd party Integrations for Postman Pro users.
 
 [![select gitlab integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-gitlab1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-gitlab1.png)
 

--- a/v5/pro/integrations/hipchat.md
+++ b/v5/pro/integrations/hipchat.md
@@ -13,7 +13,7 @@ This integration allows you to get real-time updates of what is happening in you
 
 ### Configuring Postman with HipChat
 
-1. In the [Integrations]({{site.pm.gs}}/dashboard/integrations){:target="_blank"} page, find HipChat from a list of Postman’s 3rd party Integrations for Postman Pro users.
+1. In the [Integrations](https://go.postman.co/dashboard/integrations){:target="_blank"} page, find HipChat from a list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![select hipchat integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-hipchat.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-hipchat.png)
 

--- a/v5/pro/integrations/intro_integrations.md
+++ b/v5/pro/integrations/intro_integrations.md
@@ -17,15 +17,15 @@ Organizations use the term "integration" inclusively, sometimes overly so. In fa
 
 Postman views "integrations" as a way to share data or functionality between Postman and other tools that you might use for API development. When manually importing and exporting data from one application to another becomes a chore, an integration can help.
 
-For example, suppose you use GitHub for your repository management and use Postman to develop and test your APIs. If you want to save your Postman Collections to a GitHub repository, you can use the [Postman to GitHub integration]({{site.pm.gs}}/integrations/services/github){:target="_blank"} feature. 
+For example, suppose you use GitHub for your repository management and use Postman to develop and test your APIs. If you want to save your Postman Collections to a GitHub repository, you can use the [Postman to GitHub integration](https://go.postman.co/integrations/services/github){:target="_blank"} feature. 
 
 ### Postman Pro integrations
 
-Postman Pro users can currently access over a dozen of the most requested 3rd party integrations in the [Postman Integrations directory]({{site.pm.gs}}/dashboard/integrations), with more being released every month. 
+Postman Pro users can currently access over a dozen of the most requested 3rd party integrations in the [Postman Integrations directory](https://go.postman.co/dashboard/integrations), with more being released every month. 
 
-You can access Postman Pro integrations in the [Dashboard.]({{site.pm.gs}}/dashboard?){:target="_blank"} 
+You can access Postman Pro integrations in the [Dashboard.](https://go.postman.co/dashboard?){:target="_blank"} 
 
-In the Dashboard page, click ["Integrations"]({{site.pm.gs}}/dashboard/integrations){:target="_blank"}.
+In the Dashboard page, click ["Integrations"](https://go.postman.co/dashboard/integrations){:target="_blank"}.
 
   [![integrations](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations.png)
 

--- a/v5/pro/integrations/keen.md
+++ b/v5/pro/integrations/keen.md
@@ -21,7 +21,7 @@ Setting up a Keen integration requires you to get a project ID and API key befor
 
 ### Configuring Postman monitors
 
-In the **[Integrations]({{site.pm.gs}}/dashboard/integrations){:target="_blank"}** page, find Keen IO from a list of Postman’s 3rd party Integrations for Postman Pro users.
+In the **[Integrations](https://go.postman.co/dashboard/integrations){:target="_blank"}** page, find Keen IO from a list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![keen dashboard](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_keen1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_keen1.png)
 

--- a/v5/pro/integrations/microsoft_flow.md
+++ b/v5/pro/integrations/microsoft_flow.md
@@ -13,7 +13,7 @@ You can configure Microsoft Flow with Postman to monitor run results, view team 
 
 ### Congfiguring Microsoft Flow
 
-1. In the [Integrations]({{site.pm.gs}}/dashboard/integrations){:target="_blank"} page, find Microsoft Flow from a list of Postman’s 3rd party Integrations for Postman Pro users.
+1. In the [Integrations](https://go.postman.co/dashboard/integrations){:target="_blank"} page, find Microsoft Flow from a list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![microsoft_flow](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-microsoftFlow.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-microsoftFlow.png)  
 

--- a/v5/pro/integrations/microsoft_teams.md
+++ b/v5/pro/integrations/microsoft_teams.md
@@ -14,7 +14,7 @@ Currently, we have two ways in which this integration can be configured.
 ### Configuring Microsoft Teams
 
 
-1. In the [Integrations]({{site.pm.gs}}/dashboard/integrations){:target="_blank"} page, find Microsoft Teams from a list of Postman’s 3rd party Integrations for Postman Pro users.
+1. In the [Integrations](https://go.postman.co/dashboard/integrations){:target="_blank"} page, find Microsoft Teams from a list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![select ms_teams integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-msTeam.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-msTeam.png)
 

--- a/v5/pro/integrations/pagerduty.md
+++ b/v5/pro/integrations/pagerduty.md
@@ -33,7 +33,7 @@ Click the "Add Service" link at the bottom of the page to create a new service.
 
 ### Configuring Postman Pro with PagerDuty
 
-1. In the [Integrations page]({{site.pm.gs}}/dashboard/integrations){:target="_blank"}, find PagerDuty from a list of Postman's 3rd party Integrations for Postman Pro users.
+1. In the [Integrations page](https://go.postman.co/dashboard/integrations){:target="_blank"}, find PagerDuty from a list of Postman's 3rd party Integrations for Postman Pro users.
 
 [![select pagerduty integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-pagerduty1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-pagerduty1.png)
 

--- a/v5/pro/integrations/slack.md
+++ b/v5/pro/integrations/slack.md
@@ -12,7 +12,7 @@ The Postman Pro to Slack integration enables you to receive notifications for th
 
 ### Configuring Postman with Slack 
 
-In the [Integrations page]({{site.pm.gs}}/dashboard/integrations){:target="_blank"}, find the Slack Integration.
+In the [Integrations page](https://go.postman.co/dashboard/integrations){:target="_blank"}, find the Slack Integration.
 
 [![select slack integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-slack1.png)](
 https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-slack1.png)

--- a/v5/pro/integrations/victorops.md
+++ b/v5/pro/integrations/victorops.md
@@ -39,7 +39,7 @@ You can enter your own key and select a team for which the key is applicable.
 
 ### Configuring Postman Monitors
 
-In the [Integrations]({{site.pm.gs}}/integrations){:target="_blank"} page, find VictorOps from a list of Postman’s 3rd party Integrations for Postman Pro users.
+In the [Integrations](https://go.postman.co/integrations){:target="_blank"} page, find VictorOps from a list of Postman’s 3rd party Integrations for Postman Pro users.
 
 Click the **View Details** button to see information about VictorOps and how you can configure Postman monitors to trigger incidents on VictorOps.
 

--- a/v5/pro/managing_pro/activating_trial.md
+++ b/v5/pro/managing_pro/activating_trial.md
@@ -12,7 +12,7 @@ You must have a Postman account to activate your Postman Pro trial.
 ### If you have a Postman account
 
 1. In the Postman [home page,](https://www.getpostman.com/){:target="_blank"} sign in to your Postman account. 
-2. In the [Dashboard]({{site.pm.gs}}/dashboard){:target="_blank"}, click "Activate trial".
+2. In the [Dashboard](https://go.postman.co/dashboard){:target="_blank"}, click "Activate trial".
         [![activate](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/activate_trial.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/activate_trial.png)  
 
 The Postman dashboard page indicates how many days you have remaining in the Pro trial. You can also setup a team, create collections, and download Mac, Windows, or Linux native Postman apps. 

--- a/v5/pro/managing_pro/billing_and_pricing.md
+++ b/v5/pro/managing_pro/billing_and_pricing.md
@@ -16,12 +16,12 @@ Postman Pro teams can choose between 2 billing cycles:
 
 ### Changing Billing Cycles / Team Size
 
-1.  Annual teams can only switch to the monthly plan and reduce their team size at the end of their current billing cycle. The number of days left for the current cycle are shown on the [billing page]({{site.pm.gs}}/pay/billing){:target="_blank"}. Click the "Configure next cycle" link on the billing page to switch to the monthly plan / change team size for the next cycle. If you switch to the monthly plan, you'll be charged at $8/user/month after your billing cycle ends.
-2.  Monthly teams can switch to the annual plan at any time. Head to the [billing page]({{site.pm.gs}}/pay/billing){:target="_blank"}, and click 'Change Plan' in the settings dropdown. Here, you can increase or decrease your team size, and change to the annual plan. Changes to the team size will take effect instantly, and your next invoice will be pro-rated. Changes to the billing cycle will take place after the current month ends, and you'll be charged $75/user, valid for the next one year.
+1.  Annual teams can only switch to the monthly plan and reduce their team size at the end of their current billing cycle. The number of days left for the current cycle are shown on the [billing page](https://go.postman.co/pay/billing){:target="_blank"}. Click the "Configure next cycle" link on the billing page to switch to the monthly plan / change team size for the next cycle. If you switch to the monthly plan, you'll be charged at $8/user/month after your billing cycle ends.
+2.  Monthly teams can switch to the annual plan at any time. Head to the [billing page](https://go.postman.co/pay/billing){:target="_blank"}, and click 'Change Plan' in the settings dropdown. Here, you can increase or decrease your team size, and change to the annual plan. Changes to the team size will take effect instantly, and your next invoice will be pro-rated. Changes to the billing cycle will take place after the current month ends, and you'll be charged $75/user, valid for the next one year.
 
 ### Adding Users to Annual teams
 
-Annual teams can increase their team size to invite more users at any time. Head to the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}, and click 'Add users'. If you have a saved card, you'll be able to select the number of paid slots you want to add, and have the changes take effect instantly. 
+Annual teams can increase their team size to invite more users at any time. Head to the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}, and click 'Add users'. If you have a saved card, you'll be able to select the number of paid slots you want to add, and have the changes take effect instantly. 
 
   [![add users](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addUsers.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addUsers.jpg)
 

--- a/v5/pro/managing_pro/changing_your_plan.md
+++ b/v5/pro/managing_pro/changing_your_plan.md
@@ -9,7 +9,7 @@ warning: false
 
 Postman enables you to change your Pro (Annual) or Pro (Monthly) plan.
 
-To change your plan, go to the [Billing Overview]({{site.pm.gs}}/pay/billing){:target="_blank"} page. You will see different actions for changing your plan, depending on whether you’re on the Pro (Annual) or Pro (Monthly) plan.
+To change your plan, go to the [Billing Overview](https://go.postman.co/pay/billing){:target="_blank"} page. You will see different actions for changing your plan, depending on whether you’re on the Pro (Annual) or Pro (Monthly) plan.
 
 ### Pro (Monthly)
 
@@ -54,7 +54,7 @@ If you’re on the annual Postman Pro subscription, you can:
 
 ### Adding user slots to your annual plan
 
-In the [Billing Overview]({{site.pm.gs}}/pay/billing){:target="_blank"} page, click the **Add User Slots** button to increase the size of our team
+In the [Billing Overview](https://go.postman.co/pay/billing){:target="_blank"} page, click the **Add User Slots** button to increase the size of our team
 
 [![add slot](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/currentPlan-annual.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/currentPlan-annual.png)
 

--- a/v5/pro/managing_pro/inviting_and_managing.md
+++ b/v5/pro/managing_pro/inviting_and_managing.md
@@ -7,7 +7,7 @@ warning: false
 
 ---
 
-Postman's web [dashboard]({{site.pm.gs}}/dashboard/teams){:target="_blank"} provides a number of ways to manage your team.
+Postman's web [dashboard](https://go.postman.co/dashboard/teams){:target="_blank"} provides a number of ways to manage your team.
 
 ### Member roles
 
@@ -27,7 +27,7 @@ By default, members who set up the team for themselves will be granted all three
 
 ### Managing roles
 
-Anyone with the admin role can modify roles of other members. Head to the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}, click the Settings icon, and select "Manage permissions". 
+Anyone with the admin role can modify roles of other members. Head to the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}, click the Settings icon, and select "Manage permissions". 
 	
   [![manage settings](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/managePermissions.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/managePermissions.jpg)
 	
@@ -49,7 +49,7 @@ An invite is an invitation that you send to new people to add them to a team. Th
 
   [![invite users from app](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/invite_users_from_app.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/invite_users_from_app.png)
 
-**For the user role:** To invite people to join the team with a user role, head to the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}, and click on "Invite Users". Enter the email addresses of those you wish to invite, and hit "Send Invite(s)". 
+**For the user role:** To invite people to join the team with a user role, head to the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}, and click on "Invite Users". Enter the email addresses of those you wish to invite, and hit "Send Invite(s)". 
 
   [![invite users](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/inviteUsers.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/inviteUsers.jpg)
 
@@ -58,14 +58,14 @@ These invites will be visible at the bottom of the member listing. If you don't 
   [![pending invite](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/pendingInvite.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/pendingInvite.jpg)
 
 
-**For admin or billing roles:** To invite people to join the team with an admin or billing role, head to the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}, click the Settings icon, and select "Add Support Account". Enter the recipient's email address, choose which roles to assign, and hit "Send Invite(s)". These invites will be visible at the bottom of the member listing. 
+**For admin or billing roles:** To invite people to join the team with an admin or billing role, head to the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}, click the Settings icon, and select "Add Support Account". Enter the recipient's email address, choose which roles to assign, and hit "Send Invite(s)". These invites will be visible at the bottom of the member listing. 
 
   [![add support account](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/supportAccount.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/supportAccount.jpg)
 
-**Canceling Invites:** If you'd like to revoke an invite you've already sent, hit the "X" link next to each invite in the listing on the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}. You can see how many available invites remain in the count displayed on the "Invite Users" button. The available invites will increase by 1 for every canceled invite for the user role.
+**Canceling Invites:** If you'd like to revoke an invite you've already sent, hit the "X" link next to each invite in the listing on the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}. You can see how many available invites remain in the count displayed on the "Invite Users" button. The available invites will increase by 1 for every canceled invite for the user role.
 
 ### Changing team size
 
-**For billing members**: If you're out of paid slots and need to invite more users, you'll need to click "Add Users" on the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}. You'll need to have a saved card to add users. Annual teams will be billed a pro-rated amount for the number of days left in the billing cycle.
+**For billing members**: If you're out of paid slots and need to invite more users, you'll need to click "Add Users" on the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}. You'll need to have a saved card to add users. Annual teams will be billed a pro-rated amount for the number of days left in the billing cycle.
 
   [![add users](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addUsers.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addUsers.jpg)

--- a/v5/pro/managing_pro/managing_your_billing.md
+++ b/v5/pro/managing_pro/managing_your_billing.md
@@ -7,7 +7,7 @@ warning: false
 
 ---
 
-You can manage your billing from the [Billing Overview]({{site.pm.gs}}/pay/billing){:target="_blank"} page. 
+You can manage your billing from the [Billing Overview](https://go.postman.co/pay/billing){:target="_blank"} page. 
 
 [![manage billing](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/billing-overview-page+.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/billing-overview-page+.png)
 

--- a/v5/pro/managing_pro/managing_your_team.md
+++ b/v5/pro/managing_pro/managing_your_team.md
@@ -27,7 +27,7 @@ By default, members who set up the team for themselves will be granted all three
 
 ### Managing roles
 
-Anyone with the admin role can modify roles of other members. Head to the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}, click the Settings icon, and select "Manage permissions". 
+Anyone with the admin role can modify roles of other members. Head to the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}, click the Settings icon, and select "Manage permissions". 
 	
   [![manage settings](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/managePermissions.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/managePermissions.jpg)
 	
@@ -49,7 +49,7 @@ An invite is an invitation that you send to new people to add them to a team. Th
 
   [![invite users from app](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/invite_users_from_app.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/invite_users_from_app.png)
 
-**For the user role:** To invite people to join the team with a user role, head to the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}, and click on "Invite Users". Enter the email addresses of those you wish to invite, and hit "Send Invite(s)". 
+**For the user role:** To invite people to join the team with a user role, head to the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}, and click on "Invite Users". Enter the email addresses of those you wish to invite, and hit "Send Invite(s)". 
 
   [![invite users](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/inviteUsers.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/inviteUsers.jpg)
 
@@ -58,14 +58,14 @@ These invites will be visible at the bottom of the member listing. If you don't 
   [![pending invite](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/pendingInvite.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/pendingInvite.jpg)
 
 
-**For admin or billing roles:** To invite people to join the team with an admin or billing role, head to the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}, click the Settings icon, and select "Add Support Account". Enter the recipient's email address, choose which roles to assign, and hit "Send Invite(s)". These invites will be visible at the bottom of the member listing. 
+**For admin or billing roles:** To invite people to join the team with an admin or billing role, head to the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}, click the Settings icon, and select "Add Support Account". Enter the recipient's email address, choose which roles to assign, and hit "Send Invite(s)". These invites will be visible at the bottom of the member listing. 
 
   [![add support account](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/supportAccount.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/supportAccount.jpg)
 
-**Canceling Invites:** If you'd like to revoke an invite you've already sent, hit the "X" link next to each invite in the listing on the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}. You can see how many available invites remain in the count displayed on the "Invite Users" button. The available invites will increase by 1 for every canceled invite for the user role.
+**Canceling Invites:** If you'd like to revoke an invite you've already sent, hit the "X" link next to each invite in the listing on the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}. You can see how many available invites remain in the count displayed on the "Invite Users" button. The available invites will increase by 1 for every canceled invite for the user role.
 
 ### Changing team size
 
-**For billing members**: If you're out of paid slots and need to invite more users, you'll need to click "Add Users" on the [teams page]({{site.pm.gs}}/dashboard/teams){:target="_blank"}. You'll need to have a saved card to add users. Annual teams will be billed a pro-rated amount for the number of days left in the billing cycle.
+**For billing members**: If you're out of paid slots and need to invite more users, you'll need to click "Add Users" on the [teams page](https://go.postman.co/dashboard/teams){:target="_blank"}. You'll need to have a saved card to add users. Annual teams will be billed a pro-rated amount for the number of days left in the billing cycle.
 
   [![add users](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addUsers.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addUsers.jpg)

--- a/v5/pro/managing_pro/upgrading_to_postman_pro_from_a_trial_team.md
+++ b/v5/pro/managing_pro/upgrading_to_postman_pro_from_a_trial_team.md
@@ -9,7 +9,7 @@ warning: false
 
 After your Postman Pro trial ends, you can upgrade to a monthly or annual subscription. 
 
-To upgrade to a Postman Pro subscription, go to the [Billing Overview]({{site.pm.gs}}/pay/billing){:target="_blank"} page and click the **Upgrade to Pro** button. 
+To upgrade to a Postman Pro subscription, go to the [Billing Overview](https://go.postman.co/pay/billing){:target="_blank"} page and click the **Upgrade to Pro** button. 
 
 [![Upgrade to Pro](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/upgrade+to+pro.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/upgrade+to+pro.png)
 

--- a/v6/enterprise/purchasing_enterprise.md
+++ b/v6/enterprise/purchasing_enterprise.md
@@ -12,7 +12,7 @@ The instructions below are for paying via credit card. If you need to pay via pu
 
 To upgrade your plan to a Postman Enterprise subscription, you will need a [Postman account](/docs/v6/postman/launching_postman/postman_account). 
 
-Log in to your Postman account, and go to the [billing page]({{site.pm.gs}}/pay/billing). Next to your current plan, click the **Upgrade** button. For existing Postman Pro users, click the ellipses *(...)* next to the **Upgrade** button and select the "Change plan" option. 
+Log in to your Postman account, and go to the [billing page](https://go.postman.co/pay/billing). Next to your current plan, click the **Upgrade** button. For existing Postman Pro users, click the ellipses *(...)* next to the **Upgrade** button and select the "Change plan" option. 
 
 [![Billing page](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/enterprise-upgrade.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/enterprise-upgrade.png)
 

--- a/v6/enterprise/sso/saml_duo.md
+++ b/v6/enterprise/sso/saml_duo.md
@@ -16,7 +16,7 @@ warning: false
 2.   Search for "SAML - Service Provider" and click on the **Protect this Application** link.
      [![duo protect](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/duo_protect.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/duo_protect.png)
 
-3.   Enter `Postman` as the service provider. The service provider details can be found on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit). Other fields can either be left blank or set to the default value.
+3.   Enter `Postman` as the service provider. The service provider details can be found on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit). Other fields can either be left blank or set to the default value.
      [![duo provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/duo_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/duo_provider.png)
  
      | **Field** | **Value** |
@@ -34,4 +34,4 @@ warning: false
  
 6.   Duo requires your cloud application to be added to the Duo Access Gateway. Refer to this [guide for setting this up](https://duo.com/docs/dag-generic).
 
-7.   Once the setup is complete, submit your Identity Provider's details to Postman. Collect the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer`, and `X.509 Certificate` from the Duo configuration page and fill these values in your Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **Duo Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
+7.   Once the setup is complete, submit your Identity Provider's details to Postman. Collect the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer`, and `X.509 Certificate` from the Duo configuration page and fill these values in your Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **Duo Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 

--- a/v6/enterprise/sso/saml_gsuite.md
+++ b/v6/enterprise/sso/saml_gsuite.md
@@ -22,13 +22,13 @@ warning: false
 4. Click "SETUP MY OWN CUSTOM APP".
    [![gsuite setup](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_setup.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_setup.png)
 
-5. Collect the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer` and `X.509 Certificate` from this window, and enter these values into your Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **GSuite Identity Provider Details** modal.
+5. Collect the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer` and `X.509 Certificate` from this window, and enter these values into your Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **GSuite Identity Provider Details** modal.
    [![gsuite google IdP](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_google_IdP.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_google_IdP.png)
 
 6. Enter an application name (e.g. Postman SAML App) and fill out any other optional fields.
    [![gsuite basic info](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_basic_info.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_basic_info.png)
 
-7. Enter the Postman service provider details which can be found on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **GSuite Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
+7. Enter the Postman service provider details which can be found on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **GSuite Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
    [![gsuite service provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_service_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/gsuite_service_provider.png)
  
  | **Field** | **Value** |

--- a/v6/enterprise/sso/saml_okta.md
+++ b/v6/enterprise/sso/saml_okta.md
@@ -22,7 +22,7 @@ warning: false
 4.   Under the first step "General Settings", enter an application name and then click the **Next** button.
      [![okta app name](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_app_name.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_app_name.png)
 
-5.   Under the second step “Configure SAML”, section A “SAML Settings”, enter the Postman service provider details which can be found on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit). 
+5.   Under the second step “Configure SAML”, section A “SAML Settings”, enter the Postman service provider details which can be found on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit). 
      [![okta service provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_service_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_service_provider.png)
 
      | **Field** | **Value** |
@@ -31,7 +31,7 @@ warning: false
      | Audience URI (SP Entity ID) | Entity ID |
      | Name ID Format | EmailAddress |
  
-6.   Click the **Show Advanced Settings** link to configure advanced SAML assertion settings. Configure the options as shown in the image below. For the Encryption Certificate, download the `X.509 certificate` from the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) and upload it here. Click **Next** to continue.
+6.   Click the **Show Advanced Settings** link to configure advanced SAML assertion settings. Configure the options as shown in the image below. For the Encryption Certificate, download the `X.509 certificate` from the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) and upload it here. Click **Next** to continue.
      [![okta advanced](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_advanced.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_advanced.png)
   
 7.   Under the third step “Feedback”, select “I’m an Okta customer adding an internal app”, and check “This is an internal app that we have created”, and then click **Finish**.
@@ -40,5 +40,5 @@ warning: false
 8.   Move over to the **Sign On** tab, and click the **View Setup Instructions** button.
      [![okta sign on](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_sign_on.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_sign_on.png)
   
-9.   Copy the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer` and `X.509 Certificate` from here and update the SSO authentication method that you created on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **Okta Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
+9.   Copy the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer` and `X.509 Certificate` from here and update the SSO authentication method that you created on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **Okta Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
      [![okta identity provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_identity_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/okta_identity_provider.png)

--- a/v6/enterprise/sso/saml_onelogin.md
+++ b/v6/enterprise/sso/saml_onelogin.md
@@ -19,8 +19,8 @@ warning: false
 3. Update the **Display Name**, and click **SAVE**.
    [![onelogin display name](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_display.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_display.png)
 
-4. Enter your Postman service provider details. These details can be found on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit). For the SAML Encryption, download the `X.509 certificate` from the Postman Edit Team Details page as well. Click **SAVE** to proceed.
+4. Enter your Postman service provider details. These details can be found on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit). For the SAML Encryption, download the `X.509 certificate` from the Postman Edit Team Details page as well. Click **SAVE** to proceed.
    [![onelogin service provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_service_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_service_provider.png)
 
-5. Copy the `Identity Provider Issuer URL`, `SAML 2.0 Endpoint (HTTP)`, and `X.509 Certificate` from here and update the SSO authentication method that you created at Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **Onelogin Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
+5. Copy the `Identity Provider Issuer URL`, `SAML 2.0 Endpoint (HTTP)`, and `X.509 Certificate` from here and update the SSO authentication method that you created at Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **Onelogin Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
    [![onelogin identity provider](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_identity_provider.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/onelogin_identity_provider.png)

--- a/v6/enterprise/sso/saml_ping.md
+++ b/v6/enterprise/sso/saml_ping.md
@@ -19,7 +19,7 @@ warning: false
 3. Fill in the required application details and continue to the next step.
    [![ping_details](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/ping_details)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/ping_details)
 
-4. Download the **SAML metadata** file, and enter your Postman service provider details. These details can be found on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit). 
+4. Download the **SAML metadata** file, and enter your Postman service provider details. These details can be found on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit). 
 
     | **Field** | **Value** |
     |---|---|
@@ -39,4 +39,4 @@ warning: false
 7. Once enabled, the status will show as **Active** for the application.
    [![ping active](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/ping_active)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/ping_active)
 
-7. Once the setup is completed, submit your Identity Provider's details to Postman. Copy the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer`, and `X.509 Certificate` from the downloaded **SAML metadata** file and enter these values on the Postman [Edit Team Details page]({{site.pm.gs}}/dashboard/teams/edit) within the **Ping Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 
+7. Once the setup is completed, submit your Identity Provider's details to Postman. Copy the `Identity Provider Single Sign-On URL`, `Identity Provider Issuer`, and `X.509 Certificate` from the downloaded **SAML metadata** file and enter these values on the Postman [Edit Team Details page](https://go.postman.co/dashboard/teams/edit) within the **Ping Identity Provider Details** modal. For more details on this last step, review [setting up SSO in Postman](/docs/enterprise/sso/admin_sso). 

--- a/v6/postman/api_documentation/adding_and_verifying_custom_domains.md
+++ b/v6/postman/api_documentation/adding_and_verifying_custom_domains.md
@@ -8,7 +8,7 @@ Postman users with public documentation can publish documentation on their own c
 
 ### Add a custom domain
 
-In the Postman dashboard, select [Team Settings]({{site.pm.gs}}/dashboard/teams/edit) in the Team tab.
+In the Postman dashboard, select [Team Settings](https://go.postman.co/dashboard/teams/edit) in the Team tab.
 
 [![edit view for team](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-docs-team-settings2-1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-docs-team-settings2-1.png)
 

--- a/v6/postman/api_documentation/adding_team_name_and_logo.md
+++ b/v6/postman/api_documentation/adding_team_name_and_logo.md
@@ -7,21 +7,21 @@ tags:
 warning: false
 ---
 
-Postman users with the **Admin** member role can add a team name and logo to their Postman team account directly in the [Team Settings page]({{site.pm.gs}}/dashboard/teams/edit).
+Postman users with the **Admin** member role can add a team name and logo to their Postman team account directly in the [Team Settings page](https://go.postman.co/dashboard/teams/edit).
 
 ### Update your team name
 
-To see your current team name, go to the [Team page]({{site.pm.gs}}/dashboard/teams) in the Postman website.
+To see your current team name, go to the [Team page](https://go.postman.co/dashboard/teams) in the Postman website.
 
 [![team name](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-docs-team2-1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-docs-team2-1.png)
 
-If you didn’t enter a team name when you first created your Postman Pro or Enterprise team, you can add it in the [Team Settings]({{site.pm.gs}}/dashboard/teams/edit) page.
+If you didn’t enter a team name when you first created your Postman Pro or Enterprise team, you can add it in the [Team Settings](https://go.postman.co/dashboard/teams/edit) page.
 
 [![edit team details page](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-team-settings-plain-1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-team-settings-plain-1.png)
 
 ### Update your team logo
 
-To update your logo, go to the [Team Settings]({{site.pm.gs}}/dashboard/teams/edit) page.
+To update your logo, go to the [Team Settings](https://go.postman.co/dashboard/teams/edit) page.
 
 Next hover over the logo under "Team Logo" in the "Style" section to see the **Pencil** (edit) and **Trash Can** (delete) icons.
 

--- a/v6/postman/api_documentation/viewing_documentation.md
+++ b/v6/postman/api_documentation/viewing_documentation.md
@@ -37,7 +37,7 @@ Alternatively, you can also point your cursor to any collection in your dashboar
 
 ### Viewing Public Documentation
 
-Public documentation is accessible through a URL that Postman generates at the time of publication. This link displays immediately, and can be found in your [Postman Dashboard]({{site.pm.gs}}). If you’ve opted to use a custom domain, you’ll find your published documentation link in the Postman Dashboard.
+Public documentation is accessible through a URL that Postman generates at the time of publication. This link displays immediately, and can be found in your [Postman Dashboard](https://go.postman.co). If you’ve opted to use a custom domain, you’ll find your published documentation link in the Postman Dashboard.
 
 [![public documentation link](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-docs-public-view.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-docs-public-view.png)
 

--- a/v6/postman/launching_postman/newbutton.md
+++ b/v6/postman/launching_postman/newbutton.md
@@ -136,7 +136,7 @@ A [mock server](/docs/postman/v6/mock_servers/setting_up_mock) simulates each en
 * Enter the name of the mock
 * Select an environment (optional).
 * Indicate if you want to make this mock server private
-**Note**: The number of calls made to mock servers might be limited by your Postman account. Check your [usage limits]({{site.pm.gs}}/dashboard/usage).
+**Note**: The number of calls made to mock servers might be limited by your Postman account. Check your [usage limits](https://go.postman.co/dashboard/usage).
 [![configTab mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-mock-configureTab-1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-mock-configureTab-1.png) 
 1. Click the **Create** button.
 

--- a/v6/postman/launching_postman/postman_account.md
+++ b/v6/postman/launching_postman/postman_account.md
@@ -62,7 +62,7 @@ To switch back to your previous account, click on the account user name in the d
 
 #### How to switch accounts in the Postman web view
 
-When you sign in to the [Dashboard]({{site.pm.gs}}/dashboard), you see your profile image on the top right hand corner of the screen.  
+When you sign in to the [Dashboard](https://go.postman.co/dashboard), you see your profile image on the top right hand corner of the screen.  
 
 To sign in to another account, click the **Add a new account** button at the bottom of the drop down menu.
 

--- a/v6/postman/launching_postman/syncing.md
+++ b/v6/postman/launching_postman/syncing.md
@@ -60,7 +60,7 @@ When you reload the app, Postman automatically retrieves the most recent and up-
 
 ### Deleting your Postman account
 
-If you have a Postman account and are not part of a Postman team, you can [delete your account]({{site.pm.gs}}/dashboard/profile). 
+If you have a Postman account and are not part of a Postman team, you can [delete your account](https://go.postman.co/dashboard/profile). 
 
 Otherwise, you can contact us at [{{site.pm.help_email}}](mailto:{{site.pm.help_email}}).
 

--- a/v6/postman/mock_servers/setting_up_mock.md
+++ b/v6/postman/mock_servers/setting_up_mock.md
@@ -52,7 +52,7 @@ In the Configure mock server tab, you must:
 * Select an environment (optional).
 * Indicate if you want to make this mock server private
 
-**Note**: The number of calls made to mock servers might be limited by your Postman account. Check your [usage limits]({{site.pm.gs}}/dashboard/usage).
+**Note**: The number of calls made to mock servers might be limited by your Postman account. Check your [usage limits](https://go.postman.co/dashboard/usage).
      
  [![configTab mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-mock-configureTab-p2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-mock-configureTab-p2.png) 
      

--- a/v6/postman/postman_api/continuous_integration.md
+++ b/v6/postman/postman_api/continuous_integration.md
@@ -11,7 +11,7 @@ Let's access collections using the Postman API to run inside your Continuous Int
 Before we get started:
 
 *   Ensure you have a CI system setup which can run shell commands and that you have access to modify the same.
-*   If you don't already have a [Postman API key](https://docs.api.getpostman.com/#authentication), [get one now]({{site.pm.gs}}/dashboard/integrations).
+*   If you don't already have a [Postman API key](https://docs.api.getpostman.com/#authentication), [get one now](https://go.postman.co/dashboard/integrations).
 *   Make sure you have a Postman Collection that tests your localhost server, and note the UID of the collection.
 
 ### Step 1: Install Node

--- a/v6/pro/integrations/apimatic.md
+++ b/v6/pro/integrations/apimatic.md
@@ -15,7 +15,7 @@ If you don't already have a [GitHub account](https://github.com/), you'll need t
 
 ### Configuring APIMATIC Integration
 
-1. In the [Integrations page]({{site.pm.gs}}/dashboard/integrations), find APIMATIC in the list of Postman’s 3rd party Integrations for Postman Pro users.
+1. In the [Integrations page](https://go.postman.co/dashboard/integrations), find APIMATIC in the list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![select apimatic](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_APImatic.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_APImatic.png)
 

--- a/v6/pro/integrations/bigpanda.md
+++ b/v6/pro/integrations/bigpanda.md
@@ -45,7 +45,7 @@ The generated App Key displays.
 ### Configuring Postman monitors
 
 
-1. In the **[Integrations]({{site.pm.gs}}/dashboard/integrations)** page, find BigPanda from a list of Postman's 3rd party Integrations for Postman Pro users.
+1. In the **[Integrations](https://go.postman.co/dashboard/integrations)** page, find BigPanda from a list of Postman's 3rd party Integrations for Postman Pro users.
 
 2. Click the **View Details** button to see information about BigPanda and how it can provide real-time alerting based on the results of your Postman monitors. 
 

--- a/v6/pro/integrations/coralogix.md
+++ b/v6/pro/integrations/coralogix.md
@@ -24,7 +24,7 @@ Navigate to "Send your logs" tab and copy the private key for later use, as illu
 
 ### Configuring Coralogix Integration
 
-1. In the [Integrations]({{site.pm.gs}}/dashboard/integrations) page, find Coralogix in the list of Postman’s 3rd party Integrations for Postman Pro and Enterprise users.
+1. In the [Integrations](https://go.postman.co/dashboard/integrations) page, find Coralogix in the list of Postman’s 3rd party Integrations for Postman Pro and Enterprise users.
 
 [![coralogix integrations page](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/coralogix_viewdetails.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/coralogix_viewdetails.png)
 

--- a/v6/pro/integrations/datadog.md
+++ b/v6/pro/integrations/datadog.md
@@ -22,7 +22,7 @@ Save the API Key to use later.
 
 ### Configuring Postman Monitors
 
-1. In the [Integrations]({{site.pm.gs}}/dashboard/integrations) page, find Datadog in the list of Postman’s 3rd party Integrations for Postman Pro users.
+1. In the [Integrations](https://go.postman.co/dashboard/integrations) page, find Datadog in the list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![datadog integrations page](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_datadog2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_datadog2.png)
 

--- a/v6/pro/integrations/dropbox.md
+++ b/v6/pro/integrations/dropbox.md
@@ -11,7 +11,7 @@ Backup and synchronize your Postman Collections on Dropbox for file sharing, sto
 
 ### Configuring Dropbox Integration
 
-1. In the [Integrations page]({{site.pm.gs}}/dashboard/integrations), find Dropbox from a list of Postman's 3rd party Integrations for Postman Pro users.
+1. In the [Integrations page](https://go.postman.co/dashboard/integrations), find Dropbox from a list of Postman's 3rd party Integrations for Postman Pro users.
 
 [![select dropbox integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_dropbox1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_dropbox1.png)
 

--- a/v6/pro/integrations/github.md
+++ b/v6/pro/integrations/github.md
@@ -27,7 +27,7 @@ Once that token is generated, copy it and save it somewhere for future use.
 <br>
 ### Configuring GitHub Integration
 
-1. In the **[Integrations]({{site.pm.gs}}/dashboard/integrations)** page, find Github from a list of Postman's 3rd party Integrations for Postman Pro users.
+1. In the **[Integrations](https://go.postman.co/dashboard/integrations)** page, find Github from a list of Postman's 3rd party Integrations for Postman Pro users.
 
 [![github integration](https://static.getpostman.com/postman-docs/integrations-github1.png)](https://static.getpostman.com/postman-docs/integrations-github1.png)
 

--- a/v6/pro/integrations/gitlab.md
+++ b/v6/pro/integrations/gitlab.md
@@ -27,7 +27,7 @@ Save the generated token to use later.
 
 ### Configuring a backup for Postman Collections in GitLab
 
-1. In the [Integrations page]({{site.pm.gs}}/dashboard/integrations), find GitLab from a list of Postman's 3rd party Integrations for Postman Pro users.
+1. In the [Integrations page](https://go.postman.co/dashboard/integrations), find GitLab from a list of Postman's 3rd party Integrations for Postman Pro users.
 
 [![select gitlab integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-gitlab1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-gitlab1.png)
 

--- a/v6/pro/integrations/hipchat.md
+++ b/v6/pro/integrations/hipchat.md
@@ -12,7 +12,7 @@ This integration allows you to get real-time updates of what is happening in you
 
 ### Configuring Postman with HipChat
 
-1. In the [Integrations]({{site.pm.gs}}/dashboard/integrations) page, find HipChat from a list of Postman’s 3rd party Integrations for Postman Pro users.
+1. In the [Integrations](https://go.postman.co/dashboard/integrations) page, find HipChat from a list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![select hipchat integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-hipchat.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-hipchat.png)
 

--- a/v6/pro/integrations/intro_integrations.md
+++ b/v6/pro/integrations/intro_integrations.md
@@ -21,11 +21,11 @@ For example, suppose you use GitHub for your repository management and use Postm
 
 ### Postman Pro integrations
 
-Postman Pro users can currently access over a dozen of the most requested 3rd party integrations in the [Postman Integrations directory]({{site.pm.gs}}/dashboard/integrations), with more being released every month. 
+Postman Pro users can currently access over a dozen of the most requested 3rd party integrations in the [Postman Integrations directory](https://go.postman.co/dashboard/integrations), with more being released every month. 
 
-You can access Postman Pro integrations in the [Dashboard.]({{site.pm.gs}}/dashboard?) 
+You can access Postman Pro integrations in the [Dashboard.](https://go.postman.co/dashboard?) 
 
-In the Dashboard page, click ["Integrations"]({{site.pm.gs}}/dashboard/integrations).
+In the Dashboard page, click ["Integrations"](https://go.postman.co/dashboard/integrations).
 
   [![integrations](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-integrations.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-integrations.png)
 

--- a/v6/pro/integrations/keen.md
+++ b/v6/pro/integrations/keen.md
@@ -21,7 +21,7 @@ Setting up a Keen integration requires you to get a project ID and API key befor
 
 ### Configuring Postman monitors
 
-In the **[Integrations]({{site.pm.gs}}/dashboard/integrations)** page, find Keen IO from a list of Postman’s 3rd party Integrations for Postman Pro users.
+In the **[Integrations](https://go.postman.co/dashboard/integrations)** page, find Keen IO from a list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![keen dashboard](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_keen1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations_keen1.png)
 

--- a/v6/pro/integrations/microsoft_flow.md
+++ b/v6/pro/integrations/microsoft_flow.md
@@ -12,7 +12,7 @@ You can configure Microsoft Flow with Postman to monitor run results, view team 
 
 ### Congfiguring Microsoft Flow
 
-1. In the [Integrations]({{site.pm.gs}}/dashboard/integrations) page, find Microsoft Flow from a list of Postman’s 3rd party Integrations for Postman Pro users.
+1. In the [Integrations](https://go.postman.co/dashboard/integrations) page, find Microsoft Flow from a list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![microsoft_flow](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-microsoftFlow.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-microsoftFlow.png)  
 

--- a/v6/pro/integrations/microsoft_teams.md
+++ b/v6/pro/integrations/microsoft_teams.md
@@ -13,7 +13,7 @@ Currently, we have two ways in which this integration can be configured.
 ### Configuring Microsoft Teams
 
 
-1. In the [Integrations]({{site.pm.gs}}/dashboard/integrations) page, find Microsoft Teams from a list of Postman’s 3rd party Integrations for Postman Pro users.
+1. In the [Integrations](https://go.postman.co/dashboard/integrations) page, find Microsoft Teams from a list of Postman’s 3rd party Integrations for Postman Pro users.
 
 [![select ms_teams integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-integrations-msTeam.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-integrations-msTeam.png)
 

--- a/v6/pro/integrations/pagerduty.md
+++ b/v6/pro/integrations/pagerduty.md
@@ -33,7 +33,7 @@ Click the "Add Service" link at the bottom of the page to create a new service.
 
 ### Configuring Postman Pro with PagerDuty
 
-1. In the [Integrations page]({{site.pm.gs}}/dashboard/integrations), find PagerDuty from a list of Postman's 3rd party Integrations for Postman Pro users.
+1. In the [Integrations page](https://go.postman.co/dashboard/integrations), find PagerDuty from a list of Postman's 3rd party Integrations for Postman Pro users.
 
 [![select pagerduty integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-pagerduty1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-pagerduty1.png)
 

--- a/v6/pro/integrations/slack.md
+++ b/v6/pro/integrations/slack.md
@@ -12,7 +12,7 @@ The Postman Pro to Slack integration enables you to receive notifications for th
 
 ### Configuring Postman with Slack 
 
-In the [Integrations page]({{site.pm.gs}}/dashboard/integrations), find the Slack Integration.
+In the [Integrations page](https://go.postman.co/dashboard/integrations), find the Slack Integration.
 
 [![select slack integration](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-slack1.png)](
 https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/integrations-slack1.png)

--- a/v6/pro/integrations/victorops.md
+++ b/v6/pro/integrations/victorops.md
@@ -38,7 +38,7 @@ You can enter your own key and select a team for which the key is applicable.
 
 ### Configuring Postman Monitors
 
-In the [Integrations]({{site.pm.gs}}/integrations) page, find VictorOps from a list of Postman’s 3rd party Integrations for Postman Pro users.
+In the [Integrations](https://go.postman.co/integrations) page, find VictorOps from a list of Postman’s 3rd party Integrations for Postman Pro users.
 
 Click the **View Details** button to see information about VictorOps and how you can configure Postman monitors to trigger incidents on VictorOps.
 

--- a/v6/pro/integrations/webhooks.md
+++ b/v6/pro/integrations/webhooks.md
@@ -13,7 +13,7 @@ You can configure a custom webhook with Postman to send events such as - monitor
 
 ### Configuring Custom Webhook URL
 
-1. In the [Integrations]({{site.pm.gs}}/dashboard/integrations) page, find Webhooks from a list of Postman’s 3rd party integrations for Postman Pro and Enterprise users.
+1. In the [Integrations](https://go.postman.co/dashboard/integrations) page, find Webhooks from a list of Postman’s 3rd party integrations for Postman Pro and Enterprise users.
 
 [![custom_webhook](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/webhooks_view1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/webhooks_view1.png)  
 

--- a/v6/pro/managing_pro/billing_and_pricing.md
+++ b/v6/pro/managing_pro/billing_and_pricing.md
@@ -16,12 +16,12 @@ Postman Pro teams can choose between 2 billing cycles:
 
 ### Changing Billing Cycles / Team Size
 
-1.  Annual teams can only switch to the monthly plan and reduce their team size at the end of their current billing cycle. The number of days left for the current cycle are shown on the [billing page]({{site.pm.gs}}/pay/billing). Click the "Configure next cycle" link on the billing page to switch to the monthly plan / change team size for the next cycle. If you switch to the monthly plan, you'll be charged at $8/user/month after your billing cycle ends.
-2.  Monthly teams can switch to the annual plan at any time. Head to the [billing page]({{site.pm.gs}}/pay/billing), and click 'Change Plan' in the settings dropdown. Here, you can increase or decrease your team size, and change to the annual plan. Changes to the team size will take effect instantly, and your next invoice will be pro-rated. Changes to the billing cycle will take place after the current month ends, and you'll be charged $75/user, valid for the next one year.
+1.  Annual teams can only switch to the monthly plan and reduce their team size at the end of their current billing cycle. The number of days left for the current cycle are shown on the [billing page](https://go.postman.co/pay/billing). Click the "Configure next cycle" link on the billing page to switch to the monthly plan / change team size for the next cycle. If you switch to the monthly plan, you'll be charged at $8/user/month after your billing cycle ends.
+2.  Monthly teams can switch to the annual plan at any time. Head to the [billing page](https://go.postman.co/pay/billing), and click 'Change Plan' in the settings dropdown. Here, you can increase or decrease your team size, and change to the annual plan. Changes to the team size will take effect instantly, and your next invoice will be pro-rated. Changes to the billing cycle will take place after the current month ends, and you'll be charged $75/user, valid for the next one year.
 
 ### Adding Users to Annual teams
 
-Annual teams can increase their team size to invite more users at any time. Head to the [teams page]({{site.pm.gs}}/dashboard/teams), and click 'Add users'. If you have a saved card, you'll be able to select the number of paid slots you want to add, and have the changes take effect instantly. 
+Annual teams can increase their team size to invite more users at any time. Head to the [teams page](https://go.postman.co/dashboard/teams), and click 'Add users'. If you have a saved card, you'll be able to select the number of paid slots you want to add, and have the changes take effect instantly. 
 
   [![add users](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addUsers.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addUsers.jpg)
 

--- a/v6/pro/managing_pro/changing_your_plan.md
+++ b/v6/pro/managing_pro/changing_your_plan.md
@@ -9,7 +9,7 @@ warning: false
 
 Postman enables you to change your Pro (Annual) or Pro (Monthly) plan.
 
-To change your plan, go to the [Billing Overview]({{site.pm.gs}}/pay/billing) page. You will see different actions for changing your plan, depending on whether you’re on the Pro (Annual) or Pro (Monthly) plan.
+To change your plan, go to the [Billing Overview](https://go.postman.co/pay/billing) page. You will see different actions for changing your plan, depending on whether you’re on the Pro (Annual) or Pro (Monthly) plan.
 
 ### Pro (Monthly)
 
@@ -48,7 +48,7 @@ If you’re on the annual Postman Pro subscription, you can:
 
 ### Adding user slots to your annual plan
 
-In the [Billing Overview]({{site.pm.gs}}/pay/billing) page, click the **Add User Slots** button to increase the size of our team
+In the [Billing Overview](https://go.postman.co/pay/billing) page, click the **Add User Slots** button to increase the size of our team
 
 [![add slot](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/currentPlan-annual.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/currentPlan-annual.png)
 

--- a/v6/pro/managing_pro/inviting_and_managing.md
+++ b/v6/pro/managing_pro/inviting_and_managing.md
@@ -7,7 +7,7 @@ warning: false
 
 ---
 
-Postman's web [dashboard]({{site.pm.gs}}/dashboard/teams) provides a number of ways to manage your team.
+Postman's web [dashboard](https://go.postman.co/dashboard/teams) provides a number of ways to manage your team.
 
 ### Member roles
 
@@ -27,7 +27,7 @@ By default, members who set up the team for themselves will be granted all three
 
 ### Managing roles
 
-Anyone with the admin role can modify roles of other members. Head to the [teams page]({{site.pm.gs}}/dashboard/teams), click the Settings icon, and select "Manage permissions". 
+Anyone with the admin role can modify roles of other members. Head to the [teams page](https://go.postman.co/dashboard/teams), click the Settings icon, and select "Manage permissions". 
 	
   [![manage settings](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/managePermissions.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/managePermissions.jpg)
 	
@@ -49,7 +49,7 @@ An invite is an invitation that you send to new people to add them to a team. Th
 
   [![invite users from app](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/invite_users_from_app.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/invite_users_from_app.png)
 
-**For the user role:** To invite people to join the team with a user role, head to the [teams page]({{site.pm.gs}}/dashboard/teams), and click on "Invite Users". Enter the email addresses of those you wish to invite, and hit "Send Invite(s)". 
+**For the user role:** To invite people to join the team with a user role, head to the [teams page](https://go.postman.co/dashboard/teams), and click on "Invite Users". Enter the email addresses of those you wish to invite, and hit "Send Invite(s)". 
 
   [![invite users](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/inviteUsers.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/inviteUsers.jpg)
 
@@ -58,14 +58,14 @@ These invites will be visible at the bottom of the member listing. If you don't 
   [![pending invite](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/pendingInvite.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/pendingInvite.jpg)
 
 
-**For admin or billing roles:** To invite people to join the team with an admin or billing role, head to the [teams page]({{site.pm.gs}}/dashboard/teams), click the Settings icon, and select "Add Support Account". Enter the recipient's email address, choose which roles to assign, and hit "Send Invite(s)". These invites will be visible at the bottom of the member listing. 
+**For admin or billing roles:** To invite people to join the team with an admin or billing role, head to the [teams page](https://go.postman.co/dashboard/teams), click the Settings icon, and select "Add Support Account". Enter the recipient's email address, choose which roles to assign, and hit "Send Invite(s)". These invites will be visible at the bottom of the member listing. 
 
   [![add support account](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/supportAccount.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/supportAccount.jpg)
 
-**Canceling Invites:** If you'd like to revoke an invite you've already sent, hit the "X" link next to each invite in the listing on the [teams page]({{site.pm.gs}}/dashboard/teams). You can see how many available invites remain in the count displayed on the "Invite Users" button. The available invites will increase by 1 for every canceled invite for the user role.
+**Canceling Invites:** If you'd like to revoke an invite you've already sent, hit the "X" link next to each invite in the listing on the [teams page](https://go.postman.co/dashboard/teams). You can see how many available invites remain in the count displayed on the "Invite Users" button. The available invites will increase by 1 for every canceled invite for the user role.
 
 ### Changing team size
 
-**For billing members**: If you're out of paid slots and need to invite more users, you'll need to click "Add Users" on the [teams page]({{site.pm.gs}}/dashboard/teams). You'll need to have a saved card to add users. Annual teams will be billed a pro-rated amount for the number of days left in the billing cycle.
+**For billing members**: If you're out of paid slots and need to invite more users, you'll need to click "Add Users" on the [teams page](https://go.postman.co/dashboard/teams). You'll need to have a saved card to add users. Annual teams will be billed a pro-rated amount for the number of days left in the billing cycle.
 
   [![add users](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addUsers.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/addUsers.jpg)

--- a/v6/pro/managing_pro/managing_your_billing.md
+++ b/v6/pro/managing_pro/managing_your_billing.md
@@ -6,7 +6,7 @@ tags:
 warning: false
 ---
 
-You can manage your billing from the [Billing Overview]({{site.pm.gs}}/pay/billing) page. 
+You can manage your billing from the [Billing Overview](https://go.postman.co/pay/billing) page. 
 
 [![manage billing](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-billing-overview-page.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-billing-overview-page.png)
 

--- a/v6/pro/managing_pro/managing_your_team.md
+++ b/v6/pro/managing_pro/managing_your_team.md
@@ -29,7 +29,7 @@ By default, members who set up the team for themselves will be granted all three
 
 ### Managing roles
 
-An admin can modify the roles of other team members in the [Team page]({{site.pm.gs}}/dashboard/teams). 
+An admin can modify the roles of other team members in the [Team page](https://go.postman.co/dashboard/teams). 
 	
   [![manage settings](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/PRO-managePermissions2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/PRO-managePermissions2.png)
 	
@@ -48,7 +48,7 @@ Keep in mind a few restrictions:
 An invite is an invitation you send to people you want to add to a team. Only admins can manage invites.
 
 #### Inviting members to a team in Dashboard
-In the [Team page]({{site.pm.gs}}/dashboard/teams), click the **Invite Users** button. 
+In the [Team page](https://go.postman.co/dashboard/teams), click the **Invite Users** button. 
 
 Enter the email address of the user you want to invite, and click the **Invite Users** to complete the process.
 

--- a/v6/pro/managing_pro/upgrading_to_postman_pro_from_a_trial_team.md
+++ b/v6/pro/managing_pro/upgrading_to_postman_pro_from_a_trial_team.md
@@ -8,7 +8,7 @@ warning: false
 
  You can upgrade to a monthly or annual subscription if you would like to leverage full power of Postman. 
 
-To upgrade to a Postman Pro subscription, go to the [Billing Overview]({{site.pm.gs}}/pay/billing) page and click the **Upgrade to Pro** button. 
+To upgrade to a Postman Pro subscription, go to the [Billing Overview](https://go.postman.co/pay/billing) page and click the **Upgrade to Pro** button. 
 
 [![Upgrade to Pro](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-upgrade-to-pro.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-upgrade-to-pro.png)
 


### PR DESCRIPTION
The new Learning Center cannot support interpolated strings such as `{{site.pm.gs}}` which was the previous way of setting up URLs for the Web app. Setting URLs in this manner will create dead links within the Learning Center docs.

This update removes `{{site.pm.gs}}` in favor of `https://go.postman.co`. Users are directed to `go.postman.co` because this is a generic host for all users, users can be handled accordingly, and is the preferred URL of choice. 

