### PR TITLE
Fix lint issues and redo hierarchy for Mock Servers section

### DIFF
--- a/v6/postman/mock_servers/intro_to_mock_servers.md
+++ b/v6/postman/mock_servers/intro_to_mock_servers.md
@@ -4,34 +4,33 @@ page_id: "intro_to_mock_servers"
 warning: false
 ---
 
+## What are mock servers
 
-### What are mock servers?
-
-Delays on the front- or back-end make it difficult for dependent teams to complete their work efficiently. Postman's mock servers can alleviate those delays in the development process. 
+Delays on the front- or back-end make it difficult for dependent teams to complete their work efficiently. Postman's mock servers can alleviate those delays in the development process.
 
 Before sending an actual request, front-end developers can create a mock server to simulate each endpoint and its corresponding response in a Postman Collection. Developers can view potential responses, without spinning up a back end.
 
-### Why use mock servers?
+## Why use mock servers
 
-Creating a [mock example](/docs/v6/postman/collections/examples) during the earliest phase of API development fosters clear communication among team members and aligns their expectations. 
+Creating a [mock example](/docs/v6/postman/collections/examples) during the earliest phase of API development fosters clear communication among team members and aligns their expectations.
 
 As a result, all teams in the development process can work in parallel; and dependent teams experience fewer delays.
 
-### Types of mock servers
+## Types of mock servers
 
 Postman lets you create two types of mock servers: private and public.
 
-**Private mock servers**
+### Private mock servers
 
-Private mock servers require users to add a Postman API key in the request header. `x-api-key:<your postman API key>`
+Private mock servers require users to add a Postman API key in the request header `x-api-key`, like: `x-api-key:<your postman API key>`.
 
