### PR TITLE
1913 - added Templates and links to right sidebar

### DIFF
--- a/src/pages/docs/postman/sending-api-requests/visualizer.md
+++ b/src/pages/docs/postman/sending-api-requests/visualizer.md
@@ -18,6 +18,17 @@ contextual_links:
   - type: link
     name: "Visualizer demo"
     url: "https://www.youtube.com/watch?v=Qj7j3QsY2ok"
+  - type: subtitle
+    name: "Templates"
+  - type: link
+    name: "Visualizer D3 heatmap demo"
+    url: "https://explore.postman.com/templates/4166"
+  - type: link
+    name: "Visualizer table"
+    url: "https://explore.postman.com/templates/4220"
+  - type: link
+    name: "Visualizer Example - Map"
+    url: "https://explore.postman.com/templates/4218"
 
 ---
 


### PR DESCRIPTION
This fixes #1913 

— I added a "Templates" section to the right sidebar for the /visualizer/ page
— Added 3 links to interesting templates demos

<img width="1100" alt="Screen Shot 2019-11-01 at 8 42 24 AM" src="https://user-images.githubusercontent.com/4358288/68037335-bdb2b900-fc84-11e9-9b29-ed170df59b5a.png">
