### PR TITLE
added script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "test:update": "jest -u",
     "test:lint": "node_modules/eslint/bin/eslint.js -c .eslintrc.js --ext .jsx --ext .js src/",
     "test:lint-fix": "node_modules/eslint/bin/eslint.js -c .eslintrc.js --ext .jsx --ext .js src/ --fix",
-    "test:url": "if grep -lri 's3.amazonaws.com/postman-static-getpostman-com' ./v6 ; then echo invalid s3 references found. Please use format; exit 1; else echo no s3 references found; fi"
+    "test:url": "if grep -lri 's3.amazonaws.com/postman-static-getpostman-com' ./v6 ; then echo invalid s3 references found. Please use format; exit 1; else echo no s3 references found; fi",
+    "test:mdlint": "node_modules/.bin/markdownlint ./ --ignore node_modules --ignore legacy-documentation"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
added a script in package.json to run the Markdown linter locally with `npm run test:mdlint`.

Added this line to the contribution doc in an earlier PR.