### PR TITLE
1648 blog link cleanup + heading formatting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,8 +14,8 @@ sass:
 pm:
   root: "https://www.getpostman.com"
   gs: "https://app.getpostman.com"
-  blog: "http://blog.getpostman.com"
-  support_center: "https://support.getpostman.com/hc"
+  blog: "https://blog.getpostman.com"
+  support_center: "https://www.getpostman.com/support"
   help_email: "help@getpostman.com"
   enterprise_email: "enterprise@getpostman.com"
   security_email: "security@getpostman.com"

--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -54,7 +54,7 @@
       <div><a href="/jobs/">Jobs</a></div>
       <div><a href="/resources/press-releases/">Company Resources</a></div>
       <div><a href="/contact">Contact</a></div>
-      <div><a href="http://blog.getpostman.com" target="_blank">Blog</a></div>
+      <div><a href="https://blog.getpostman.com" target="_blank">Blog</a></div>
     </div>
     <div class="footer-links clearfix">
       <div class="category-title title-4">Resources</div>
@@ -140,7 +140,7 @@
           </g>
         </svg>
       </a>
-      <a class="pm-rss-icon" href="http://blog.getpostman.com/" target="_blank">
+      <a class="pm-rss-icon" href="https://blog.getpostman.com" target="_blank">
         <svg
           fill="#ffffff"
           width="21px"
@@ -239,7 +239,7 @@
         </a>
         <a
           class="pm-rss-icon"
-          href="http://blog.getpostman.com/"
+          href="https://blog.getpostman.com"
           target="_blank"
         >
           <svg

--- a/v6/postman/collection_runs/building_workflows.md
+++ b/v6/postman/collection_runs/building_workflows.md
@@ -7,7 +7,7 @@ warning: false
 
 When you start a collection run, all requests are run in the order you see them in the main app. So all requests are executed first, by order of the folder, and then any requests in the root of the collection. 
 
-However, you can override this behavior using a [built-in function](/docs/v6/postman/scripts/branching_and_looping) called `postman.setNextRequest()`. This function, as the name suggests, allows you to specify which request runs next. 
+However, you can override this behavior using a [built-in function](/docs/postman/scripts/branching_and_looping/) called `postman.setNextRequest()`. This function, as the name suggests, allows you to specify which request runs next. 
 
 Let's look at a sample collection to understand this function.
 
