### PR TITLE
1646 updated link to Apple + img links

### DIFF
--- a/v6/postman/sending_api_requests/capturing_http_requests.md
+++ b/v6/postman/sending_api_requests/capturing_http_requests.md
@@ -5,11 +5,11 @@ warning: false
 
 ---
 
-If you are using APIs to build client-side applications - mobile apps, websites or desktop applications - you might want to see the actual HTTP request traffic that is being sent and received in the application. In some cases, you might discover APIs that are not even documented. Postman gives you tools to see and capture this network traffic easily. You can use the built-in proxy in the Postman native apps or use the [Interceptor extension](/docs/postman/sending_api_requests/interceptor_extension) for the Postman Chrome app. 
+If you are using APIs to build client-side applications - mobile apps, websites or desktop applications - you might want to see the actual HTTP request traffic that is being sent and received in the application. In some cases, you might discover APIs that are not even documented. Postman gives you tools to see and capture this network traffic easily. You can use the built-in proxy in the Postman native apps or use the [Interceptor extension](/docs/postman/sending_api_requests/interceptor_extension/) for the Postman Chrome app. 
 
 **Note:** for the Postman native apps, request captures over HTTPS will not work if the website has HSTS enabled. Most websites have this check in place.
 
-### The Postman built-in proxy
+## The Postman built-in proxy
 
 Postman has a proxy in the Postman app that captures the HTTP request.
 
@@ -19,15 +19,15 @@ Postman has a proxy in the Postman app that captures the HTTP request.
 
 [![postman capture proxy](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/proxymobile.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/proxymobile.png)
 
-Similar to the [Interceptor Chrome extension](/docs/postman/sending_api_requests/interceptor_extension), the Postman app proxy also INTERCEPTS and captures your requests. In this scenario, the Postman app is the proxy, and you can inspect HTTP communication going out from your phone like in the following example, and log all network requests under the History tab of the sidebar.
+Similar to the [Interceptor Chrome extension](/docs/postman/sending_api_requests/interceptor_extension/), the Postman app proxy also INTERCEPTS and captures your requests. In this scenario, the Postman app is the proxy, and you can inspect HTTP communication going out from your phone like in the following example, and log all network requests under the History tab of the sidebar.
 
 [![proxy logs](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-proxy.logs.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-proxy.logs.png)
 
-### Using Postman's proxy example
+## Using Postman's proxy example
 
 In this tutorial, we will use Postman's proxy feature to inspect HTTP communication going out from your phone. To get started, make sure your computer and mobile are connected to the same local wireless network.
 
-##### **Step 1: Set up the proxy in Postman**
+### Step 1: Set up the proxy in Postman
 
 Open the **PROXY SETTINGS** modal in the Postman app (MacOS) by clicking the icon in the header toolbar.
 
@@ -37,17 +37,17 @@ Keep a note of the port mentioned in the proxy settings. In this case, let's kee
 
 [![proxy settings modal](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-postman-proxy-settings.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-postman-proxy-settings.jpg)
 
-##### **Step 2: Note your computer's IP address**
+### Step 2: Note your computer's IP address
 
 On OS X, the computer's IP address can be found in _System Preferences > Network_. The IP address of your system will be something like the example here `192.168.0.101`.
 
-[![system preferences](http://blog.getpostman.com/wp-content/uploads/2016/06/840x710xosx-network-settings-1024x865.png,qx38712.pagespeed.ic.gnTM2O4wH5.jpg)](http://blog.getpostman.com/wp-content/uploads/2016/06/osx-network-settings.png?x38712)
+[![system preferences](https://blog.getpostman.com/wp-content/uploads/2016/06/osx-network-settings.png)](https://blog.getpostman.com/wp-content/uploads/2016/06/osx-network-settings.png)
 
-##### **Step 3: Configure HTTP proxy on your mobile device**
+### Step 3: Configure HTTP proxy on your mobile device
 
 Open the wireless settings of your mobile device and update the configuration of the wireless connection to use HTTP Proxy. Set the IP address with the IP you retrieved from your computer in the second step. Set the port with the port you established in Postman in **Step 1**. 
 
-[![wireless settings on mobile device](http://blog.getpostman.com/wp-content/uploads/2016/06/405x720xios-http-proxy-settings-576x1024.png,qx38712.pagespeed.ic._l8Fxy2LqV.jpg)](http://blog.getpostman.com/wp-content/uploads/2016/06/ios-http-proxy-settings.png?x38712)
+[![wireless settings on mobile device](https://blog.getpostman.com/wp-content/uploads/2016/06/ios-http-proxy-settings.png)](https://blog.getpostman.com/wp-content/uploads/2016/06/ios-http-proxy-settings.png)
 
 Set the proxy IP address of your device (an iPhone in this example) to the IP address you obtained from your system and port ``5555``.
 
@@ -55,12 +55,12 @@ You are all set! Head over to the Postman app, and you will start seeing the net
 
 [![requests under History tab](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-postman-proxy-history-sidebar.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-postman-proxy-history-sidebar.jpg)
 
-### Connect to proxy for target devices
+## Connect to proxy for target devices
 
 The broader development community has published some useful tutorials for setting up a proxy server on various operating systems.
 
    *   [Windows](https://www.howtogeek.com/tips/how-to-set-your-proxy-settings-in-windows-8.1/)
    *   [Linux](https://www.shellhacks.com/linux-proxy-server-settings-set-proxy-command-line/)
-   *   [macOS](https://support.apple.com/kb/PH18553?locale=en_US)
+   *   [macOS](https://support.apple.com/en-gb/guide/mac-help/mchlp2591/mac)
    *   [Android](https://www.howtogeek.com/295048/how-to-configure-a-proxy-server-on-android/)
 


### PR DESCRIPTION
This fixes issue #1646 

— updated link for Apple as per O.P.
— updated header formatting to be hierarchical and SEO friendly (H1 > H2 > H3)
— updated links to blog images to remove http and redirects (making new issue to do global cleanup)