### PR TITLE
#1718 changed dynamic link to postman sandbox api reference

### DIFF
--- a/v6/postman/environments_and_globals/variables.md
+++ b/v6/postman/environments_and_globals/variables.md
@@ -107,10 +107,8 @@ Dynamic variables cannot be used in the Sandbox. You can only use them in the `
    *   `{{$timestamp}}`: Adds the current timestamp
    *   `{{$randomInt}}`: Adds a random integer between 0 and 1000
 
-   For a complete list of dynamic variables, refer to the section [Dynamic Variables List](https://learning.getpostman.com/docs/postman/scripts/postman_sandbox_api_reference/#dynamic-variables).
+   For a complete list of dynamic variables, refer to the section [Dynamic Variables List](/docs/v6/postman/scripts/postman_sandbox_api_reference/#dynamic-variables).
 
-
-https://learning.getpostman.com/docs/postman/scripts/postman_sandbox_api_reference/#dynamic-variables
 [![dynamic variables](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals5.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals5.png)
 
 ## Quick Look for variables

--- a/v6/postman/environments_and_globals/variables.md
+++ b/v6/postman/environments_and_globals/variables.md
@@ -7,7 +7,7 @@ warning: false
 
 Variables are symbolic names that represent the information you store in them. The information the variables represent can change, but the operations on the variable remain the same. Variables in Postman work the same way.
 
-This topic covers: 
+This topic covers:
 
 * [Variable scopes](#variable-scopes)
 * [Accessing variables in the request builder](#accessing-variables-in-the-request-builder)
@@ -30,7 +30,7 @@ You can assign five types of variable scopes:
 3. Environment
 4. Data
 5. Local
-  
+
 You can view different kinds of buckets in which values reside. If a variable is in two different scopes, the scope with a higher priority takes precedence. Postman resolves scopes using this hierarchy progressing from broad to narrow scope. 
 
 [![nested variable scopes](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Variables-Pic.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Variables-Pic.png)
@@ -39,7 +39,7 @@ If a variable from the currently active environment shares its name with a globa
 
 ## Accessing variables in the request builder
 
-You can use variables in the following form in the Postman user interface - `{{variableName}}`. 
+You can use variables in the following form in the Postman user interface - `{{variableName}}`.
 
 The string `{{variableName}}` will be replaced with its current value when Postman resolves the variable.
 
@@ -57,9 +57,9 @@ You can assign a current value when running your collection or a simple request 
         *  To set a variable in a script, use the `pm.environment.set()` method or `pm.globals.set()` method depending on the desired scope. The method requires the variable key and value as parameters to set the variable. When you send the request, the script will be evaluated and the value will be stored as a variable. Note that [defining a collection variable](/docs/postman/environments_and_globals/variables/) is a little different and can be done by editing the collection details.
   2.  Fetching a pre-defined variable: 
         *  Once a variable has been set, use the `pm.variables.get()` method or, alternatively, use the `pm.environment.get()` or `pm.globals.get()` method, depending on the appropriate scope to fetch the variable. The method requires the variable name as a parameter to retrieve the stored value in a script.
-        
+
         **Note**: When you specify a .get() method it always obtains the current value while .set() method modifies the current value. The way these variables work depends much on a setting in Postman [Automatically persist variable values](/docs/postman/launching_postman/settings/)
-        
+
   3.  Setting a variable in a scope: 
         *  Environment variables can be accessed with the corresponding environments. Collection variables can be accessed from a request within the collection. Global variables can be accessed broadly regardless of the selected environment.
 
@@ -77,13 +77,13 @@ Often while using variables in scripts, you will need to see the values they obt
 
 ## Data variables
 
-The Collection Runner lets you import a CSV or a JSON file, and then use the values from the data file inside HTTP requests and scripts. We call these 'data variables'. 
+The Collection Runner lets you import a CSV or a JSON file, and then use the values from the data file inside HTTP requests and scripts. We call these 'data variables'.
 
 To use them inside Postman, follow the same syntax as environment or global variables. 
 
 ### Data variables in requests
 
-Variables inside the Postman UI are enclosed inside curly braces. 
+Variables inside the Postman UI are enclosed inside curly braces.
 
 For example, in the screenshot below, `{{username}}` and `{{password}}` inside URL parameters would be replaced by corresponding values from the data file:
 
@@ -91,7 +91,7 @@ For example, in the screenshot below, `{{username}}` and `{{password}}` insi
 
 ### Data variables in pre-request and test scripts
 
-Here's an example of Inside pre-request and test scripts. Let's say you have the `pm.iterationData.get("username")` method inside pre-request and test scripts. The method lets you access the value of the username variable from a data file. 
+Here's an example of Inside pre-request and test scripts. Let's say you have the `pm.iterationData.get("username")` method inside pre-request and test scripts. The method lets you access the value of the username variable from a data file.
 
 [![data variables in scripts](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals4.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals4.png)
 
@@ -107,13 +107,15 @@ Dynamic variables cannot be used in the Sandbox. You can only use them in the `
    *   `{{$timestamp}}`: Adds the current timestamp
    *   `{{$randomInt}}`: Adds a random integer between 0 and 1000
 
