### PR TITLE
Update Team Collaboration Hyperlink

### DIFF
--- a/v6/pro/what_is_pro.md
+++ b/v6/pro/what_is_pro.md
@@ -17,7 +17,7 @@ Postman’s vision is to help you build a super fast and smooth workflow for API
 
 Postman Pro offers solutions that satisfy each of the questions above. 
 
-*   Team [collaboration](/docs/postman/team_library/sharing) for the single source of truth about your API, or review historical versions and the latest updates.
+*   Team [collaboration](/docs/postman/workspaces/intro_to_workspaces) for the single source of truth about your API, or review historical versions and the latest updates.
 *   API [documentation](/docs/postman/api_documentation/intro_to_api_documentation) to share public or private documentation, beautifully viewable via a web page.
 *   Powerful [mock servers](/docs/postman/mock_servers) to simulate the real API and decouple teams.
 *   Collection [monitoring](/docs/postman/monitors/intro_monitors) to check for the performance, uptime and correctness of your API.


### PR DESCRIPTION
The hyperlink is currently pointing to /docs/postman/team_library – our legacy collaboration feature – which is causing some confusion when perusing the documentation.

@ArifPMan 