### PR TITLE
Bring back deleted files that belong to the managing_pro section

### DIFF
--- a/v6/pro/managing_pro/migrating_to_v7.md
+++ b/v6/pro/managing_pro/migrating_to_v7.md
@@ -1,0 +1,70 @@
+---
+title: "Migrating to Postman v7"
+page_id: "migrating_to_v7"
+warning: false
+---
+
+This section describes the steps/flow to migrate to Postman v7.
+
+**Note**: Non-team users can move to Postman v7 by updating the app via **Settings > Update > Check for Updates**, without worrying about the steps described in this section.
+
+This section describes the following topics:
+
+* [Why migrate?](#why-migrate)
+* [How to migrate](#how-to-migrate)
+
+## Why migrate?
+
+If you are a team user, you must migrate to Postman v7 to leverage fine-grained role-based access of Postman’s features. If you stay back on the older version of Postman app, you will not be able to:
+
+* Use role-based permissions which come with a fine-grained access management of some of Postman’s prominent features.
+
+* Access new features and updates because new feature development will be based on Postman v7.
+
+**Note:** Once your team migrates to Postman v7, the native apps 5.x and 6.x versions and Chrome app 5.x versions will stop syncing and all collaboration features will stop working and all members of the team need to update to their apps to Postman v7 to continue collaborating.
+
+## How to migrate?
+
+This section illustrates the possible user flows and guides you through the migration process. Role-based access is a team feature. To use this feature, the entire team must be on Postman v7.
+
+**Note:** The migration decision is restricted to the team Administrators. If you are a Postman team member and are not on Postman v7, please contact your Administrator to migrate to Postman v7.
+
+The next section explains the following scenarios:
+
+* [Team on Postman version 5/6](#team-on-postman-version-5/6)
+* [Team user on Postman v7](#team-user-on-postman-v7)
+
+### Team on Postman version 5/6
+
+If you are an admin, you can go to the [Postman dashboard](https://go.postman.co/settings/team/roles) and migrate to Postman v7.
+
+[![migration to v7](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Migrate2.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/Migrate2.png)
+
+Click **Migrate my team to v7** and Postman takes care of the next steps for you and your team.
+
+Once your team has migrated to Postman v7, all users in the team would be notified, via email and banners within the app, that they need to update their app to Postman v7.
+
+#### Updating app to Postman v7 after migration
+
+You can update your Postman v6 app to Postman v7, via **Settings > Update > Check for Updates**. Postman v7 would be available via auto-updates to all team users after the admin has successfully migrated the team.
+
+**Note:** If you are using Postman for Linux, and had installed the app via 'Ubuntu Software Center' or 'Snap Store', you will not be able to update the app via the steps explained above. Please use the following commands to update your app via the terminal:
+
+```
+sudo snap switch --channel=candidate postman
+sudo snap refresh postman
+```
+
+### Team user on Postman v7
+
+If you are in a team and download Postman v7 when the entire team is on an older version, you will not be able to migrate to Postman v7. Postman displays a message saying you can’t access features on this version of Postman app until the team migrates to Postman v7. If you happen to be on Postman v7 and would like to downgrade to Postman v6 to continue working with a team that has not migrated yet, please download the latest Postman v6 app from the links below.
+
+## Download latest Postman v6 app
+
+Please use the following links to download the latest Postman v6 version for your platform.
+
+* [Download Postman v6 for macOS 64-bit](https://go.pstmn.io/dl-macos64-v6-latest)
+* [Download Postman v6 for Windows 64-bit](https://go.pstmn.io/dl-win64-v6-latest)
+* [Download Postman v6 for Windows 32-bit](https://go.pstmn.io/dl-win32-v6-latest)
+* [Download Postman v6 for Linux 64-bit](https://go.pstmn.io/dl-linux64-v6-latest)
+* [Download Postman v6 for Linux 32-bit](https://go.pstmn.io/dl-linux32-v6-latest)

--- a/v6/pro/managing_pro/roles_and_permissions.md
+++ b/v6/pro/managing_pro/roles_and_permissions.md
@@ -1,0 +1,125 @@
+---
+title: "Roles and permissions"
+page_id: "roles_and_permissions"
+warning: false
+---
+Roles and permissions in Postman have been enhanced to provide a more robust access-control mechanism. In Postman v7, you access features through assigned roles that have their own set of user permissions.
+
+This chapter describes the following topics:
+
+* [Understanding roles in Postman](#understanding-roles-in-postman)
+* [List of roles and permissions](#list-of-roles-and-permissions)
+* [Roles before and after](#roles-before-and-after)
+* [Migrating to Postman v7](#migrating-to-postman-v7)
+
+### Understanding roles in Postman
+
+Permissions to perform certain tasks and/or operations are assigned to
+specific roles in Postman. For instance, Postman provides an admin-level role to help manage the permissions of Postman for the entire team. Likewise, Postman has other roles with specific permissions.
+
+The diagram below illustrates the roles in Postman:
+
+[![roles overview](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/RBAC3.png)](https://s3.amazonaws.com/postman-static-getpostman-com/postman-docs/RBAC3.png)
+
+The following is a brief outline of the main roles:
+
+* **Collection viewer** can view, run, and share a collection. When a viewer shares a collection it carries the same viewer permissions to the viewer with whom it is shared.
+* **Collection editor** can manage a collection and controls the highest level administrative and security settings.
+* **Workspace collaborator** can view all resources in the workspace, has add and remove privileges, can create history, and even add members.
+* **Workspace admin** can edit workspace’s information like name, summary, settings, remove members and change workspace roles, and delete the workspace.
+* **Team developer** can access some team resources (collections, environments, workspaces).
+* **Team admin** can’t access team resources, can edit team details, settings and invite/remove team members.
+* **Team billing** can’t access team resources, can access billing related things.
+
+### List of roles and permissions
+
+Roles and permissions is not a new feature in Postman. In Postman v7 the roles have been enhanced to provide a fine-grained access management of its features. This sections clearly outlines the roles and permissions for collections, workspaces, and teams in a table format.
+
+This section describes the following topics:
+
+* [Collection roles](#collection-roles)
+* [Workspace roles](#workspace-roles)
+* [Team roles](#team-roles)
+
+#### Collection roles
+
+In Postman v7, collections have two roles - **Collection Viewer** and **Collection Editor**. The following table illustrates the roles and permissions of collections:
+
+| Collections |   Viewer   | Editor |
+| ---   |   ---     | ---   |
+| Add, edit, and delete mock servers  |         | &#9745;   |
+| Add, edit, and delete monitors |       | &#9745;    |
+| Edit and delete a collection |       | &#9745;    |
+| Manage roles on collections  |     | &#9745;  |
+| View and run collections  |     | &#9745;  |
+| View and run collection runs  |   &#9745;    | &#9745;  |
+| Export a collection  |   &#9745;   | &#9745;   |
+| Fork a collection |   &#9745;   | &#9745;   |
+| Merge forks on a collection  |  &#9745;   | &#9745;   |
+| Publish collection documentation and add to API Network or Postman template  |      | &#9745;  |
+| Share collection to a different workspace  |    | &#9745;   |
+| Tag and restore collection versions   |    | &#9745;   |
+
+#### Workspace roles
+
+In Postman v7, workspaces have two roles - **Workspace Collaborator** and **Workspace Admin**. The following table illustrates the roles and permissions of workspaces:
+
+| Workspaces |   Collaborator   | Admin |
+| ---   |   ---     | ---   |
+| Add and remove collections, environments |  &#9745;        | &#9745;   |
+| View, create, edit, and delete Collection runs, Header Presets, History, and Integrations |   &#9745;     | &#9745;    |
+| Delete workspace|       | &#9745;    |
+| Join and leave workspace |  &#9745;    | &#9745;  |
+| Add mock servers and monitors  |   &#9745;    | &#9745;  |
+| View workspace contents and data like name, summary, and settings |   &#9745;   | &#9745;   |
+| Edit workspace details like - name, summary, and settings |     | &#9745;   |
+| Add members |  &#9745;   | &#9745;   |
+| Remove members  |      | &#9745;  |
+| Manage roles and visibility of the workspace |    | &#9745;   |
+
+#### Team roles
+
+In Postman v7, teams have three roles - **Developer**, **Admin**, and **Billing**. The following table illustrates team's roles and permissions:
+
+| Teams | Developer | Admin | Billing |
+| ---   |   ---     | ---   | ------- |
+| Create and delete invitations  |         | &#9745;   |
+| Edit team information and logo |       | &#9745;    |
+| Manage team roles (except billing)|       | &#9745;    |
+| Remove users from the team |     | &#9745;  |
+| Manage custom domains  |      | &#9745;  |
+| Manage authentication methods |      | &#9745;   |
+| View monitoring usage data for all monitors created by the team|      | &#9745;   |
+| View team audit logs  |    | &#9745;   |
+| Create and manage payment links  |    | &#9745;   | &#9745;
+| Use a purchase key  |    | &#9745;   | &#9745;
+| View all published collections in the team  | &#9745;    | &#9745;   |
+| Manage billing details  |    | &#9745;   |
+| Manage payment and payment methods |    | &#9745;   |
+| Cancel and change team plan  |    | &#9745;   | &#9745;
+| Assign billing role  |    | &#9745;   | &#9745;
+| View collections, environments, mock servers and monitors visible to the team  |    | &#9745;   | &#9745;
+| View and create team workspaces |    | &#9745;   | &#9745;
+| View team activity feed  |    | &#9745;   | &#9745;
+| View team's custom domains and use them to publish documentation  |    | &#9745;   | &#9745;
+
+### Roles before and after
+
+A user's role determines what they can and cannot do in Postman. Each role has a default set of permissions. The following section illustrates the roles prior to version 7 and post 7. The following lists the old roles and the newer ones feature-wise:
+
+* Collections
+    * *Can view* changed to **Collection Viewer**
+    * *Can edit* changed to **Collection Editor**
+* Workspace (No roles existed prior to version 7.0)
+    * Workspace Collaborator
+    * Workspace Admin
+* Team
+    * *User* changed to **Developer**
+    * Admin
+    * Billing
+
+**Note:** In the Postman app UI, the right-click option *Modify team permissions* has changed to **Manage Roles**. Also note that the older set of roles applied till Postman app version 6.
+
+### Migrating to Postman v7
+
+To know more about migration-related information, please refer to [migrating to v7](/docs/postman_pro/managing_postman_pro/migrating_to_v7/) section.


### PR DESCRIPTION
Files changed:

- `v6/postman/migrating_to_v7.md` -> `v6/pro/managing_pro/migrating_to_v7.md`
- `v6/postman/roles_and_permissions.md` -> `v6/pro/managing_pro/roles_and_permissions.md`

These files were deleted in #1789. They were in the `v6/postman/` directory, but Contentful had picked those changes initially. Moving them to their rightful positions and will observe if Contentful borks.

This will close #1814.