-   For a complete list of dynamic variables, refer to the section [Dynamic Variables List](/docs/postman/environments_and_globals/variables_list).
+   For a complete list of dynamic variables, refer to the section [Dynamic Variables List](https://learning.getpostman.com/docs/postman/scripts/postman_sandbox_api_reference/#dynamic-variables).
 
+
+https://learning.getpostman.com/docs/postman/scripts/postman_sandbox_api_reference/#dynamic-variables
 [![dynamic variables](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals5.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Env&Globals5.png)
 
 ## Quick Look for variables
 
-Quick Look is a quick preview feature that displays all your environment and global variables in one place. 
+Quick Look is a quick preview feature that displays all your environment and global variables in one place.
 
 Click the "eye" icon in the top right to toggle the display, or type the keyboard shortcut **(CMD/CTRL + ALT + E)**.
 
@@ -127,7 +129,7 @@ Postman variables are very powerful, and two features - autocomplete and tool ti
 
 [![autocomplete for variables](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Autocomp_tooltips1.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Autocomp_tooltips1.png)
 
-Type an open curly bracket to bring up the autocomplete menu. For the pre-request and test scripts section, which [uses the data editor](/docs/postman/launching_postman/navigating_postman/), entering the first letter of a variable triggers autocomplete. The menu contains a list of all variables in the current environment, followed by globals. Navigating through the list also shows the initial value, current value and scope for each variable, along with feedback for overridden variables. If the request is saved in a collection, Postman also displays the collection variables in the list. 
+Type an open curly bracket to bring up the autocomplete menu. For the pre-request and test scripts section, which [uses the data editor](/docs/postman/launching_postman/navigating_postman/), entering the first letter of a variable triggers autocomplete. The menu contains a list of all variables in the current environment, followed by globals. Navigating through the list also shows the initial value, current value and scope for each variable, along with feedback for overridden variables. If the request is saved in a collection, Postman also displays the collection variables in the list.
 
 The following screen displays selection of Token1 with its initial and current values and scope:
 
@@ -138,5 +140,3 @@ The following screen displays selection of Token1 with its initial and current v
 Variables are highlighted in orange, with unresolved variables shown in red. Hovering over a variable shows its initial and current value and the scope. If a variable is unresolved - i.e., no value in the current environment - the tooltip shows appropriate feedback.
 
 **Note:** You can also read [Session FAQs](https://blog.getpostman.com/2018/08/09/sessions-faq/)
-
-


### PR DESCRIPTION
Fix for #1718 
Changed the link in the docs to the Sandbox API reference. 

The only issue is I don't know how to do an anchor by id in Jekyell so I only did a hard link to the site's anchor on dynamic variables. 

If someone can find and show me an example of an anchor link on a header that'd be helpful and I can make that change.