### PR TITLE
setNextRequest scope: clearer guideline

### DIFF
--- a/v5/postman/collection_runs/building_workflows.md
+++ b/v5/postman/collection_runs/building_workflows.md
@@ -33,5 +33,5 @@ Now that we have a good understanding of how `setNextRequest()` works, we can do
 
 There are some gotchas to keep in mind:
 
-   *   `setNextRequest()` is always executed at the end of the current script. This means that if you put `setNextRequest()` before other code blocks, these blocks will still be executed.
+   *   `setNextRequest()` is always executed at the end of the current request. This means that if you put this function before other code blocks anywhere in pre-request or test script, these blocks will still execute.
    *   `setNextRequest()` has a scope, which is the source of your collection run. This means that if you run a collection, you can jump to any request in the collection (even requests inside folders, using the same syntax). However, if you run a folder, the scope of `setNextRequest()` is limited to that folder. This means that you can jump to any request within this folder, but not ones that are outside of the folder. This includes requests inside other folders, and also root-level requests in the collection. To read more about [running collections or folders](/docs/postman/collection_runs/starting_a_collection_run).

--- a/v6/postman/collection_runs/building_workflows.md
+++ b/v6/postman/collection_runs/building_workflows.md
@@ -47,7 +47,7 @@ This [blog post](http://blog.getpostman.com/2016/11/09/generate-spotify-playlist
 
 Remember these two facts as you use this workflow:
 
-   *   `postman.setNextRequest()` is always executed at the end of the current script. If you put this function before other code blocks, these blocks will still execute.
+   *   `postman.setNextRequest()` is always executed at the end of the current request. This means that if you put this function before other code blocks anywhere in pre-request or test script, these blocks will still execute.
    
    *   `postman.setNextRequest()` has a scope, which is the source of your collection run. If you run a collection, you can jump to any request in the collection (even requests inside folders, using the same syntax). However, if you run a folder, the scope of `postman.setNextRequest()` is limited to that folder. So you can jump to any request in this folder, but not ones that are outside of the folder. It includes requests inside other folders, and also root-level requests in the collection. To read more about [running collections or folders](/docs/v6/postman/collection_runs/starting_a_collection_run).
   


### PR DESCRIPTION
**Change:** setNextRequest -> scope -> clearer message
**Why**
The current message says "postman.setNextRequest() is always executed at the end of the current script" which is ambiguous to understand as the current script can be "Pre-Request" or "Test" 
due to misunderstanding, I ended up investing time in debugging the actual cause. 

Discussion with Joyce [here for reference](https://community.getpostman.com/t/workflow-how-to-run-another-test-in-loop/2126/7?u=p00j).
