### PR TITLE
[DOCUMENTER-1243] Add Run in Postman button to documentation docs

### DIFF
--- a/v6/postman/api_documentation/environments_and_environment_templates.md
+++ b/v6/postman/api_documentation/environments_and_environment_templates.md
@@ -20,7 +20,7 @@ All of your local and shared environments will be available to you in your team 
 
 ## Environments in public documentation
 
-An environment that you select while publishing documentation will be available to all documentation viewers.
+An environment that you select while publishing documentation will be available to all documentation viewers. This environment will also be downloaded when users select the automatically generated [Run in Postman button](/docs/postman_for_publishers/run_button/using_run_button).
 
 If your public documentation is published on a custom domain, only the selected environment will be available in the published page, even if the user is signed into their Postman account.
 

--- a/v6/postman/api_documentation/intro_to_api_documentation.md
+++ b/v6/postman/api_documentation/intro_to_api_documentation.md
@@ -51,6 +51,7 @@ Documentation for your API includes:
 * Sample requests, headers, and other metadata
 * Descriptions associated with requests, folders, and collections
 * Generated code snippets in some of the most popular programming languages
+* [Run in Postman button](/docs/postman_for_publishers/run_button/using_run_button)
 
 Postman uses ordered requests and folders to organize documentation in sections to reflect the structure of your collection.
 


### PR DESCRIPTION
Added:

- RiP button mention to [What gets automatically generated?](https://learning.getpostman.com/docs/postman/api_documentation/intro_to_api_documentation/#what-gets-automatically-generated) in "Intro to API documentation".

- RiP button mention to [Environments in public documentation](https://learning.getpostman.com/docs/postman/api_documentation/environments_and_environment_templates#environments-in-public-documentation) in "Local environments and shared environments".