### PR TITLE
1830 updated info and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-# postman-docs
+![Postman logo](https://assets.getpostman.com/common-share/postman-github-logo.png "Postman logo")
 
-We have added a new markdown linter with GitHub Actions. When making a pull request, it will run against this linter. Your changed files are required to pass linting before they will be merged.
+# Postman Learning Center
 
-To contribute to this project, please read:
+Postman is the collaboration platform for API development. And the [Postman Learning Center](https://learning.getpostman.com/) has the resources you need to ramp up quickly and extend your skills with Postman.
+
+## Contribution guidelines
+
+We would love for you to contribute to the Learning Center! To contribute to this project, please read:
 
 * The [Code of Conduct](https://github.com/postmanlabs/postman-docs/blob/develop/CODE_OF_CONDUCT.md)
 * The [Contribution Guidelines](https://github.com/postmanlabs/postman-docs/blob/develop/CONTRIBUTING.md)
 * [Setting up your GitHub Pages site locally with Jekyll](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/)
+
+**NOTE:** We have added a new Markdown linter with GitHub Actions. When making a pull request, it will run against this linter. Your changed files are required to pass linting before they will be merged. More information on this can be found in the [contribution guidelines](https://github.com/postmanlabs/postman-docs/blob/develop/CONTRIBUTING.md).
 
 ## Build your Jekyll site locally
 
@@ -14,23 +20,33 @@ To contribute to this project, please read:
    $ bundle exec jekyll serve
 ```
 
+For more information and help with local builds, see [Jekyll's docs](https://jekyllrb.com/docs/).
+
 ## Project Structure
 
-There are 2 independent versions of docs currently in the project (v5 and v6)
-`www.getpostman/docs` is redirected to `www.getpostman/docs/v6/`
+There are 2 independent versions of docs currently in the project (/v5 and /v6). The /v6 docs are the current version (/v5 docs are archived, please do not contribute to them at this time.)
 
-*To update v6 (same procedure to update v5):*
+### To update the docs
 
-* Landing page reference links is maintained at `/_data/v6_map.json`
+* Posts are maintained under the `/v6` folder.
 
-* Posts are maintained under `/v6`
+* The folder structure of /v6 is the URL structure for posts. For example, `/v6/postman/environments_and_globals/sessions.md` is mapped to URL `https://learning.getpostman.com/docs/postman/environments_and_globals/Sessions/`.
 
-* The folder structure of /v6 is the URL structure for posts. For example, `/v6/Do_what_ever/As_long_as/It_is_fun.md` is mapped to URL `www.getpostman/docs/v6/Do_what_ever/As_long_as/It_is_fun`
+* Links in the docs should be relative. Example:
 
-* Popular Topics is maintained at `/_includes/_popular_topics.html`
+```
+   [Newman](/docs/postman/collection_runs/command_line_integration_with_newman/)
+```
 
-* Version selector is maintained at `/_includes/_version_selector.html`
+## Resources
 
-* Docs specific styling is maintained at `/_includes/_meta.html` (we currently hide the version selector via css, when the time comes, change the css in this _meta.html file to display the version selector.)
+* [Download Postman](https://www.getpostman.com/downloads/)
+* [Postman Release Notes](https://www.getpostman.com/downloads/release-notes)
+* [Postman Integrations](https://www.getpostman.com/integrations/)
+* [The Postman API](https://docs.api.getpostman.com/)
+* [Postman Release Notes](https://www.getpostman.com/downloads/release-notes)
+* [Postman community](https://community.getpostman.com/) on Discourse.
 
-This project does not have any hacky implementations, follows strictly the standard way of implementing pages and it is documented in [Jekyll's docs](https://jekyllrb.com/docs/home/)
+## License
+
+[Apache License 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Postman is the collaboration platform for API development. And the [Postman Lear
 
 We would love for you to contribute to the Learning Center! To contribute to this project, please read:
 
-* The [Code of Conduct](https://github.com/postmanlabs/postman-docs/blob/develop/CODE_OF_CONDUCT.md)
-* The [Contribution Guidelines](https://github.com/postmanlabs/postman-docs/blob/develop/CONTRIBUTING.md)
+* The [Code of Conduct](CODE_OF_CONDUCT.md)
+* The [Contribution Guidelines](CONTRIBUTING.md)
 * [Setting up your GitHub Pages site locally with Jekyll](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/)
 
-**NOTE:** We have added a new Markdown linter with GitHub Actions. When making a pull request, it will run against this linter. Your changed files are required to pass linting before they will be merged. More information on this can be found in the [contribution guidelines](https://github.com/postmanlabs/postman-docs/blob/develop/CONTRIBUTING.md).
+**NOTE:** We have added a new Markdown linter with GitHub Actions. When making a pull request, it will run against this linter. Your changed files are required to pass linting before they will be merged. More information on this can be found in the [contribution guidelines](CONTRIBUTING.md).
 
 ## Build your Jekyll site locally
 


### PR DESCRIPTION
Fixes #1830 

— added logo to top
— added description of LC
— updated instructions
— added resources and license sections

<img width="1183" alt="Screen Shot 2019-10-03 at 12 45 34 AM" src="https://user-images.githubusercontent.com/4358288/66108291-22400280-e577-11e9-90b6-5aeb1b9740f3.png">
