### PR TITLE
pulls replacements from json file

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -26,6 +26,9 @@
       .nav-link:hover {
         color: $postman-orange;
       }
+      .v5_btn {
+        margin-bottom: 0;
+      }
     }
   }
   @media (max-width: 1200px) {

--- a/src/components/LeftNav/LeftNav.jsx
+++ b/src/components/LeftNav/LeftNav.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import './LeftNav.scss';
 
 const uuidv4 = require('uuid/v4');
+const replacements = require('./replacements.json');
 
 let slugs;
 
@@ -31,7 +32,7 @@ class ListItem extends React.Component {
   } // sets a given list item as active
 
   toggleActive = (e) => {
-    const title = e.target.textContent.replace(/ /g, '_');
+    const title = e.target.attributes.identifier.value;
     const { active } = this.state;
     const titleIndex = active.indexOf(title);
     if (titleIndex !== -1) {
@@ -80,8 +81,8 @@ class ListItem extends React.Component {
       >
         <li className={`parent${this.inUrl(`/${name}/`) ? ' currentUrl' : ''}`}>
           <img className={`caret${this.isActive(name) ? ' active-caret' : ''}`} src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3IiBoZWlnaHQ9IjQiIHZpZXdCb3g9IjAgMCA3IDQiPgogICAgPHBhdGggZmlsbD0iIzI4MjgyOCIgZmlsbC1vcGFjaXR5PSIuOCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNyAwTDMuNSA0IDAgMHoiLz4KPC9zdmc+Cg==" alt="" />
-          <button type="button" onClick={this.toggleActive}>
-            {name.replace(/_/g, ' ')}
+          <button type="button" onClick={this.toggleActive} identifier={name}>
+            {replacements[name] ? replacements[name] : name.replace(/_/g, ' ')}
           </button>
         </li>
         <ListItem data={JSON.stringify(data)} />

--- a/src/components/LeftNav/replacements.json
+++ b/src/components/LeftNav/replacements.json
@@ -1,0 +1,10 @@
+{
+  "sso": "Single sign-on (SSO)",
+  "api_documentation": "API documentation",
+  "design_and_develop_apis": "Design and Develop APIs",
+  "postman_api": "Postman API",
+  "sending_api_requests": "Sending API Requests",
+  "api_network": "API Network",
+  "public_api_documentation": "Public API Documentation",
+  "api_search": "API Search"
+}


### PR DESCRIPTION
This is a hold over, I would like to find a way to do this in frontmatter but it's tricky because each parent has multiple children which all have their own frontmatter, so it's wide open for conflicts. maybe fix it in the future by creating an index.md file that informs parent name and child order but doesn't render a page?