### PR TITLE
[1764] adding Code of Conduct page

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of the Postman Docs project, we pledge to respect everyone who contributes.
+
+Please read our [Code of Conduct](https://community.getpostman.com/t/postman-code-of-conduct/5 "Postman's Code of Conduct") that covers all Postman communites.


### PR DESCRIPTION
fixes #1764 

— added Code of Conduct page
— linked it to the Code of Conduct we link all Postman communities to.