### PR TITLE
Fix typo in Mocking with Examples that escaped review

### DIFF
--- a/v6/postman/mock_servers/mocking_with_examples.md
+++ b/v6/postman/mock_servers/mocking_with_examples.md
@@ -136,7 +136,7 @@ When you call that Mock Server endpoint, you will see the response change to som
 }
 ```
 
-For the Postman Sandbox page for full list of available [random data dynamic variables](/docs/v6/postman/scripts/postman_sandbox_api_reference#dynamic-variables).
+See the Postman Sandbox page for full list of available [random data dynamic variables](/docs/v6/postman/scripts/postman_sandbox_api_reference#dynamic-variables).
 
 ## Using query params
 


### PR DESCRIPTION
A quick fix for typo that skipped review in #1733. 