### PR TITLE
Update Monitoring FAQ

### DIFF
--- a/v6/postman/monitors/faqs_monitors.md
+++ b/v6/postman/monitors/faqs_monitors.md
@@ -40,6 +40,10 @@ You can view the full console output for every monitor run, including any errors
 
 Monitors are visible to all members of the workspace they were created in. If a collection is shared in both a personal and team workspace, but its monitor is created in the personal workspace, members of the team workspace will not be able to view or access that monitor.
 
+### Who can edit my Monitors?
+
+Monitors can be edited in their respective workspace by members who have been granted [Editor permissions](/docs/postman_pro/managing_postman_pro/roles_and_permissions/#collection-roles) on the associated collection.
+
 ### Can I delete a Monitor?
 
 You can delete a monitor at any time. Once deleted, all run history for the monitor is deleted too. If you want to retain the history, then you should pause the monitor instead of deleting it.

--- a/v6/postman/monitors/faqs_monitors.md
+++ b/v6/postman/monitors/faqs_monitors.md
@@ -38,9 +38,7 @@ You can view the full console output for every monitor run, including any errors
 
 ### Who can see my Monitors?
 
-Monitors have the same permissions as Postman Collections. By default, your collections are private, so only you can see the collection and its monitors. If you share a collection, then other members of your Postman Pro or Enterprise team can see the collection and its monitors. If you grant ``View & Edit`` permissions, then your team members can add monitors to your collection.
-
-Each collection can have different permissions. As a result, you can choose to have some private monitors, some shared monitors that are view-only, and some monitors that are shared and editable.
+Monitors are visible to all members of the workspace they were created in. If a collection is shared in both a personal and team workspace, but its monitor is created in the personal workspace, members of the team workspace will not be able to view or access that monitor.
 
 ### Can I delete a Monitor?
 


### PR DESCRIPTION
Fix #1707 .
This PR updates the answer to "Who can see my Monitors?" to explain that monitors stay within the workspace they were created in regardless of where their associated collections are shared. 

It also adds "Who can edit my Monitors?", as the original version of the aforementioned answer verged into discussing editing permissions. I think it makes sense to separate the two for clarity.