### PR TITLE
404 Error for all External Links

### DIFF
--- a/v6/postman/design_and_develop_apis/managing_apis.md
+++ b/v6/postman/design_and_develop_apis/managing_apis.md
@@ -90,6 +90,6 @@ You can comment on your APIs the same way as you do on your collections. For mor
 For more information on APIs, see:
 
 - [Sharing an API](/docs/v6/postman/design_and_develop_apis/sharing_apis)
-- [Managing API workflow](/docs/v6/postman/design_and_develop_apis/managing-api-workflow)
-- [Versioning an API](/docs/v6/postman/design_and_develop_apis/versioning-an-api)
-- [Introduction to APIs](/docs/v6/postman/design_and_develop_apis/introduction-to-apis)
+- [Managing API workflow](/docs/v6/postman/design_and_develop_apis/the_api_workflow)
+- [Versioning an API](/docs/v6/postman/design_and_develop_apis/versioning_an_api)
+- [Introduction to APIs](/docs/v6/postman/design_and_develop_apis/introduction_to_apis)

--- a/v6/postman/design_and_develop_apis/sharing_apis.md
+++ b/v6/postman/design_and_develop_apis/sharing_apis.md
@@ -34,3 +34,10 @@ In the above screen, you can manage the roles and permissions of that specific m
 In the [workspaces dashboard](https://app.getpostman.com/dashboard), click the corresponding **Share** button of the API. The **Share API** button is shown in the below screen. The procedure, after clicking **Share API** button is similar as in app. Refer to the section above **Sharing APIs in the app** for further information. 
 
 [![api share dashboard](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/API-Share2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/API-Share2.png)
+
+For more information on APIs, see:
+
+- [Managing APIs](/docs/v6/postman/design_and_develop_apis/managing_apis)
+- [Managing API workflow](/docs/v6/postman/design_and_develop_apis/the_api_workflow)
+- [Versioning an API](/docs/v6/postman/design_and_develop_apis/versioning_an_api)
+- [Introduction to APIs](/docs/v6/postman/design_and_develop_apis/introduction_to_apis)

--- a/v6/postman/design_and_develop_apis/the_api_workflow.md
+++ b/v6/postman/design_and_develop_apis/the_api_workflow.md
@@ -79,7 +79,7 @@ The mock server is now added to the API and appears as illustrated below:
 [![api add mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/API-AddMock1-VersionTag.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/API-AddMock1-VersionTag.png)
 
 To understand how versioning influences mock servers, refer to the section
-[Versioning an API](/docs/v6/postman/design_and_develop_apis/versioning-an-api).
+[Versioning an API](/docs/v6/postman/design_and_develop_apis/versioning_an_api).
 
 To add a mock server to a specific version of your collection, refer to the section [Setting up mock](/docs/v6/postman/mock_servers/setting_up_mock)
 
@@ -91,7 +91,7 @@ You can link your documentation on collections with an API. In the **Develop** t
 
 In the above screen, select a corresponding collection from the list whose documentation you want to link and click **Add Documentation**. The documentation is now added to the API. Only available collections will be shown in this list.
 
-To understand how versioning influences documentation, refer to the section [Versioning an API](/docs/v6/postman/design_and_develop_apis/versioning-an-api).
+To understand how versioning influences documentation, refer to the section [Versioning an API](/docs/v6/postman/design_and_develop_apis/versioning_an_api).
 
 To learn more about generating and viewing version-specific documentation, refer to the section [Publishing version-specific documentaion](/docs/v6/postman/api_documentation/publishing_public_docs)
 
@@ -153,6 +153,6 @@ To add a monitor to a specific version of your collection, refer to the section 
 For more information on APIs, see:
 
 - [Sharing an API](/docs/v6/postman/design_and_develop_apis/sharing_apis)
-- [Versioning an API](/docs/v6/postman/design_and_develop_apis/versioning-an-api)
-- [Managing APIs](/docs/v6/postman/design_and_develop_apis/managing-apis)
-- [Introduction to APIs](/docs/v6/postman/design_and_develop_apis/introduction-to-apis)
+- [Versioning an API](/docs/v6/postman/design_and_develop_apis/versioning_an_api)
+- [Managing APIs](/docs/v6/postman/design_and_develop_apis/managing_apis)
+- [Introduction to APIs](/docs/v6/postman/design_and_develop_apis/introduction_to_apis)

--- a/v6/postman/design_and_develop_apis/versioning_an_api.md
+++ b/v6/postman/design_and_develop_apis/versioning_an_api.md
@@ -41,7 +41,7 @@ Click **Create another version** to go to the following screen:
 
 Specify a name for the new version of your API. In the **Carry over elements from a previous version** list, select a version if you want to carry over the elements. Else, select **Don't carry over any elements** to create a new API version from scratch.
 
-If you choose to **Carry over elements from a previous version**, then select the elements you'd like to carry over. Click **Create Version**. Postman creates a new version of your API and takes you to the [API workflow](<(/docs/v6/postman/design_and_develop_apis/managing-api-workflow)>) screen where you can _define, develop, test, and observe_ your new API version.
+If you choose to **Carry over elements from a previous version**, then select the elements you'd like to carry over. Click **Create Version**. Postman creates a new version of your API and takes you to the [API workflow](/docs/v6/postman/design_and_develop_apis/the_api_workflow) screen where you can _define, develop, test, and observe_ your new API version.
 
 ### Renaming API version tags
 
@@ -122,6 +122,6 @@ For more information on this, refer to [Publishing version-specific documentaion
 For more information on APIs, see:
 
 - [Sharing an API](/docs/v6/postman/design_and_develop_apis/sharing_apis)
-- [Managing API workflow](/docs/v6/postman/design_and_develop_apis/managing-api-workflow)
-- [Managing APIs](/docs/v6/postman/design_and_develop_apis/managing-apis)
-- [Introduction to APIs](/docs/v6/postman/design_and_develop_apis/introduction-to-apis)
+- [Managing API workflow](/docs/v6/postman/design_and_develop_apis/the_api_workflow)
+- [Managing APIs](/docs/v6/postman/design_and_develop_apis/managing_apis)
+- [Introduction to APIs](/docs/v6/postman/design_and_develop_apis/introduction_to_apis)


### PR DESCRIPTION
After the Design and Develop APIs renaming, the directory structure for links changed. The new directory was updated along with the following chapter name too. For instance,  [Managing API workflow](/docs/v6/postman/design_and_develop_apis/the-api-workflow). The chapter 'the-api-workflow' had an underscore originally, but got replaced with a hyphen. I updated all the links. They should be working now. Currently, most of the external links don't work. 