-If you create a private mock server, users can [share the underlying collection](/docs/v6/postman/team_library/sharing#sharing-collections) with the team or specific team members, and provide permissions to edit or view. Your team members can use their Postman API keys to consume the mock. Team members can use the mock if they have permissions to access the underlying collection.
+If you create a private mock server, users can [share the underlying collection](/docs/v6/postman/workspaces/using_workspaces#sharing-collections-and-environments-in-workspaces) with the team or specific team members, and provide permissions to edit or view. Your team members can use their Postman API keys to consume the mock. Team members can use the mock if they have permissions to access the underlying collection.
 
-**Public mock servers**
+### Public mock servers
 
-Mock servers are public by default. Public mock servers are accessible to anyone. When you share a public mock server, users don’t need to add a Postman API key. 
+Mock servers are public by default. Public mock servers are accessible to anyone. When you share a public mock server, users don’t need to add a Postman API key.
 
-
+## Further reading
 
 For more information about mock servers, see:
 
@@ -39,5 +38,3 @@ For more information about mock servers, see:
 * [Mocking with examples](/docs/v6/postman/mock_servers/mocking_with_examples)
 * [Mocking with the Postman API](/docs/v6/postman/mock_servers/mock_with_api)
 * [Matching algorithm (for mocks)](/docs/v6/postman/mock_servers/matching_algorithm)
-
-

--- a/v6/postman/mock_servers/matching_algorithm.md
+++ b/v6/postman/mock_servers/matching_algorithm.md
@@ -6,13 +6,13 @@ warning: false
 
 Using the Postman mock service requires the following: a collection with requests, a mock server, and saved request examples. You can save as many examples to a collection as you please, and the mock server will return these examples predictably. But how exactly does the mock decide which example to return?
 
-### Matching algorithm for mocks
+## Matching algorithm for mocks
 
-To begin, let’s start with an example. 
+To begin, let’s start with an example.
 
 [![create mock diagram](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/create_mock.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/create_mock.jpg)
 
-When a mock is created using either the Postman API or the Postman app, a call is made to the Postman servers that associates a particular collection (and environment if you choose one) with a newly created mock. The collection `C1` that we just mocked is now associated with the new mock `M1`. 
+When a mock is created using either the Postman API or the Postman app, a call is made to the Postman servers that associates a particular collection (and environment if you choose one) with a newly created mock. The collection `C1` that we just mocked is now associated with the new mock `M1`.
 
 [![show mock diagram](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/show_mock.jpg)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/show_mock.jpg)
 
@@ -28,7 +28,7 @@ Other optional headers like `x-mock-response-name` or `x-mock-response-id` allow
 
 [![mock configurable](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/mock_configurable.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/mock_configurable.png)
 
-Keeping these various configurable elements in mind, let’s take a look at the matching algorithm logic. 
+Keeping these various configurable elements in mind, let’s take a look at the matching algorithm logic.
 
 1. **Properly formatted responses**
 
@@ -40,8 +40,8 @@ Keeping these various configurable elements in mind, let’s take a look at the 
 
 3. **Filter by URL**
 
-   The matching process will now examine each saved example, and iterate over every possibility. Compare the `mockPath` of the input URL with that of the saved example. If the input URL was `https://M1.mock.pstmn.io/test` and the example currently being examined had a URL of `https://google.com/help`, the mock service would compare `/test` with `/help`. While comparing URLs, a step-by-step matching is conducted. Each consecutive step that the matching algorithm traverses reduces the matching threshold of the current example response. 
-   
+   The matching process will now examine each saved example, and iterate over every possibility. Compare the `mockPath` of the input URL with that of the saved example. If the input URL was `https://M1.mock.pstmn.io/test` and the example currently being examined had a URL of `https://google.com/help`, the mock service would compare `/test` with `/help`. While comparing URLs, a step-by-step matching is conducted. Each consecutive step that the matching algorithm traverses reduces the matching threshold of the current example response.
+
    For example:
 
    * Try to match the input path with the example path exactly as it is. The max value is set as the matching threshold.
@@ -52,10 +52,10 @@ Keeping these various configurable elements in mind, let’s take a look at the 
 
 4. **Response code**
 
-   If the `x-mock-response-code` header is explicitly provided, filter out all examples that do not have a matching response code. 
-   
+   If the `x-mock-response-code` header is explicitly provided, filter out all examples that do not have a matching response code.
+
 5. **Highest threshold value**
-   
+
    Sort the remaining filtered responses in descending order and return the response with the highest threshold value.
 
 And there we have it! This is how the mock service finds and returns the appropriate response to a mock request.

--- a/v6/postman/mock_servers/mock_with_api.md
+++ b/v6/postman/mock_servers/mock_with_api.md
@@ -6,7 +6,7 @@ warning: false
 
 You can [mock a collection](/docs/v6/postman/mock_servers/setting_up_mock) directly from the Postman app. Additionally, you can create a mock using the Postman API. Let’s walk through this step by step.
 
-### Set up a collection for mocking
+## Set up a collection for mocking
 
 In this example, we have a Collection `testAPI` with corresponding environment `testAPIEnv`.  Let's set up a mock service to enable your front-end team to simulate each endpoint in `testAPI` and view the various responses.
 
@@ -16,25 +16,25 @@ Navigate to every request in the Collection `testAPI` that you would like to i
 
 [![saved responses](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-mock-PM-API67.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-mock-PM-API67.png)
 
-### Retrieve information needed for mock creation
+## Retrieve information needed for mock creation
 
 Let's retrieve the `collectionId` of `testAPI` using the [Postman API](https://api.getpostman.com/). Get a list of all your Collections using the [GET All Collections endpoint](https://docs.api.getpostman.com/#3190c896-4216-a0a3-aa38-a041d0c2eb72). Search for the name of your Collection and retrieve the `uid` from the results, which will be used as the `collectionId` in the next step.
 
-[![get collection id](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-get-info-46.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-get-info-46.png) 
+[![get collection id](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-get-info-46.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-get-info-46.png)
 
-You can also use the Postman app to retrieve the `collectionId`. Find the Collection in your app and hit `View Docs`. The `collectionId` is visible in the documentation url: 
+You can also use the Postman app to retrieve the `collectionId`. Find the Collection in your app and hit `View Docs`. The `collectionId` is visible in the documentation url:
 
-```
+```text
 https://documenter.getpostman.com/collection/view/{{collectionId}}
-``` 
+```
 
 As an optional step, you can include an environment as a part of your simulation by retrieving the `environmentId` of `testAPIEnv` using the [Postman API](https://api.getpostman.com/). Get a list of all your environments using the [GET All Environments endpoint](https://docs.api.getpostman.com/#d26bd079-e3e1-aa08-7e21-66f55df99351). Search for the name of your environment and retrieve the `uid` from the results, which will be used as the `environmentId` in the next step.
 
 [![get environment id](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-get-info-46.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-get-info-46.png)
 
-### Create a mock using the Postman API
+## Create a mock using the Postman API
 
-Create a mock using the [POST Create Mock endpoint](https://docs.api.getpostman.com/#a54b358e-2686-bb4e-15c6-125b23776593) with the `collectionId` and `environmentId` you retrieved previously. 
+Create a mock using the [`POST Create Mock` endpoint](https://docs.api.getpostman.com/#a54b358e-2686-bb4e-15c6-125b23776593) with the `collectionId` and `environmentId` you retrieved previously.
 
 Mocks are accessible to the public by default. If you want the mock to only be available privately, include `"private": true`.
 
@@ -42,25 +42,25 @@ Mocks are accessible to the public by default. If you want the mock to only be a
 
 Verify that the mock has been created using the [GET All Mocks endpoint](https://docs.api.getpostman.com/#018b5d62-f6fc-f752-597e-c1eb4bb98d24), and your Collection is now ready to be simulated.
 
-### Run the mock service
+## Run the mock service
 
-**Mock your Collection using the following url:** 
+**Mock your Collection using the following url:**
 
-```
+```text
 https://{{mockId}}.mock.pstmn.io/{{mockPath}}
-``` 
+```
 
-   *   `mockId` is the `id` that you received upon creating the mock and can be retrieved using the [GET All Mocks endpoint](https://docs.api.getpostman.com/#018b5d62-f6fc-f752-597e-c1eb4bb98d24).
-   *   `mockPath` is the path of your request that you’d like to mock, for example `api/response`.
+* `mockId` is the `id` that you received upon creating the mock and can be retrieved using the [GET All Mocks endpoint](https://docs.api.getpostman.com/#018b5d62-f6fc-f752-597e-c1eb4bb98d24).
+* `mockPath` is the path of your request that you’d like to mock, for example `api/response`.
 
 **Add the request header(s):**
 
-   *   Mock requests also accept another optional header, `x-mock-response-code`, which specifies which integer response code your returned response should match. For example, 500 will return only a 500 response. If this header is not provided, the closest match of any response code will be returned.
-   *   Similarly, other optional headers like `x-mock-response-name` or `x-mock-response-id` allow you to further specify the exact response you want by the name or by the uid of the saved example respectively. You can get the example response uid by using the Postman API to [GET a Single Collection](https://docs.api.getpostman.com/#647806d5-492a-eded-1df6-6529b5dc685c) and searching for your example in the response. The uid has the syntax `<user_id>-<response_id>`. Without these optional headers, the mock will follow a [matching algorithm](/docs/v6/postman/mock_servers/matching_algorithm) to decide which example to return.
-   * Mock requests also accepts optional headers `x-mock-match-request-body` for request body matching and `x-mock-match-request-headers` for matching incoming mock request headers. You must set `x-mock-match-request-body` header to `true` to enable request body matching. To enable incoming mock request headers matching, you must ensure that `x-mock-match-request-headers` header is present in the request and its value is a comma separated string of header keys that you want to match against in the saved examples.
+* Mock requests also accept another optional header, `x-mock-response-code`, which specifies which integer response code your returned response should match. For example, 500 will return only a 500 response. If this header is not provided, the closest match of any response code will be returned.
+* Similarly, other optional headers like `x-mock-response-name` or `x-mock-response-id` allow you to further specify the exact response you want by the name or by the uid of the saved example respectively. You can get the example response uid by using the Postman API to [GET a Single Collection](https://docs.api.getpostman.com/#647806d5-492a-eded-1df6-6529b5dc685c) and searching for your example in the response. The uid has the syntax `<user_id>-<response_id>`. Without these optional headers, the mock will follow a [matching algorithm](/docs/v6/postman/mock_servers/matching_algorithm) to decide which example to return.
+* Mock requests also accepts optional headers `x-mock-match-request-body` for request body matching and `x-mock-match-request-headers` for matching incoming mock request headers. You must set `x-mock-match-request-body` header to `true` to enable request body matching. To enable incoming mock request headers matching, you must ensure that `x-mock-match-request-headers` header is present in the request and its value is a comma separated string of header keys that you want to match against in the saved examples.
 
 [![request headers](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-run-mock40.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-run-mock40.png)
 
-### Mock requests and responses with examples
+## Mock requests and responses with examples
 
-In the previous example, we used a saved response to mock our collection. You can also [mock a request and response using examples](/docs/v6/postman/collections/examples) in Postman before sending the actual request or setting up a single endpoint to return the response. With examples, you can mock raw responses and save them. Then, you’ll be able to generate a mock endpoint for each of them using Postman’s mock service. 
+In the previous example, we used a saved response to mock our collection. You can also [mock a request and response using examples](/docs/v6/postman/collections/examples) in Postman before sending the actual request or setting up a single endpoint to return the response. With examples, you can mock raw responses and save them. Then, you’ll be able to generate a mock endpoint for each of them using Postman’s mock service.

--- a/v6/postman/mock_servers/mocking_with_examples.md
+++ b/v6/postman/mock_servers/mocking_with_examples.md
@@ -13,133 +13,131 @@ Let's deep dive into how [mock servers](/docs/postman/mock_servers/setting_up_mo
 5. Sending a request using the mock server (M1)
 6. Using query params to match
 
-### Setting up some basics
+## Setting up some basics
 
 Before we get into the details of mocking, let’s start with setting up some basics required for mocks to work:
 
-##### **Step 1: Sending a request (R1)**
-  
-  From the Postman app, send a `GET` request to the URL `https://postman-echo.com/get?test=123`. This request hits the [Postman Echo](https://docs.postman-echo.com/#078883ea-ac9e-842e-8f41-784b59a33722) service which you can use to test out your REST clients and make sample API calls.
-  
-  The resulting response can be seen on the right, and a record of this request will now be visible in your [history](/docs/postman/sending_api_requests/responses) on the left.
-  
-  [![sending request](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock1.png)
+### Step 1: Sending a request (R1)
 
-##### **Step 2: Saving the request (R1) to a collection (C1)**
-  
-  Hit the **Save** button to open the **SAVE REQUEST** modal. [Collections](/docs/postman/collections/creating_collections) are simply groups of requests that can be connected together to create APIs and workflows.
-  
-  [![save request button](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock2-1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock2-1.png)
-  
-  You can save a request to an existing collection, or save it to a new collection.  Let's create our new collection called `C1`. 
-  
-  [![save request modal](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock3.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock3.png)
-  
-  Collection `C1` will now be accessible in the **Collections** tab in the application. We can do all sorts of things within the collection details view: [viewing API documentation](/docs/postman/api_documentation/viewing_documentation), [mocking a collection](/docs/postman/mock_servers/setting_up_mock), [monitoring a collection](/docs/postman/monitors/setting_up_monitor), or [running the collection](/docs/postman/collection_runs/starting_a_collection_run).
+From the Postman app, send a `GET` request to the URL `https://postman-echo.com/get?test=123`. This request hits the [Postman Echo](https://docs.postman-echo.com/#078883ea-ac9e-842e-8f41-784b59a33722) service which you can use to test out your REST clients and make sample API calls.
 
-  [![collection tab](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock4.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock4.png)
-  
-##### **Step 3: Saving the request R1's response as an example (P1)**
+The resulting response can be seen on the right, and a record of this request will now be visible in your [history](/docs/postman/sending_api_requests/responses) on the left.
 
-  Now, let's save an example response from the request we just sent by hitting the **Save Response** button.
-  
-  [![save response button](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock5.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock5.png)
-  
-  This takes us to the **Examples** screen which can be used to save the request response as an example. Let's call this example `P1`.
-  
-  [![examples screen](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock6.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock6.png)
-  
-  Enter a name for this example.  The request method, URL, and status code are crucial in determining which responses will be returned by the mock we will create. Verify these elements are all as desired, and hit the **Save Example** button. Hit the back arrow in the top left to return to the request builder, and we can now see the example we created in the top right, added to the request.
+[![sending request](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock1.png)
 
-  [![see example](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock7.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock7.png)
+### Step 2: Saving the request (R1) to a collection (C1)
 
-### Mocking with examples
+Hit the **Save** button to open the **SAVE REQUEST** modal. [Collections](/docs/postman/collections/creating_collections) are simply groups of requests that can be connected together to create APIs and workflows.
+
+[![save request button](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock2-1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock2-1.png)
+
+You can save a request to an existing collection, or save it to a new collection.  Let's create our new collection called `C1`.
+
+[![save request modal](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock3.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock3.png)
+
+Collection `C1` will now be accessible in the **Collections** tab in the application. We can do all sorts of things within the collection details view: [viewing API documentation](/docs/postman/api_documentation/viewing_documentation), [mocking a collection](/docs/postman/mock_servers/setting_up_mock), [monitoring a collection](/docs/postman/monitors/setting_up_monitor), or [running the collection](/docs/postman/collection_runs/starting_a_collection_run).
+
+[![collection tab](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock4.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock4.png)
+
+### Step 3: Saving the request R1's response as an example (P1)
+
+Now, let's save an example response from the request we just sent by hitting the **Save Response** button.
+
+[![save response button](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock5.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock5.png)
+
+This takes us to the **Examples** screen which can be used to save the request response as an example. Let's call this example `P1`.
+
+[![examples screen](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock6.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock6.png)
+
+Enter a name for this example.  The request method, URL, and status code are crucial in determining which responses will be returned by the mock we will create. Verify these elements are all as desired, and hit the **Save Example** button. Hit the back arrow in the top left to return to the request builder, and we can now see the example we created in the top right, added to the request.
+
+[![see example](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock7.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock7.png)
+
+## Mocking with examples
 
 In the previous steps, we prepared the collection, request, and example response necessary for us to get started with mocking. So let’s continue with the next steps.
-  
-##### **Step 4: Creating a mock (M1) for the collection (C1)**
 
-  There are two ways to create a mock for our collection: 1) using the Postman app and 2) [using the Postman API](/docs/postman/mock_servers/mock_with_api). In this example, we will mock a collection using the Postman app.
-  
-  From the Postman app, click on the arrow (&#9656;) next to the collection you wish to mock to expand the collection details view. 
-  
-  [![mock in collection details view](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock10.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock10.png)
-  
-  Under the **Mocks** tab, click the **Add a mock** link to open the **MOCK COLLECTION** modal. Here, you can choose a corresponding environment to include in your mock. 
-  
-  We are not using any environment variables in our single saved example (P1), therefore we are going to go ahead and create a mock with `No Environment` chosen. It’s important to note that if your saved example has an environment variable in the URL, for example, `{{base_url}}/my/path` and you do not provide the corresponding environment when creating the mock, trying to mock that particular request will not work. 
-  
-  Mocks are accessible to public by default. If you check the box making the mock server private, Postman Pro and Enterprise users can [share the underlying collection](/docs/postman/team_library/sharing#sharing-collections) with the team or specific team members, and provide permissions to edit or view.
-  
-  [![mock collection modal](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock9.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock9.png)
-  
-  Once you mock the collection, it will be visible under the `Mocks` tab of the collection details view. You can also see the mock URL we will need for the next step.
-  
-##### **Step 5: Sending a request using the mock server (M1)**
+### Step 4: Creating a mock (M1) for the collection (C1)
 
-  Now that we have created our mock `M1`, let's try sending a request to this mock endpoint. Copy the mock URL from the mock we created in the previous step, and paste it into a new request, with an undefined path in this case `https://b75a340e-4268-4b20-8f5f-3cfc8f37cec6.mock.pstmn.io`. 
-  
-  [![send a request to mock server](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock8-1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock8-1.png)
-  
-  Sending a request to this mock endpoint with an undefined path returns an error. As you can see, there is no matching saved example with the path `''` and the request method `GET`. Responses returned by the mock service are entirely dependent on your saved examples and the included URL and request method type. 
-  
-  [![mock request not found error](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock11.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock11.png)
-  
-  We do, however, have a saved example with the path `/get` and the request method `GET`. So sending a `GET` request to the URL `https://b75a340e-4268-4b20-8f5f-3cfc8f37cec6.mock.pstmn.io/get` will return a proper response we are looking for.
+There are two ways to create a mock for our collection: 1) using the Postman app and 2) [using the Postman API](/docs/postman/mock_servers/mock_with_api). In this example, we will mock a collection using the Postman app.
 
-  [![mock response](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock12.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock12.png)
+From the Postman app, click on the arrow (&#9656;) next to the collection you wish to mock to expand the collection details view.
 
-##### **Adding more examples**
-  
-  To further illustrate how responses from the mock service are entirely dependent on your saved examples, let's try adding another example to this collection. We'll repeat steps 1 to 3 of saving the request to a collection and saving the response as an example, with a new URL `https://postman-echo.com/test`.
-  
-  [![second example](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock13.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock13.png)
+[![mock in collection details view](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock10.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock10.png)
 
-  Sending a `GET` request to `https://postman-echo.com/test` returns a 404 error which we will then save as another example. Our collection `C1` now has two requests and two saved examples:
-  
-  * `GET` > `/get`
-  * `GET` > `/test/`
-  
-  Mocking the `/test` mock path also gives us our expected 404 response.
-  
-  [![404 example](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock14.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock14.png)
+Under the **Mocks** tab, click the **Add a mock** link to open the **MOCK COLLECTION** modal. Here, you can choose a corresponding environment to include in your mock.
 
-  Your examples might vary depending on the URL endpoint, request method type, or status code. If you have multiple examples saved to the same mock, you can choose to save each example under a unique URL endpoint like we saw in this example with `/get` and `/test`. Alternatively, if you have saved examples with different response status codes, you can send an authenticated request to the mock endpoint along with the `x-mock-response-code` header specifying which integer response code your returned response should match.
+We are not using any environment variables in our single saved example (P1), therefore we are going to go ahead and create a mock with `No Environment` chosen. It’s important to note that if your saved example has an environment variable in the URL, for example, `{{base_url}}/my/path` and you do not provide the corresponding environment when creating the mock, trying to mock that particular request will not work.
 
-### Using query params
+Mocks are accessible to public by default. If you check the box making the mock server private, Postman Pro and Enterprise users can [share the underlying collection](/docs/postman/team_library/sharing#sharing-collections) with the team or specific team members, and provide permissions to edit or view.
 
-  Postman's Mock server functionality is enhanced to return different responses based on matching request query params. Postman's Mock server looks at the query params while matching requests to the examples. Which means if you have examples that differ only in query params and want to mock different responses for different query params on the same request path, Postman's mock server will return the exact response matching that request path and the corresponding query params. 
-  
-  Let's look at an example how this works:
+[![mock collection modal](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock9.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock9.png)
 
-  In this example, we have a collection by name **Query Param Demo** that has one request **Request1** with two examples in it - Example1 and Example2. 
+Once you mock the collection, it will be visible under the `Mocks` tab of the collection details view. You can also see the mock URL we will need for the next step.
 
-  Example 1 has the following values and params:  
+### Step 5: Sending a request using the mock server (M1)
 
-  [![query param1](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param_1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param_1.png)
+Now that we have created our mock `M1`, let's try sending a request to this mock endpoint. Copy the mock URL from the mock we created in the previous step, and paste it into a new request, with an undefined path in this case `https://b75a340e-4268-4b20-8f5f-3cfc8f37cec6.mock.pstmn.io`.
 
-  As illustrated, you can see the query params (highlighted in red circle) we are passing '1'.
+[![send a request to mock server](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock8-1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock8-1.png)
 
-  Example 2 has the following values and params:
+Sending a request to this mock endpoint with an undefined path returns an error. As you can see, there is no matching saved example with the path `''` and the request method `GET`. Responses returned by the mock service are entirely dependent on your saved examples and the included URL and request method type.
 
-  [![query param2](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param_2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param_2.png)
+[![mock request not found error](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock11.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock11.png)
 
-  As you can see, in Example1 and Example2, we are passing 1 and 5 respectively. When you copy the mock url path and pass on these different query params to it, Postman returns the exact response matching that path and its query params. This is illustrated in the below screen:
+We do, however, have a saved example with the path `/get` and the request method `GET`. So sending a `GET` request to the URL `https://b75a340e-4268-4b20-8f5f-3cfc8f37cec6.mock.pstmn.io/get` will return a proper response we are looking for.
 
+[![mock response](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock12.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock12.png)
 
-  [![query param3](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param.gif)
-  
-  **Note:** If there is no exact match found, Postman will return the best matching response based on its algorithm. 
+### Adding more examples
 
-  Learn more about the [matching algorithm](/docs/postman/mock_servers/matching_algorithm) for mocks.
+To further illustrate how responses from the mock service are entirely dependent on your saved examples, let's try adding another example to this collection. We'll repeat steps 1 to 3 of saving the request to a collection and saving the response as an example, with a new URL `https://postman-echo.com/test`.
 
+[![second example](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock13.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock13.png)
 
-  ### Mocking GraphQL queries
+Sending a `GET` request to `https://postman-echo.com/test` returns a 404 error which we will then save as another example. Our collection `C1` now has two requests and two saved examples:
 
-  Postman enables you to mock your GraphQL queries easily. To mock your GraphQL queries, you make a request to the mock server using the request path and request body saved in the examples when creating a mock server on the collection. 
-  
-  Ensure you set the *Content-type* header to *application/json* in the example you create. You then need to ensure to pass the *x-mock-match-request-body* header with a value set to *true* in the request header while hitting the mock URL. The following screen illustrates this process:
+* `GET` > `/get`
+* `GET` > `/test/`
 
-  [![mock graphql](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Mock-Graphql2.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Mock-Graphql2.gif)
+Mocking the `/test` mock path also gives us our expected 404 response.
+
+[![404 example](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock14.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-anuhyaMock14.png)
+
+Your examples might vary depending on the URL endpoint, request method type, or status code. If you have multiple examples saved to the same mock, you can choose to save each example under a unique URL endpoint like we saw in this example with `/get` and `/test`. Alternatively, if you have saved examples with different response status codes, you can send an authenticated request to the mock endpoint along with the `x-mock-response-code` header specifying which integer response code your returned response should match.
+
+## Using query params
+
+Postman's Mock server functionality is enhanced to return different responses based on matching request query params. Postman's Mock server looks at the query params while matching requests to the examples. Which means if you have examples that differ only in query params and want to mock different responses for different query params on the same request path, Postman's mock server will return the exact response matching that request path and the corresponding query params.
+
+Let's look at an example how this works:
+
+In this example, we have a collection by name **Query Param Demo** that has one request **Request1** with two examples in it - Example1 and Example2.
+
+Example 1 has the following values and params:
+
+[![query param1](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param_1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param_1.png)
+
+As illustrated, you can see the query params (highlighted in red circle) we are passing '1'.
+
+Example 2 has the following values and params:
+
+[![query param2](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param_2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param_2.png)
+
+As you can see, in Example1 and Example2, we are passing 1 and 5 respectively. When you copy the mock url path and pass on these different query params to it, Postman returns the exact response matching that path and its query params. This is illustrated in the below screen:
+
+[![query param3](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/query_param.gif)
+
+**Note:** If there is no exact match found, Postman will return the best matching response based on its algorithm.
+
+Learn more about the [matching algorithm](/docs/postman/mock_servers/matching_algorithm) for mocks.
+
+## Mocking GraphQL queries
+
+Postman enables you to mock your GraphQL queries easily. To mock your GraphQL queries, you make a request to the mock server using the request path and request body saved in the examples when creating a mock server on the collection.
+
+Ensure you set the *Content-type* header to *application/json* in the example you create. You then need to ensure to pass the *x-mock-match-request-body* header with a value set to *true* in the request header while hitting the mock URL. The following screen illustrates this process:
+
+[![mock graphql](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Mock-Graphql2.gif)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Mock-Graphql2.gif)
 
 And we're done! We have walked through how to create a collection, save requests, save examples, create a mock, and use a mock.

--- a/v6/postman/mock_servers/setting_up_mock.md
+++ b/v6/postman/mock_servers/setting_up_mock.md
@@ -6,26 +6,16 @@ warning: false
 
 Before sending an actual request, front-end developers can create a mock server to simulate each endpoint and its corresponding response in a Postman Collection. Developers can view potential responses, without spinning up a back end.
 
-* [Setting up a mock server](#setting-up-a-mock-server)
-
-* [Using HTTP access control for a mock](#using-http-access-control-for-a-mock)
-
-* [Using free mock server calls with your Postman account](#using-free-mock-server-calls)
-
-
-### Setting up a mock server 
-
 You can create a mock in several ways:
 
-* **New** button
-* Launch screen
-* [Postman app](/docs/v6/postman/mock_servers/mocking_with_examples)
-* [Postman API](/docs/v6/postman/mock_servers/mock_with_api)
- 
+* Using the **New** button
+* From the Launch screen
+* In the [Postman app using Examples](/docs/v6/postman/mock_servers/mocking_with_examples)
+* Using the [Postman API](/docs/v6/postman/mock_servers/mock_with_api)
 
-**Note**: This topic only covers how to create a mock with the **New** button and the Launch screen. To learn how to create a mock with the [Postman app](/docs/v6/postman/mock_servers/mocking_with_examples) or the [Postman API](/docs/v6/postman/mock_servers/mock_with_api), click the corresponding link for detailed information.
+This topic only covers how to create a mock with the **New** button and the Launch screen. To learn how to create a mock with the [Postman app](/docs/v6/postman/mock_servers/mocking_with_examples) or the [Postman API](/docs/v6/postman/mock_servers/mock_with_api), click the corresponding link for detailed information.
 
-#### New button
+## New button
 
 In the header toolbar, click the **New** button.
 
@@ -39,57 +29,58 @@ The Create New tab appears.
 
 Click "Mock Server".
 
-Select if you want to mock a new API or an existing or team collection. If you create a new API to mock, you must select a request method and enter the request path, response code, and response body. If you use an existing or team collection to mock, you must select a collection from a list of existing or team collections. 
+Select if you want to mock a new API or an existing or team collection. If you create a new API to mock, you must select a request method and enter the request path, response code, and response body. If you use an existing or team collection to mock, you must select a collection from a list of existing or team collections.
 
-[![config mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Create_New_Tab_Updated2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Create_New_Tab_Updated2.png) 
+[![config mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Create_New_Tab_Updated2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Create_New_Tab_Updated2.png)
 
 After you select or create the request you want to mock, click the **Next** button.
-  
+
 In the Configure mock server tab, you must:
-  
+
 * Enter the name of the mock
-* Specify a version tag 
+* Specify a version tag
 * Select an environment (optional).
 * Indicate if you want to make this mock server private
 
 **Note**: The number of calls made to mock servers might be limited by your Postman account. Check your [usage limits](https://go.postman.co/usage).
-     
- [![configTab mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Mock-Collection-Version1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Mock-Collection-Version1.png) 
-     
+
+[![configTab mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Mock-Collection-Version1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Mock-Collection-Version1.png)
+
 Click the **Create** button.
 
 In the Next steps tab, see a list of suggested next steps to maximize the effectiveness of your mock server.
 
- [![next mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-next-steps.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-next-steps.png)  
-   
-#### Launch screen
+[![next mock](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-next-steps.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/WS-next-steps.png)
 
-The Create New tab appears by default when you launch Postman. 
+## Launch screen
+
+The "Create New" tab appears by default when you launch Postman.
 
 Open the Postman app.
 
-In the Create New tab, click "Mock Server".
+In the "Create New" tab, click "Mock Server".
 
-Follow the steps in the previous **New** button section. 
+Follow the steps in the previous **New** button section.
 
 **Note**: At the bottom, you can select "Show this window at launch" to indicate whether you want the Create New tab to display each time you open Postman.
 
-
-### Using HTTP access control for a mock
+## Using HTTP access control for a mock
 
 In addition to using the [Postman app](/docs/v6/postman/mock_servers/mocking_with_examples) to make requests to mock endpoints, you also can make those requests in a browser.
 
-A web browser makes a cross-origin HTTP request when it requests a resource from a domain, protocol, or port that's different from its own.  
+A web browser makes a cross-origin HTTP request when it requests a resource from a domain, protocol, or port that's different from its own.
 
 [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) is a standard that defines a way in which a browser and server can interact securely. In this case, we are referring to how a web browser interacts with the mock endpoints hosted on the Postman server.
 
 CORS is enabled for Postman mock servers. As a result, you can stub your web apps with mocked data using the mock endpoints. So development or production web apps can make requests to the Postman mock endpoint you just created and receive an example response.
 
-### Using free mock server calls 
+## Using free mock server calls
 
-Your Postman account gives you a limited number of free mock server calls per month. 
+Your Postman account gives you a limited number of free mock server calls per month.
 
 You can check your usage limits in the [Postman API](https://docs.api.getpostman.com) or in the [account usage page](https://go.pstmn.io/postman-account-limits).
+
+## Further reading
 
 For more information about mock servers, see:
 


### PR DESCRIPTION
This PR fixes markdown lint issues and reorders content hierarchy for the Mock Servers section.

Pages affected:

- `Mock Servers/Intro to Mock Servers`
- `Mock Servers/Setting up Mock`
- `Mock Servers/Mocking with Examples`
- `Mock Servers/Mocking with API`
- `Mock Servers/Matching Algorithm`