@@ -15,11 +15,11 @@ Let's look at a sample collection to understand this function.
 * [Basic workflow](#basic-workflow)
 * [Advanced workflow](#advanced-workflow)
 
-### Getting started
+## Getting started
 
-Before you start, download and [import](/docs/v6/postman/collections/data_formats) [collection.json](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58793802.json) for the example we'll discuss in this topic.
+Before you start, download and [import](/docs/postman/collections/data_formats/) [collection.json](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/58793802.json) for the example we'll discuss in this topic.
 
-### Basic workflow
+## Basic workflow
 
 Let's assume that we have a collection with four requests. If you run this collection directly, the collection runner runs all four requests in order.
 
@@ -37,32 +37,32 @@ In the example, we're setting the next request to Request 4 in the test script f
 
 Note that `postman.setNextRequest()` only works with the collection runner and Newman where the intent is to run a collection, as opposed to sending a single request.
 
-### Advanced workflow
+## Advanced workflow
 
 Now that we have a good understanding of how `setNextRequest()` works, we can perform advanced actions. 
 
 Since you are no longer restricted by the order in which you define your requests, you can jump around your collection, establish conditional logic, or skip unnecessary requests. 
 
-This [blog post](http://blog.getpostman.com/2016/11/09/generate-spotify-playlists-using-a-postman-collection/) explains how you can write a collection that will generate Spotify playlists for you based on your favorite musical artists.
+This [blog post](https://blog.getpostman.com/2016/11/09/generate-spotify-playlists-using-a-postman-collection/) explains how you can write a collection that will generate Spotify playlists for you based on your favorite musical artists.
 
 Remember these two facts as you use this workflow:
 
    *   `postman.setNextRequest()` is always executed at the end of the current request. This means that if you put this function before other code blocks anywhere in pre-request or test script, these blocks will still execute.
    
-   *   `postman.setNextRequest()` has a scope, which is the source of your collection run. If you run a collection, you can jump to any request in the collection (even requests inside folders, using the same syntax). However, if you run a folder, the scope of `postman.setNextRequest()` is limited to that folder. So you can jump to any request in this folder, but not ones that are outside of the folder. It includes requests inside other folders, and also root-level requests in the collection. To read more about [running collections or folders](/docs/v6/postman/collection_runs/starting_a_collection_run).
+   *   `postman.setNextRequest()` has a scope, which is the source of your collection run. If you run a collection, you can jump to any request in the collection (even requests inside folders, using the same syntax). However, if you run a folder, the scope of `postman.setNextRequest()` is limited to that folder. So you can jump to any request in this folder, but not ones that are outside of the folder. It includes requests inside other folders, and also root-level requests in the collection. To read more about [running collections or folders](/docs/postman/collection_runs/starting_a_collection_run/).
   
   <br>
   <br>
-  For more information about collection runs, see:
-   
-* [Starting a collection run](/docs/v6/postman/collection_runs/starting_a_collection_run)
-* [Using environments in collection runs](/docs/v6/postman/collection_runs/using_environments_in_collection_runs) 
-* [Working with data files](/docs/v6/postman/collection_runs/working_with_data_files)
-* [Running multiple iterations](/docs/v6/postman/collection_runs/running_multiple_iterations)
-* [Sharing a collection run](/docs/v6/postman/collection_runs/sharing_a_collection_run)
-* [Debugging a collection run](/docs/v6/postman/collection_runs/debugging_a_collection_run)
-* [Command line integration with Newman](/docs/v6/postman/collection_runs/command_line_integration_with_newman)
-* [Integration with Jenkins](/docs/v6/postman/collection_runs/integration_with_jenkins)
-* [Integration with Travis CI](/docs/v6/postman/collection_runs/integration_with_travis)
-* [Newman with Docker](/docs/v6/postman/collection_runs/newman_with_docker)
-   
+For more information on collection runs, see:
+
+* [Starting a collection run](/docs/postman/collection_runs/starting_a_collection_run/)
+* [Using environments in collection runs](/docs/postman/collection_runs/using_environments_in_collection_runs/)
+* [Working with data files](/docs/postman/collection_runs/working_with_data_files/)
+* [Running multiple iterations](/docs/postman/collection_runs/running_multiple_iterations/)
+* [Building workflows](/docs/postman/collection_runs/building_workflows/)
+* [Sharing a collection run](/docs/postman/collection_runs/sharing_a_collection_run/)
+* [Debugging a collection run](/docs/postman/collection_runs/debugging_a_collection_run/)
+* [Command line integration with Newman](/docs/postman/collection_runs/command_line_integration_with_newman/)
+* [Integration with Jenkins](/docs/postman/collection_runs/integration_with_jenkins/)
+* [Integration with Travis CI](/docs/postman/collection_runs/integration_with_travis/)
+* [Newman with Docker](/docs/postman/collection_runs/newman_with_docker/)

--- a/v6/postman/collection_runs/newman_with_docker.md
+++ b/v6/postman/collection_runs/newman_with_docker.md
@@ -13,11 +13,11 @@ This topic describes how to use Newman with Docker in these platforms:
 * [Windows](#windows)
 
 
-### macOS and Ubuntu
+## macOS and Ubuntu
 
 Follow these steps to use [Newman](https://github.com/postmanlabs/newman) with [Docker](https://www.docker.com/):
 
-1\. In the [Docker Hub](http://registry.hub.docker.com/u/postman/newman:ubuntu), download your copy. 
+1\. In the [Docker Hub](https://hub.docker.com/r/postman/newman_ubuntu1404/), download your copy. 
 
 2\. Ensure you have Docker installed and running in your system. Docker has extensive installation guidelines for popular operating systems. Choose your operating system and follow the instructions. 
 
@@ -43,22 +43,22 @@ At this stage, you should see the Collection running in Newman and the output di
 
 The entry point to the Docker image is Newman. So you can use all Newman command line parameters. You can also run locally stored collection files. The README of the image outlines how to mount shared data volumes.
 
-### Windows
+## Windows
 
-Check our [blog post](http://blog.getpostman.com/2015/08/07/using-the-newman-docker-image-in-windows/) on how to run Newman in Docker for Windows.
+Check our [blog post](https://blog.getpostman.com/2015/08/07/using-the-newman-docker-image-in-windows/) on how to run Newman in Docker for Windows.
 <br>
 <br>
 
 For more information on collection runs, see:
 
-* [Starting a collection run](/docs/v6/postman/collection_runs/starting_a_collection_run)
-* [Using environments in collection runs](/docs/v6/postman/collection_runs/using_environments_in_collection_runs)
-* [Working with data files](/docs/v6/postman/collection_runs/working_with_data_files)
-* [Running multiple iterations](/docs/v6/postman/collection_runs/running_multiple_iterations)
-* [Building workflows](/docs/v6/postman/collection_runs/building_workflows)
-* [Sharing a collection run](/docs/v6/postman/collection_runs/sharing_a_collection_run)
-* [Debugging a collection run](/docs/v6/postman/collection_runs/debugging_a_collection_run)
-* [Command line integration with Newman](/docs/v6/postman/collection_runs/command_line_integration_with_newman)
-* [Integration with Jenkins](/docs/v6/postman/collection_runs/integration_with_jenkins)
-* [Integration with Travis CI](/docs/v6/postman/collection_runs/integration_with_travis)
-* [Newman with Docker](/docs/v6/postman/collection_runs/newman_with_docker)
+* [Starting a collection run](/docs/postman/collection_runs/starting_a_collection_run/)
+* [Using environments in collection runs](/docs/postman/collection_runs/using_environments_in_collection_runs/)
+* [Working with data files](/docs/postman/collection_runs/working_with_data_files/)
+* [Running multiple iterations](/docs/postman/collection_runs/running_multiple_iterations/)
+* [Building workflows](/docs/postman/collection_runs/building_workflows/)
+* [Sharing a collection run](/docs/postman/collection_runs/sharing_a_collection_run/)
+* [Debugging a collection run](/docs/postman/collection_runs/debugging_a_collection_run/)
+* [Command line integration with Newman](/docs/postman/collection_runs/command_line_integration_with_newman/)
+* [Integration with Jenkins](/docs/postman/collection_runs/integration_with_jenkins/)
+* [Integration with Travis CI](/docs/postman/collection_runs/integration_with_travis/)
+* [Newman with Docker](/docs/postman/collection_runs/newman_with_docker/)

--- a/v6/postman/collections/data_formats.md
+++ b/v6/postman/collections/data_formats.md
@@ -7,7 +7,8 @@ warning: false
 
 Postman can export and import collections, environments, globals and header presets as files and links. This topic covers:
 
-* [Exporting and importing Postman data](#exporting-and-importing-postman-data)
+* [Exporting Postman data](#exporting-postman-data)
+* [Importing Postman data](#importing-postman-data)
 * [Importing cURL](#importing-curl)
 * [Importing RAML](#importing-raml)
 * [Importing Swagger](#importing-swagger)
@@ -15,33 +16,31 @@ Postman can export and import collections, environments, globals and header pres
 * [Validating Collection JSON files](#validating-collection-json-files)
 
 
-
-
-### Exporting and importing Postman data
+## Exporting Postman data
 
 Postman can export and import the following formats as a file or generated URL. When you export a collection from the Postman app, the exported file is a JSON file. The file contains all data (and metadata) that is required by Postman to recreate the collection when imported back into Postman, or that is utilized by Newman to run the collection from the command line interface (CLI).
 
-##### **Collections**
+### Collections
 
 [![export collection](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-collections-view.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-collections-view.png)
 
-Postman can export collections in two formats - v1 and v2\. Both Collection v1 and v2 download as JSON files; v2 is more versatile and the most-used choice. Learn more about the [v1 and v2 formats](http://blog.getpostman.com/2015/06/05/travelogue-of-postman-collection-format-v2/). 
+Postman can export collections in two formats - v1 and v2\. Both Collection v1 and v2 download as JSON files; v2 is more versatile and the most-used choice. Learn more about the [v1 and v2 formats](https://blog.getpostman.com/2015/06/05/travelogue-of-postman-collection-format-v2/). 
 
 [![select v1 or v2 format](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-export-collection1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-export-collection1.png)
 
-##### **Environments**
+### Environments
 
 Environments can be exported from the **MANAGE ENVIRONMENTS** modal, and imported here as well.
 
 [![export environments](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-manage-environments2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-manage-environments2.png)
 
-##### **Data dumps**
+### Data dumps
 
 From the **Data** tab of the **SETTINGS** modal, Postman allows you to export all collections, environments, globals and header presets into one JSON file. Postman does not export your history. You can import this data back into Postman.
 
 [![export all Postman data](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-data-dumps-settings.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-data-dumps-settings.png)
 
-##### **Importing Postman data**
+## Importing Postman data
 
 Postman data can be imported from the **Data** tab of the **SETTINGS** modal, or using the **Import** button in the header toolbar. Import a collection, environment, data dump, curl command, or a RAML / WADL / Swagger (v1/v2) / Runscope file using the **IMPORT** modal.
 
@@ -75,18 +74,18 @@ A few commands which can be imported include:
 
 ### Importing RAML
 
-##### **Saving a RAML folder as a collection**
+#### Saving a RAML folder as a collection
 
    1.  Clone the repository containing the RAML definition to your local machine, or save it locally as a folder.
    2.  Click on the Import button, and choose the Import Folder tab. 
       [![import button](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-collections-view-raml-1a.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-collections-view-raml-1a.png)
    3.  Click on **Choose Files** and upload the RAML folder.
          
-   You’re done! Postman will detect all the RAML definitions and convert them internally to Postman and then show you an import success message.
+   You're done! Postman will detect all the RAML definitions and convert them internally to Postman and then show you an import success message.
     
  [![confirmation message](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-data-format-raml-2a.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-data-format-raml-2a.png)
 
-##### **Examples**
+#### Examples
 
 Download an example RAML file: [github-api-v3.raml](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/github-api-v3.raml)
 
@@ -96,7 +95,7 @@ Download an example RAML file: [github-api-v3.raml](https://s3.amazonaws.com/po
 
 A Swagger API definition usually lives as a single file, so we only support imports of single swagger files. If you have a lot of unrelated Swagger files in a folder, you can import those through the folder importer.
 
-##### **Saving a Swagger file as a collection**
+#### Saving a Swagger file as a collection
 
    1.  Clone the repository containing the Swagger definition to your local machine. If you have it saved locally as file already, that’s fine of course.  
 
@@ -110,7 +109,7 @@ A Swagger API definition usually lives as a single file, so we only support impo
 
 [![confirmation message](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-data-format-raml-2a.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-data-format-raml-2a.png)
 
-##### **Examples**
+#### Examples
 
   [Swagger 2.0](https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v2.0) 
   
@@ -121,7 +120,7 @@ A Swagger API definition usually lives as a single file, so we only support impo
 
 Postman lets you import WADL specs too. While all aspects are not supported yet, you can expect the various parameters that Postman uses (collections, folder, requests, headers, request payloads) to be correctly generated. We're currently working on extending this feature.
 
-##### **Example WADL file**
+#### Example WADL file
 
 ```
 <application xmlns="http://wadl.dev.java.net/2009/02">
@@ -149,15 +148,15 @@ Postman lets you import WADL specs too. While all aspects are not supported yet,
 </application>
 ```
 
-[Source](http://www.nurkiewicz.com/2012/01/gentle-introduction-to-wadl-in-java.html)
+[Source](https://www.nurkiewicz.com/2012/01/gentle-introduction-to-wadl-in-java.html)
 
-### Validating Collection JSON files
+## Validating Collection JSON files
 
 To validate if a JSON file is in the correct collections format, you can use our [schema files for collections](http://schema.getpostman.com/).
 
-* [Schema file](http://schema.getpostman.com/json/collection/v1.0.0/collection.json)
+* [Schema file](https://schema.getpostman.com/json/collection/v1.0.0/collection.json)
 * [Associated documentation](https://schema.getpostman.com/) 
 * [Postman schemas in GitHub](https://github.com/postmanlabs/schemas) 
-* [Example of data validation using our schema](http://blog.getpostman.com/2015/07/02/introducing-postman-collection-format-schema/) and a [validator](https://github.com/mafintosh/is-my-json-valid)
+* [Example of data validation using our schema](https://blog.getpostman.com/2015/07/02/introducing-postman-collection-format-schema/) and a [validator](https://github.com/mafintosh/is-my-json-valid)
 
 

--- a/v6/postman/collections/sharing_collections.md
+++ b/v6/postman/collections/sharing_collections.md
@@ -7,7 +7,7 @@ warning: false
 
 Postman enables you to share Collections in Workspaces from the Postman app and the [workspaces dashboard](https://app.getpostman.com/dashboard). 
 
-**Note**: Before you can upload or share a collection, you must sign in to your [Postman account](/docs/v6/postman/launching_postman/postman_account). However, you can share collections as a file without being signed in.
+**Note**: Before you can upload or share a collection, you must sign in to your [Postman account](/docs/postman/launching_postman/postman_account/). However, you can share collections as a file without being signed in.
 
 This topic covers:
 * [Sharing collections in the app](#sharing-collections-in-the-app)
@@ -15,9 +15,9 @@ This topic covers:
 * [Sharing as a file](#sharing-as-a-file)
 * [Modifying team permissions](#modifying-team-permissions)
 
-### Sharing collections in the app
+## Sharing collections in the app
 
-**In the sidebar**
+### In the sidebar
 
 In the Postman app, select a collection in the sidebar and click the ellipsis **(...)** button.
 
@@ -31,13 +31,13 @@ The **SHARE COLLECTION** modal appears. It offers three ways to share a collecti
 
 [![share sidebar](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Collection_Share-Sidebar.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Collection_Share-Sidebar.png)
 
-**Sharing collections in another workspace**
+### Sharing collections in another workspace
 
 Select this option to share a collection to another workspace or with a workspace member. If shared to a team workspace, the collection will be visible to others in the team. 
 
 You can set team default permissions to either view-only or edit; only after sharing a collection. First, you share the collection and then assign a role. You also will be able to grant existing team members individual user permissions. Remember, the **Manage Roles** modal will not be available until the collection is shared. 
 
-**Note:** Refer to [Roles and permissions](docs/v6/postman/roles_and_permissions) for more information on role-based user permissions. 
+**Note:** Refer to [Roles and permissions](/docs/postman_pro/managing_postman_pro/roles_and_permissions/) for more information on role-based user permissions. 
 
 [![in app collection sharing](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Collection_sharing_new.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Collection_sharing.png)
 
@@ -45,9 +45,9 @@ In the [workspaces dashboard](https://app.getpostman.com/dashboard), select a co
 
 [![share collections](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-collection-dashboard.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-share-collection-dashboard.png)
 
-**Sharing collections with the Embed or Run In Postman button**
+### Sharing collections with the Embed or Run In Postman button
 
-Select this option to embed a **[Run in Postman](/docs/v6/postman_for_publishers/run_button/creating_run_button)** button in your collection for your API documentation, website, or Github readme. 
+Select this option to embed a **[Run in Postman](/docs/postman_for_publishers/run_button/creating_run_button/)** button in your collection for your API documentation, website, or Github readme. 
 
 The **Run in Postman** button lets anyone import and run this collection with one click. 
 
@@ -57,33 +57,33 @@ The **Run in Postman** button shares the collection directly from Postman, so th
 
 [![share embed-rip](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Collection_sharing_link.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Collection_sharing_link.png)
 
-**Sharing collections with a link**
+### Sharing collections with a link
 
 Select this option to generate a shareable link for others to access your collections. You can manage a complete list of your collection links from your [workspaces dashboard](https://app.getpostman.com/dashboard).
 
 [![share get link](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Collection_sharing_link2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Collection_sharing_link2.png)
 
-**In the Browse view**
+### In the Browse view
 
 In the bottom bar, select "Browse", and then select a collection
 
 Click the **Share** button.
 
-### Sharing collections in the Dashboard
+## Sharing collections in the Dashboard
 
 In the [workspaces dashboard](https://app.getpostman.com/dashboard), select "Browse", and then select a collection. 
 
 Click the **Share** button.
 
-### Sharing as a file
+## Sharing as a file
 
 You can download collections as a JSON file to share with others, with or without signing in to your Postman account. 
 
 You can share collections anonymously, but we strongly recommend you sign in to your Postman account when uploading collections. When you're signed in, you can update your existing collection, make it public, or delete it later.
 
-Learn more about [exporting and importing collections](/docs/v6/postman/collections/data_formats), and the differences between collection formats [v1 and v2](http://blog.getpostman.com/2015/06/05/travelogue-of-postman-collection-format-v2/).
+Learn more about [exporting and importing collections](/docs/postman/collections/data_formats/), and the differences between collection formats [v1 and v2](https://blog.getpostman.com/2015/06/05/travelogue-of-postman-collection-format-v2/).
 
-### Modifying team permissions
+## Modifying team permissions
 
 You can share collections with your entire team or assign individual permissions for team members. You can designate view or edit permissions for the team only after sharing a collection. **Note**: For now, each collection's permission must be set individually by the collection editor. The default team permission is view-only.
 

--- a/v6/postman/environments_and_globals/variables.md
+++ b/v6/postman/environments_and_globals/variables.md
@@ -21,7 +21,7 @@ This topic covers:
 
 Variables allow you to reuse values in multiple places so you can keep your code DRY (Don't Repeat Yourself). Also, if you want to change the value, you can change the variable once with the impact cascading through the rest of your code.
 
-### Variable scopes
+## Variable scopes
 
 You can assign five types of variable scopes:
 
@@ -35,9 +35,9 @@ You can view different kinds of buckets in which values reside. If a variable is
 
 [![nested variable scopes](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Variables-Pic.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Variables-Pic.png)
 
-If a variable from the currently active environment shares its name with a global variable, the environment variable will take precedence. In other words, global variables are overridden by environment variables, which are overridden by [data variables](http://blog.getpostman.com/index.php/2014/10/28/using-csv-and-json-files-in-the-postman-collection-runner/) (only available in the [collection runner](/docs/v6/postman/collection_runs/starting_a_collection_run)).
+If a variable from the currently active environment shares its name with a global variable, the environment variable will take precedence. In other words, global variables are overridden by environment variables, which are overridden by [data variables](https://blog.getpostman.com/2014/10/28/using-csv-and-json-files-in-the-postman-collection-runner/) (only available in the [collection runner](/docs/postman/collection_runs/starting_a_collection_run/)).
 
-### Accessing variables in the request builder
+## Accessing variables in the request builder
 
 You can use variables in the following form in the Postman user interface - `{{variableName}}`. 
 
@@ -49,39 +49,39 @@ Since variables in the request builder are accessed using string substitution, t
 
 [![variables used in request builder](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals1.png)
 
-### Accessing variables through scripts
+## Accessing variables through scripts
 
 You can assign a current value when running your collection or a simple request and you also use variables in pre-request and test scripts. Since these sections for scripts are written in JavaScript, you will initialize and retrieve these variables in a different manner. You can initialize variables in scripts and put them in a particular scope. 
 
   1.  Defining an environment or global variable in a script: 
-        *  To set a variable in a script, use the `pm.environment.set()` method or `pm.globals.set()` method depending on the desired scope. The method requires the variable key and value as parameters to set the variable. When you send the request, the script will be evaluated and the value will be stored as a variable. Note that [defining a collection variable](/docs/v6/postman/environments_and_globals/variables#defining-collection-variables) is a little different and can be done by editing the collection details.
+        *  To set a variable in a script, use the `pm.environment.set()` method or `pm.globals.set()` method depending on the desired scope. The method requires the variable key and value as parameters to set the variable. When you send the request, the script will be evaluated and the value will be stored as a variable. Note that [defining a collection variable](/docs/postman/environments_and_globals/variables/) is a little different and can be done by editing the collection details.
   2.  Fetching a pre-defined variable: 
         *  Once a variable has been set, use the `pm.variables.get()` method or, alternatively, use the `pm.environment.get()` or `pm.globals.get()` method, depending on the appropriate scope to fetch the variable. The method requires the variable name as a parameter to retrieve the stored value in a script.
         
-        **Note**: When you specify a .get() method it always obtains the current value while .set() method modifies the current value. The way these variables work depends much on a setting in Postman [Automatically persist variable values](/docs/v6/postman/launching_postman/settings)
+        **Note**: When you specify a .get() method it always obtains the current value while .set() method modifies the current value. The way these variables work depends much on a setting in Postman [Automatically persist variable values](/docs/postman/launching_postman/settings/)
         
   3.  Setting a variable in a scope: 
         *  Environment variables can be accessed with the corresponding environments. Collection variables can be accessed from a request within the collection. Global variables can be accessed broadly regardless of the selected environment.
 
 [![variables used in script](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals2.png)
 
-### Defining collection variables
+## Defining collection variables
 
 Collection variables can be defined by editing the collection details. Click ellipsis **(...)** next to the collection name, and select “Edit” to open the **EDIT COLLECTION** modal. Select the **Variables** tab to add and edit collection variables. You can also define collection variables when creating the collection.  
 
-### Logging variables
+## Logging variables
 
-Often while using variables in scripts, you will need to see the values they obtain. You can use the [Postman Console](/docs/v6/postman/sending_api_requests/debugging_and_logs) to do this easily. From the application menu, select "View" and then "Show Postman Console".  To log the value of a variable, you can use `console.log(foo);` in your script. When you send a request, the script will be evaluated and the value of the variable will be logged in the Postman Console.
+Often while using variables in scripts, you will need to see the values they obtain. You can use the [Postman Console](/docs/postman/sending_api_requests/debugging_and_logs/) to do this easily. From the application menu, select "View" and then "Show Postman Console".  To log the value of a variable, you can use `console.log(foo);` in your script. When you send a request, the script will be evaluated and the value of the variable will be logged in the Postman Console.
 
 [![variables logged](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/var_logging.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/var_logging.png)
 
-### Data variables
+## Data variables
 
 The Collection Runner lets you import a CSV or a JSON file, and then use the values from the data file inside HTTP requests and scripts. We call these 'data variables'. 
 
 To use them inside Postman, follow the same syntax as environment or global variables. 
 
-##### **Data variables in requests**
+### Data variables in requests
 
 Variables inside the Postman UI are enclosed inside curly braces. 
 
@@ -89,15 +89,15 @@ For example, in the screenshot below, `{{username}}` and `{{password}}` insi
 
 [![data variables in requests](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals3.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals3.png)
 
-##### **Data variables in pre-request and test scripts**
+### Data variables in pre-request and test scripts
 
 Here's an example of Inside pre-request and test scripts. Let's say you have the `pm.iterationData.get("username")` method inside pre-request and test scripts. The method lets you access the value of the username variable from a data file. 
 
 [![data variables in scripts](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals4.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals4.png)
 
-Learn more about [working with data files](/docs/v6/postman/collection_runs/working_with_data_files). 
+Learn more about [working with data files](/docs/postman/collection_runs/working_with_data_files/). 
 
-### Dynamic variables
+## Dynamic variables
 
 Postman has a few dynamic variables that you can use in your requests. 
 
@@ -109,7 +109,7 @@ Dynamic variables cannot be used in the Sandbox. You can only use them in the `
 
 [![dynamic variables](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals5.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals5.png)
 
-### Quick Look for variables
+## Quick Look for variables
 
 Quick Look is a quick preview feature that displays all your environment and global variables in one place. 
 
@@ -117,19 +117,19 @@ Click the "eye" icon in the top right to toggle the display, or type the keyboar
 
 [![quick look](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-environ_quick-look_Updated.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-environ_quick-look_Updated.png)
 
-### Autocomplete and tooltips for variables
+## Autocomplete and tooltips for variables
 
 Postman variables are very powerful, and two features - autocomplete and tool tips - make them even more convenient.
 
-#### Autocomplete for variables
+## Autocomplete for variables
 
 [![autocomplete for variables](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Autocomp_tooltips1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Autocomp_tooltips1.png)
 
-Type an open curly bracket to bring up the autocomplete menu. For the pre-request and test scripts section, which [uses the data editor](/docs/v6/postman/launching_postman/navigating_postman), entering the first letter of a variable triggers autocomplete. The menu contains a list of all variables in the current environment, followed by globals. Navigating through the list also shows the initial value, current value and scope for each variable, along with feedback for overridden variables. If the request is saved in a collection, Postman also displays the collection variables in the list. 
+Type an open curly bracket to bring up the autocomplete menu. For the pre-request and test scripts section, which [uses the data editor](/docs/postman/launching_postman/navigating_postman/), entering the first letter of a variable triggers autocomplete. The menu contains a list of all variables in the current environment, followed by globals. Navigating through the list also shows the initial value, current value and scope for each variable, along with feedback for overridden variables. If the request is saved in a collection, Postman also displays the collection variables in the list. 
 
 The following screen displays selection of Token1 with its initial and current values and scope:
 
-#### Variable highlighting and tooltip on hover
+## Variable highlighting and tooltip on hover
 
 [![variable highlighting and tooltips](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Autocomp_tooltips2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Autocomp_tooltips2.png)
 

--- a/v6/postman/launching_postman/installation_and_updates.md
+++ b/v6/postman/launching_postman/installation_and_updates.md
@@ -4,7 +4,7 @@ page_id: "installation_and_updates"
 warning: false
 
 ---
-### **Installing the Postman app**
+## Installing the Postman app
 
 ### Postman native apps
 
@@ -14,19 +14,19 @@ To install Postman, go to the [download page](https://www.getpostman.com/downlo
 
 ![Postman download page](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Download_Screen1.png "Postman download page")
 
-##### **macOS installation**
+### macOS installation
 
 Once you’ve downloaded and unzipped the app, double click on Postman. You will be prompted to move file into the "Applications" folder. Click "Move to Applications Folder" to ensure future updates can be installed correctly. The app will open after the prompt.
    
 ![Move to Applications Folder](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Download_MoveFolder.png "Move to Applications Folder")
 
-##### **Windows installation**
+### Windows installation
 
    *   Download the setup file 
    *   Run the installer
    
 
-##### **Linux installation**
+### Linux installation
 
   For installation on Linux, perform the following steps:
    
@@ -58,15 +58,15 @@ Once you’ve downloaded and unzipped the app, double click on Postman. You will
 
     apt-get install libgconf-2-4
   
-### Supported Platforms
+## Supported Platforms
 
    This section describes the additional software and infrastructure you'll need to run Postman. Please review this info before installing Postman. You should only use Postman with a supported platform. Any platforms and versions not listed on this page are unsupported, which means we don't test, fix bugs or provide assistance. 
 
-#### macOS
+### macOS
    
    The minimum version supported is macOS 10.9.
 
-#### Windows
+### Windows
 
    Postman supports Windows 7 and above. Older operating systems are not supported.
 
@@ -84,11 +84,11 @@ Once you’ve downloaded and unzipped the app, double click on Postman. You will
 
 `apt-get install libgconf-2-4`
 
-### Postman Chrome app
+## Postman Chrome app
 
-We recommend using the Postman native apps, but Postman is also available as a Chrome app. Read more about [why support for the Postman Chrome app is being deprecated](http://blog.getpostman.com/2017/03/14/going-native/).
+We recommend using the [Postman native apps](https://www.getpostman.com/downloads/), but Postman is also available as a Chrome app. Read more about [why support for the Postman Chrome app is being deprecated](https://blog.getpostman.com/2017/03/14/going-native/).
 
-The Postman Chrome app can only run on the Chrome browser. To use the Postman Chrome app, you will first need to [install Google Chrome](http://www.google.com/chrome/).
+The Postman Chrome app can only run on the Chrome browser. To use the Postman Chrome app, you will first need to [install Google Chrome](https://www.google.com/chrome/).
 
 If you already have Chrome installed, head over to [Postman’s page](https://chrome.google.com/webstore/detail/postman-rest-client-packa/fhbjgbiflinjbdggehcddcbncdddomop?hl=en) on the Chrome Web Store, and click ‘Add to Chrome’.
 
@@ -96,35 +96,35 @@ The download should take a few minutes depending on your internet connection. On
 
 ### Differences between Chrome and native apps
 
-Postman’s native apps are built on [Electron](http://electron.atom.io/), and overcome a number of restrictions of the Chrome platform.
+Postman’s native apps are built on [Electron](https://electronjs.org/), and overcome a number of restrictions of the Chrome platform.
 
 A few features exclusive to the native apps are listed here:
 
-##### **Cookies**
+#### Cookies
 
-The native apps let you work with [cookies](/docs/v6/postman/sending_api_requests/cookies) directly. Unlike the Chrome app, no separate extension ([Interceptor](/docs/v6/postman/sending_api_requests/interceptor_extension)) is needed.
+The native apps let you work with [cookies](/docs/postman/sending_api_requests/cookies/) directly. Unlike the Chrome app, no separate extension ([Interceptor](/docs/postman/sending_api_requests/interceptor_extension/)) is needed.
 
-##### **Built-in proxy**
+#### Built-in proxy
 
-The native apps come with a built-in proxy that you can use to [capture network traffic](/docs/v6/postman/sending_api_requests/capturing_http_requests).
+The native apps come with a built-in proxy that you can use to [capture network traffic](/docs/postman/sending_api_requests/capturing_http_requests/).
 
-##### **Menu bar**
+#### Menu bar
 
-The native apps are not restricted by the Chrome standards for the menu bar. With the native apps, you can check for updates, create Postman Windows and tabs, edit preferences, and can perform many other tasks. 
+The native apps are not restricted by the Chrome standards for the menu bar. With the native apps, you can check for updates, create Postman Windows and tabs, edit preferences, and can perform many other tasks. More on [navigating the Postman App](/docs/postman/launching_postman/navigating_postman/).
 
-##### **Restricted headers**
+#### Restricted headers
 
-The latest versions of the native apps let you send headers like Origin and User-Agent. These are [restricted](/docs/v6/postman/sending_api_requests/interceptor_extension#restricted-headers) in the Chrome app. 
+The latest versions of the native apps let you send headers like Origin and User-Agent. These are [restricted](/docs/postman/sending_api_requests/interceptor_extension/#restricted-headers) in the Chrome app. 
 
-##### **Don't follow redirects option**
+#### Don't follow redirects option
 
 This option exists in the native apps to prevent requests that return a 300-series response from being automatically redirected. Previously, users needed to use the Interceptor extension to do this in the Chrome app.
 
-##### **Postman console**
+#### Postman console
 
-The latest version of the native app also has a built-in [console](/docs/v6/postman/sending_api_requests/debugging_and_logs#network-calls-with-postman-console), which allows you to view the network request details for API calls.
+The latest version of the native app also has a built-in [console](/docs/postman/sending_api_requests/debugging_and_logs/#network-calls-with-postman-console), which allows you to view the network request details for API calls.
 
-### **Migrating to the native app**
+## Migrating to the native app
 
 It’s simple.  Sign in to your Postman account after you [download](https://www.getpostman.com/downloads/) and start the new native app, and all your history and collections will be automatically synced.
 
@@ -132,17 +132,17 @@ Alternatively, if you don't want to sign in to your Postman account, you can bul
 
 [![import data](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-export-data-settings.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-export-data-settings.png)  
 
-##### **Bulk export**
+### Bulk export
 
 From the Postman settings, select the **Data** tab and click the **Download** button to export all your collections, environments, globals and header presets to a single dump file.
 
-##### **Bulk import**
+### Bulk import
 
 From the same area in Postman settings, you can initiate a bulk import from a Postman data dump file. This will overwrite your existing data so be careful.
 
-### **Updating Postman**
+## Updating Postman
 
-##### **Native app (macOS, Windows and Linux)**
+### Native app (macOS, Windows and Linux)
 
 Postman's native apps will notify you whenever a major update is available. Other updates are indicated by an indicator that appears on the settings icon. If the indicator is red instead of orange, it indicates a failed update.
 
@@ -154,7 +154,8 @@ You can also configure your preferences to enable automatic download for major u
 
 [![set automatic updates in settings](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/auto+update+enable.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/auto+update+enable.png)
 
-##### **Troubleshooting Postman Updates***
+### Troubleshooting Postman Updates*
+
 Some users may encounter issues updating in the Windows version of Postman 6.1. To resolve you must set the environmental variable `POSTMAN_DISABLE_GPU=true`. In order to do this, follow these steps:
 
 1. Open `Advanced system settings` 
@@ -169,9 +170,9 @@ Some users may encounter issues updating in the Windows version of Postman 6.1. 
 [![step 3](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Troubleshootwindows6.1+(1).png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Troubleshootwindows6.1+(1).png)
 
 
-##### **Chrome**
+## Postman Chrome App
 
-Postman’s Chrome app has been deprecated. Although you can still use it, new features and bug fixes are being released exclusively in our native apps. We recommend you download the free native app [Postman app](https://www.getpostman.com/downloads/) available for Mac, Windows, and Linux operating systems.
+Postman's Chrome app has been deprecated. Although you can still use it, new features and bug fixes are being released exclusively in our native apps. We recommend you download the free native app [Postman app](https://www.getpostman.com/downloads/) available for Mac, Windows, and Linux operating systems.
 
 
 

--- a/v6/postman/scripts/postman_sandbox.md
+++ b/v6/postman/scripts/postman_sandbox.md
@@ -8,22 +8,22 @@ warning: false
 
 The Postman Sandbox is a JavaScript execution environment that is available to you when writing pre-request scripts and test scripts for requests (both in Postman and Newman). The code you write in the pre-request/test script section is executed in this sandbox.
 
-### Commonly used libraries and utilities
+## Commonly used libraries and utilities
 
 *   [Lodash](https://lodash.com/): JS utility library
 *   [cheerio](https://cheerio.js.org/): A fast, lean implementation of the core jQuery API (available in versions 4.6.0 and up)
-*   [BackboneJS](http://backbonejs.org/) **Deprecated**: Provides simple models, views, and collections. This will be removed in future versions of the sandbox.
-*   [SugarJS](http://sugarjs.com/) **Deprecated**: Extends native JS objects with useful methods. This will be removed in future versions of the sandbox.
+*   [BackboneJS](https://backbonejs.org/) **Deprecated**: Provides simple models, views, and collections. This will be removed in future versions of the sandbox.
+*   [SugarJS](https://sugarjs.com/) **Deprecated**: Extends native JS objects with useful methods. This will be removed in future versions of the sandbox.
 *   [tv4 JSON schema validator](https://github.com/geraintluff/tv4) **Deprecated**: Validates JSON objects against v4 of the json-schema draft
 *   [Ajv](https://github.com/epoberezkin/ajv): JSON schema validator.
-*   [CryptoJS](https://code.google.com/p/crypto-js/): standard and secure cryptographic algorithms. Supported algorithms: AES, DES, EvpKDF, HMAC-MD5, HMAC-SHA1/3/256/512, MD5, PBKDF2, Rabbit, SHA1/3/224/256/512, TripleDES
+*   [CryptoJS](https://code.google.com/archive/p/crypto-js/): standard and secure cryptographic algorithms. Supported algorithms: AES, DES, EvpKDF, HMAC-MD5, HMAC-SHA1/3/256/512, MD5, PBKDF2, Rabbit, SHA1/3/224/256/512, TripleDES
 *   `xml2Json(xmlString)`: This function behaves the same in Newman and Postman
 *   `xmlToJson(xmlString)` **Deprecated**: This function does NOT behave the same in Newman and Postman
 *   `postman.getResponseHeader(headerName)` Test-only: Returns the response header with name “headerName”, if it exists. Returns null if no such header exists. **Note**: According to W3C specifications, header names are case-insensitive. This method takes care of this. `postman.getResponseHeader("Content-type")` and `postman.getResponseHeader("content-Type")` will return the same value.
 
 Note: jQuery support has been discontinued since version 4.6.0, in favor of [cheerio](https://cheerio.js.org/).
 
-### Environment and global variables
+## Environment and global variables
 
 *   `postman.setEnvironmentVariable(variableName, variableValue)`: Sets an environment variable “variableName”, and assigns the string “variableValue” to it. You must have an environment selected for this method to work. **Note**: Only strings can be stored. Storing other types of data will result in unexpected behavior.
 *   `postman.getEnvironmentVariable(variableName)`: Returns the value of an environment variable “variableName”, for use in pre-request & test scripts. You must have an environment selected for this method to work.
@@ -36,7 +36,7 @@ Note: jQuery support has been discontinued since version 4.6.0, in favor of [ch
 *   `environment`: A dictionary of variables in the current environment. Use `environment["foo"]` to access the value of the “foo” environment variable. **Note:** This can only be used to read the variable. Use `setEnvironmentVariable()` to set a value.
 *   `globals`: A dictionary of global variables. Use `globals["bar"]` to access the value of the “bar” global variable. **Note:** This can only be used to read the variable. Use `setGlobalVariable()` to set a value
 
-### Dynamic variables
+## Dynamic variables
 
 Postman also has a few dynamic variables which you can use in your requests. This is primarily an experiment right now. More functions would be added soon. Note that dynamic variables cannot be used in the Sandbox. You can only use them in the `{{..}}` format in the request URL / headers / body.
 
@@ -44,12 +44,12 @@ Postman also has a few dynamic variables which you can use in your requests. Thi
 *   `{{$timestamp}}`: Adds the current timestamp
 *   `{{$randomInt}}`: Adds a random integer between 0 and 1000
 
-### Cookies
+## Cookies
 
 *   `responseCookies {array}` Postman-only: Gets all cookies set for the domain. You will need to enable the [Interceptor](/docs/postman/sending_api_requests/interceptor_extension) for this to work.
-*   `postman.getResponseCookie(cookieName)` Postman-only: Gets the response cookie with the given name. You will need to enable the interceptor for this to work. Check out the [blog post](http://blog.getpostman.com/index.php/2014/11/28/using-the-interceptor-to-read-and-write-cookies/).
+*   `postman.getResponseCookie(cookieName)` Postman-only: Gets the response cookie with the given name. You will need to enable the interceptor for this to work. Check out the [blog post](https://blog.getpostman.com/2014/11/28/using-the-interceptor-to-read-and-write-cookies/).
 
-### Request/response related properties
+## Request/response related properties
 
 *   `request {object}`: Postman makes the request object available to you while writing scripts. This object is read-only. Changing properties of this object will have no effect. Note: Variables will NOT be resolved in the request object. The request object is composed of the following:
     *   `data {object}` - this is a dictionary of form data for the request. (`request.data[“key”]==”value”`)
@@ -68,10 +68,10 @@ Postman also has a few dynamic variables which you can use in your requests. Thi
 
 **Test-only**: This object is only available in the test script section. Using this in a pre-request script throws an error.
 
-### Data files
+## Data files
 
-If you’re using [data files](http://blog.getpostman.com/index.php/2014/10/28/using-csv-and-json-files-in-the-postman-collection-runner/) in the Collection Runner or in Newman, you’ll have access to a `data` object, which is a dictionary of data values in the current test run.
+If you're using [data files](https://blog.getpostman.com/2014/10/28/using-csv-and-json-files-in-the-postman-collection-runner/) in the Collection Runner or in Newman, you'll have access to a `data` object, which is a dictionary of data values in the current test run.
 
-### pm.* APIs
+## pm.* APIs
 
-Review [Postman Sandbox API Reference](/docs/postman/scripts/postman_sandbox_api_reference).
+Review [Postman Sandbox API Reference](/docs/postman/scripts/postman_sandbox_api_reference/).

--- a/v6/postman/sending_api_requests/authorization.md
+++ b/v6/postman/sending_api_requests/authorization.md
@@ -20,7 +20,7 @@ When you select "Authorization" in the request builder, you see the **TYPE** dro
 * NTLM Authentication [Beta]
 
 
-**Note**: NTLM and Bearer token are only available in Postman native apps. All other authorization types are available in Postman native apps and the Chrome app. Note that the [Postman Chrome app is being deprecated](http://blog.getpostman.com/2017/11/01/goodbye-postman-chrome-app/).
+**Note**: NTLM and Bearer token are only available in Postman native apps ([download native app](https://www.getpostman.com/downloads/)). All other authorization types are available in Postman native apps and the Chrome app. Note that the [Postman Chrome app is being deprecated](https://blog.getpostman.com/2017/11/01/goodbye-postman-chrome-app/).
 
 [![auth menu](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-auth-menu.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-auth-menu.png)
 
@@ -34,9 +34,9 @@ If you want to inspect the authorization headers and parameters that Postman gen
 
 **Note**: You can inspect a raw dump of the entire request in the Postman console after you send it.
 
-### Inherit auth from parent
+## Inherit auth from parent
 
-#### Adding authorization to a collection or folder
+### Adding authorization to a collection or folder
 
 Suppose you [add a folder](/docs/postman/collections/managing_collections#adding-folders) to a collection. Under the **Authorization** tab, the default authorization type is set to “Inherit auth from parent”. 
 
@@ -58,11 +58,11 @@ To update the collection or folder authorization, click on the ellipsis (...) ne
  
 For example, if you create a collection with "Basic Auth", every request within the collection will use the same authorization helper. If you want a specific request in the collection to use a different authorization, or no authorization at all, use the **TYPE** dropdown under the **Authorization** tab to define the authorization helper for the specific request.
  
-### No Auth
+## No Auth
 
 By default "No Auth" appears first on the drop down menu list. Use "No Auth" when you don’t need an authorization parameter to send a request. 
   
-### Bearer Token
+## Bearer Token
 
 A bearer token is a security token. Any user with a bearer token can use it to access data resources without using a cryptographic key. 
 
@@ -74,7 +74,7 @@ To use a bearer token:
 
 [![bearer auth](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-auth-BearerToken.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-auth-BearerToken.png)
 
-### Basic Auth
+## Basic Auth
 
 Basic Auth is an authorization type that requires a verified username and password to access a data resource. 
 
@@ -87,7 +87,7 @@ To use Basic Auth:
 [![basic auth](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-auth-Basic.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-auth-Basic.png)
 
 
-### Digest Auth
+## Digest Auth
 
 In a digest authentication flow, the client sends a request to a server, which sends back nonce and realm values for the client to authenticate. The client sends back a hashed username and password with the nonce and realm. The server then sends back the requested data.
 
@@ -114,7 +114,7 @@ This table describes the advanced parameters for Digest Auth. Advanced configura
 | Client Nonce  | An opaque quoted string valued provided by the client and used by both client and server to avoid chosen plaintext attacks to provide mutual authentication and to provide some message integrity protection. The count must be specified if a qop directive is sent, and must not be specified if the server did not send a qop directive in the www-Authenticate response header.  |
 | Opaque | This is a string of data specified by the server in the www-Authenticate response header and should be used here unchanged with URLs in the same protection space. We recommend this string be base64 encoded data. |
 
-### **OAuth 1.0**
+## **OAuth 1.0**
 
 OAuth 1.0 is an authorization type that enables you to approve an application that contacts another application for you without exposing your password. 
 
@@ -144,7 +144,7 @@ This table describes the parameters for OAuth 1.0 authorization.
 
 **Note**: Some implementations of OAuth 1.0 require empty parameters to be added to the signature. You can select "Add empty parameters to signature" to add empty parameters.
 
-### OAuth 2.0
+## OAuth 2.0
 
 OAuth 2.0 is an authorization type that enables you to approve an application that contacts another application for you without exposing your password. 
 
@@ -181,7 +181,7 @@ You can click "Manage Tokens" in the list to view more details about each token 
 
 **Note**: Deleting a token does not revoke the access token. Only the server that issues the token can revoke it.
 
-### Hawk authentication
+## Hawk authentication
 
 Hawk authentication enables you to make authenticated requests with partial cryptographic verification of the request. 
  
@@ -213,7 +213,7 @@ This table describes the advanced parameters for Hawk Authentication. Advanced c
 
 **Note**: Advanced configuration settings are optional. Postman auto generates values for some fields if left blank.
 
-### Amazon Web Services (AWS) authentication
+## Amazon Web Services (AWS) authentication
 
 AWS is the authorization workflow for Amazon Work Services requests. AWS users must use a custom HTTP scheme based on a keyed-HMAC (Hash Message Authentication Code) for authentication. Postman supports this scheme.
 
@@ -237,7 +237,7 @@ This table describes the advanced parameters for AWS Authentication. Advanced co
 | Service Name| The service receiving the request.|
 | Session Token |Required only when using temporary security credentials.|
 
-### NTLM authentication
+## NTLM authentication
 
 Windows Challenge/Response (NTLM) is the authorization flow for the Windows operating system and for stand-alone systems.
 By default, Postman extracts values from the received response, adds it to the request, and retries it. Postman gives you the option to disable this default behavior.

--- a/v6/postman/sending_api_requests/making_soap_requests.md
+++ b/v6/postman/sending_api_requests/making_soap_requests.md
@@ -9,7 +9,7 @@ To make SOAP requests using Postman:
 
 1. Give the SOAP endpoint as the URL. If you are using a WSDL, then give the path to the WSDL as the URL.
 2. Set the request method to POST.
-3. Open the raw editor, and set the body type as “text/xml”.
+3. Open the raw editor, and set the body type as "text/xml".
 4. In the request body, define the SOAP Envelope, Header and Body tags as required. Start by giving the SOAP Envelope tag, which is necessary, and define all the namespaces. Give the SOAP header and the body. The name of the SOAP method (operation) should be specified in the SOAP body.
 
-Check out [an example of making SOAP requests using Postman](http://blog.getpostman.com/2014/08/22/making-soap-requests-using-postman/).
+Check out [an example of making SOAP requests using Postman](https://blog.getpostman.com/2014/08/22/making-soap-requests-using-postman/), and our blog [Postman makes SOAP requests too](https://blog.getpostman.com/2017/11/18/postman-makes-soap-requests-too/).

--- a/v6/postman_pro_integrations/slack_integration.md
+++ b/v6/postman_pro_integrations/slack_integration.md
@@ -7,17 +7,17 @@ tags:
 warning: false
 ---
 
-**Connect to receive notifications from Postman**
+## Postman Pro to Slack Integration
 
-In the Postman Pro to Slack Integration, there are 3 ways to connect.
+In the Postman Pro to Slack Integration, there are 3 ways to connect to receive notifications from Postman.
 
-**Team Activity Feed**
+### Team Activity Feed
 
 The [Postman Team Activity Feed][0] is a real-time feed showing the creates, updates, subscriptions, and deletes performed across the shared Postman Collections in your team.
 
 Using the Postman Pro to Slack Integration, you can pipe your team’s Activity Feed to a Slack channel of your choosing. This can help, for example, with tracking progress of a particular Postman Collection, or seeing development momentum within your team environment.
 
-**Postman Search**
+### Postman Search
 
 This element of the Postman Pro to Slack Integration enables you to easily search across the names and descriptions of your shared Postman Collections, folders, requests, and responses, and then display results in any of your team or personal Slack channels.
 
@@ -25,13 +25,13 @@ After enabling this integration, a new slash command, `/postman`, will find its 
 
 This is super useful when searching for particular requests, or trying to point a colleague to a set of Collections related to your current discussion.
 
-**Monitor Results**
+### Monitor Results
 
 Postman Monitors enable you to set up recurring runs of your Postman Collections at scheduled intervals. By using Postman Monitors, you can ensure that your systems are stable and your APIs are working as they should.
 
 The Postman Monitor to Slack connection allows you to pipe any set of Monitoring run results to a pre-configured Slack channel. This provides extra visibility on your Monitor run results, right in Slack. Plus, you can add further Slack alerting and notifications, based on Monitor run results.
 
-**Add the Slack Integration**
+### Add the Slack Integration
 
 From the [Integrations page][1], select the Slack Integration:
 
@@ -47,7 +47,7 @@ Authenticate with Slack and if prompted, choose a Slack channel to post results 
 
 And you’re done!
 
-[0]: http://blog.getpostman.com/2016/10/27/new-more-useful-activity-feed-in-postman-collections/
+[0]: https://blog.getpostman.com/2016/10/27/new-more-useful-activity-feed-in-postman-collections/
 [1]: https://app.getpostman.com/dashboard/integrations
 [2]: https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/slackINT.png
 [3]: https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/slack_add.png

--- a/v6/pro/integrations/intro_integrations.md
+++ b/v6/pro/integrations/intro_integrations.md
@@ -11,15 +11,15 @@ Postman provides a strong API development toolchain that integrates seamlessly 
 
 Postman has always supported an open ecosystem. We work with industry leaders to introduce new features and integrations that make API development easier and faster.
 
-### What is an integration anyway?
+## What is an integration anyway?
 
 Organizations use the term "integration" inclusively, sometimes overly so. In fact, different teams in the same organization might use the term in different ways. 
 
 Postman views "integrations" as a way to share data or functionality between Postman and other tools that you might use for API development. When manually importing and exporting data from one application to another becomes a chore, an integration can help.
 
-For example, suppose you use GitHub for your repository management and use Postman to develop and test your APIs. If you want to save your Postman Collections to a GitHub repository, you can use the [Postman to GitHub integration](https://learning.getpostman.com/docs/postman_pro/integrations/github/#configuring-github-integration) feature. 
+For example, suppose you use GitHub for your repository management and use Postman to develop and test your APIs. If you want to save your Postman Collections to a GitHub repository, you can use the [Postman to GitHub integration](/docs/postman_pro/integrations/github/#configuring-github-integration) feature. 
 
-### Postman Pro integrations
+## Postman Pro integrations
 
 Postman Pro users can currently access over a dozen of the most requested 3rd party integrations in the [Postman Integrations directory](https://go.postman.co/workspaces), with more being released every month. 
 
@@ -32,5 +32,5 @@ In the Dashboard page, click ["Integrations"](https://go.postman.co/workspaces)
 The Integrations page lists all the currently available integrations for Postman Pro users.
   <br>
   <br>
-[![list of integrations](http://blog.getpostman.com/wp-content/uploads/2017/02/gif-highfps-1.gif)](http://blog.getpostman.com/wp-content/uploads/2017/02/gif-highfps-1.gif)
+[![list of integrations](https://blog.getpostman.com/wp-content/uploads/2017/02/gif-highfps-1.gif)](https://blog.getpostman.com/wp-content/uploads/2017/02/gif-highfps-1.gif)
 

--- a/v6/variables_and_environments/environments.md
+++ b/v6/variables_and_environments/environments.md
@@ -14,7 +14,7 @@ You won't have to worry about remembering all those values once they are in Post
 [![](https://www.getpostman.com/img/v1/docs/thumbs/28.png)
 ][0]
 
-Each environment is a set of key-value pairs. These can be edited using the [key-value editor][1]. They key is the variable name.
+Each environment is a set of key-value pairs. These can be edited using the [key-value editor][1]. The key is the variable name.
 
 Variables can be used in the following form - `{{variableName}}`. The string {{variableName}} will be replaced with its corresponding value.
 For example, for an environment variable 'url' with the value 'http://localhost' , you will have to use `{{url}}` in the request URL field.
@@ -30,7 +30,7 @@ As a best practice, you should save all sensitive values in an environment and p
 
 Variables can be used in the following places: URL, URL parameters, headers (both names and values), form-data, url-encoded-data, raw data.
 
-Warning - Environment and global variables will always be stored as strings.
+**Warning** - Environment and global variables will always be stored as strings.
 If you're storing objects/arrays, be sure to JSON.stringify() them before storing, and JSON.parse() them while retrieving.
 
 ## Global variables
@@ -42,7 +42,7 @@ If a variable from the currently active environment shares its name with a globa
 In other words, global variables are overriden by environment variables, which are overriden by
 [data variables][2] (only available in the [collection runner][3]).
 
-#### Dynamic variables
+## Dynamic variables
 
 Postman also has a few dynamic variables which you can use in your requests. This is primarily an experiment right now. More functions would be added soon. Note that dynamic variables cannot be used in the Sandbox.
 You can only use them in the `{{..}}` format in the request URL / headers / body.
@@ -53,6 +53,6 @@ You can only use them in the `{{..}}` format in the request URL / headers / body
 
 
 [0]: https://www.getpostman.com/img/v1/docs/source/28.png
-[1]: https://www.getpostman.com/docs/keyvalue_editor
-[2]: http://blog.getpostman.com/index.php/2014/10/28/using-csv-and-json-files-in-the-postman-collection-runner/
+[1]: /docs/postman/launching_postman/navigating_postman/#data-editor
+[2]: https://blog.getpostman.com/2014/10/28/using-csv-and-json-files-in-the-postman-collection-runner/
 [3]: https://www.getpostman.com/docs/jetpacks_running_collections

--- a/v6/variables_and_environments/multiple_instances.md
+++ b/v6/variables_and_environments/multiple_instances.md
@@ -54,4 +54,4 @@ Testing your API using the Collection Runner and data files would make it more r
 [4]: https://www.getpostman.com/img/v1/docs/multiple_instances/multiple_instances_3.png
 [5]: https://www.getpostman.com/img/v1/docs/multiple_instances/multiple_instances_4.png
 [6]: https://www.getpostman.com/img/v1/docs/multiple_instances/multiple_instances_5.png
-[7]: http://blog.getpostman.com/2014/10/28/using-csv-and-json-files-in-the-postman-collection-runner/
+[7]: https://blog.getpostman.com/2014/10/28/using-csv-and-json-files-in-the-postman-collection-runner/

--- a/v6/variables_and_environments/test_multi_environments.md
+++ b/v6/variables_and_environments/test_multi_environments.md
@@ -58,4 +58,4 @@ To see some examples of testing in multiple environments and other use cases for
 [1]: https://www.getpostman.com/img/v1/docs/test_multi_environments/test_multi_environments_2.png
 [2]: https://www.getpostman.com/img/v1/docs/test_multi_environments/test_multi_environments_3.png
 [3]: https://www.getpostman.com/img/v1/docs/test_multi_environments/test_multi_environments_4.png
-[4]: http://blog.getpostman.com/2014/02/20/using-variables-inside-postman-and-collection-runner/
+[4]: https://blog.getpostman.com/2014/02/20/using-variables-inside-postman-and-collection-runner/


### PR DESCRIPTION
Fixes #1648 
— updated all /v6 docs with `http://blog` to us https (re-verified links resolved)
— updated any `/v6` docs links on page to resolved URL
— updated headings hierarchy (H1 > H2 > H3) to improve readability 