### PR TITLE
Fix broken link in Sharing (v5)

### DIFF
--- a/v5/postman/team_library/sharing.md
+++ b/v5/postman/team_library/sharing.md
@@ -16,7 +16,7 @@ Your Team Library should be the single source of truth about your APIs. It will 
 
 [![team library](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59167045.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/59167045.png)
 
-The Team Library allows team members to subscribe to shared collections. When someone subscribes to a collection, they get a synced copy of this collection in their Postman app. If they have edit permissions for the collection, they can make changes which will be reflected in everyone else's collection copy too. Changes made to shared collections are visible under the [Activity Feed](/docs/postman/team_library/activity_feed_and_restoring_collections).
+The Team Library allows team members to subscribe to shared collections. When someone subscribes to a collection, they get a synced copy of this collection in their Postman app. If they have edit permissions for the collection, they can make changes which will be reflected in everyone else's collection copy too. Changes made to shared collections are visible under the [Activity Feed](/docs/postman/workspaces/activity_feed_and_restoring_collections/).
 
 Environment templates work slightly differently. Through an environment template, you can create and share a snapshot of a local environment. Users may have different environment variable values, so updates to these values are not synced between shared environments.
 


### PR DESCRIPTION
Fix #1805 . 

[V5 page](https://learning.getpostman.com/docs/postman/team_library/sharing/) is still indexed and accessible to users. Link to Activity Feed is correct in V6 file.