### PR TITLE
Update and rename migrating_to_postman_v7.md to migrating_to_v7.md

### DIFF
--- a/v6/postman/migrating_to_v7.md
+++ b/v6/postman/migrating_to_v7.md
@@ -1,6 +1,6 @@
 ---
 title: "Migrating to Postman v7"
-page_id: "migrating_to_Postman_v7"
+page_id: "migrating_to_v7"
 warning: false
 ---
 


### PR DESCRIPTION
The incorrect name/slug was causing problems updating the learning center