### PR TITLE
Remove "Pro" from the documentation page

### DIFF
--- a/v6/postman_for_publishers/public_api_docs.md
+++ b/v6/postman_for_publishers/public_api_docs.md
@@ -5,11 +5,11 @@ warning: false
 
 ---
 
-API publishers require public API documentation and require easy-to-read examples and specifications. Postman publishes [our own API documentation](http://docs.api.getpostman.com) using Postman Pro's documentation. Developers rely on this documentation for learning about the service, implementing their integrations, and debugging. Learn [how to publish your own public docs](/docs/postman/api_documentation/publishing_public_docs).
+API publishers require public API documentation and require easy-to-read examples and specifications. Postman publishes [our own API documentation](http://docs.api.getpostman.com) using Postman's documentation. Developers rely on this documentation for learning about the service, implementing their integrations, and debugging. Learn [how to publish your own public docs](/docs/postman/api_documentation/publishing_public_docs).
 
 [![postman API docs](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59189909.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59189909.png)  
 
-Postman Pro automatically generates documentation for any of your collections. Publish public API documentation that is:
+Postman automatically generates documentation for any of your collections. Publish public API documentation that is:
 
 ##### **Complete**
 
@@ -23,7 +23,7 @@ Create clear and elegant documentation [using Markdown](/docs/postman/api_docume
 
 Publish your API documentation with the click of a button. The pages are automatically generated, and updates are automatically synced. You will never have to host or manage servers for your API documentation ever again.
 
-### Examples of public APIs published using Postman Pro's documentation
+### Examples of public APIs published using Postman's documentation
 
 [![Travefy API docs](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59189815.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59189815.png)
 [![Imgur API docs](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59189801.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59189801.png)


### PR DESCRIPTION
Pro plan is not required to publish documentation 