### PR TITLE
Document pm.environment.name

### DIFF
--- a/src/pages/docs/postman/scripts/postman-sandbox-api-reference.md
+++ b/src/pages/docs/postman/scripts/postman-sandbox-api-reference.md
@@ -171,7 +171,7 @@ The variables defined in the individual scopes may also be accessed via `pm.envi
 
 `pm.environment:` [Read more about VariableScope](http://www.postmanlabs.com/postman-collection/VariableScope.html)
 
-* `pm.environment.name`: Contains the name of the current environment. 
+* `pm.environment.name`: Contains the name of the current environment.
 * `pm.environment.has(variableName:String):function → Boolean`: Check if the environment has a variable with the given name.
 * `pm.environment.get(variableName:String):function → *`: Get the environment variable with the given name.
 * `pm.environment.set(variableName:String, variableValue:String):function`: Sets an environment variable with the given name and value.

--- a/src/pages/docs/postman/scripts/postman-sandbox-api-reference.md
+++ b/src/pages/docs/postman/scripts/postman-sandbox-api-reference.md
@@ -171,6 +171,7 @@ The variables defined in the individual scopes may also be accessed via `pm.envi
 
 `pm.environment:` [Read more about VariableScope](http://www.postmanlabs.com/postman-collection/VariableScope.html)
 
+* `pm.environment.name`: Contains the name of the current environment. 
 * `pm.environment.has(variableName:String):function → Boolean`: Check if the environment has a variable with the given name.
 * `pm.environment.get(variableName:String):function → *`: Get the environment variable with the given name.
 * `pm.environment.set(variableName:String, variableValue:String):function`: Sets an environment variable with the given name and value.

--- a/src/pages/docs/postman/scripts/postman-sandbox-api-reference.md
+++ b/src/pages/docs/postman/scripts/postman-sandbox-api-reference.md
@@ -171,7 +171,7 @@ The variables defined in the individual scopes may also be accessed via `pm.envi
 
 `pm.environment:` [Read more about VariableScope](http://www.postmanlabs.com/postman-collection/VariableScope.html)
 
-* `pm.environment.name`: Contains the name of the current environment.
+* `pm.environment.name:String`: Contains the name of the current environment.
 * `pm.environment.has(variableName:String):function → Boolean`: Check if the environment has a variable with the given name.
 * `pm.environment.get(variableName:String):function → *`: Get the environment variable with the given name.
 * `pm.environment.set(variableName:String, variableValue:String):function`: Sets an environment variable with the given name and value.

--- a/src/pages/docs/postman/scripts/postman-sandbox.md
+++ b/src/pages/docs/postman/scripts/postman-sandbox.md
@@ -45,7 +45,7 @@ Note: jQuery support has been discontinued since version 4.6.0, in favor of [ch
 
 ## Environment and global variables
 
-* `pm.environment.name`: Returns the name of the current environment. Returns `null` if no environment is selected.
+* `pm.environment.name`: Contains the name of the current environment. Returns `null` if no environment is selected.
 * `pm.environment.set("variableName", variableValue)`: Sets an environment variable “variableName”, and assigns the string “variableValue” to it. You must have an environment selected for this method to work. **Note**: Only strings can be stored. Storing other types of data will result in unexpected behavior.
 * `pm.environment.get("variableName")`: Returns the value of an environment variable “variableName”, for use in pre-request & test scripts. You must have an environment selected for this method to work.
 * `pm.environment.has("variableName")`: Returns `true` if an environment variable by the name `"variableName"` exists.

--- a/src/pages/docs/postman/scripts/postman-sandbox.md
+++ b/src/pages/docs/postman/scripts/postman-sandbox.md
@@ -45,6 +45,7 @@ Note: jQuery support has been discontinued since version 4.6.0, in favor of [ch
 
 ## Environment and global variables
 
+* `pm.environment.name`: Returns the name of the current environment. Returns `null` if no environment is selected.
 * `pm.environment.set("variableName", variableValue)`: Sets an environment variable “variableName”, and assigns the string “variableValue” to it. You must have an environment selected for this method to work. **Note**: Only strings can be stored. Storing other types of data will result in unexpected behavior.
 * `pm.environment.get("variableName")`: Returns the value of an environment variable “variableName”, for use in pre-request & test scripts. You must have an environment selected for this method to work.
 * `pm.environment.has("variableName")`: Returns `true` if an environment variable by the name `"variableName"` exists.

--- a/src/pages/docs/postman/scripts/postman-sandbox.md
+++ b/src/pages/docs/postman/scripts/postman-sandbox.md
@@ -45,7 +45,7 @@ Note: jQuery support has been discontinued since version 4.6.0, in favor of [ch
 
 ## Environment and global variables
 
-* `pm.environment.name`: Contains the name of the current environment. Returns `null` if no environment is selected.
+* `pm.environment.name {string}`: Contains the name of the current environment. Returns `null` if no environment is selected.
 * `pm.environment.set("variableName", variableValue)`: Sets an environment variable “variableName”, and assigns the string “variableValue” to it. You must have an environment selected for this method to work. **Note**: Only strings can be stored. Storing other types of data will result in unexpected behavior.
 * `pm.environment.get("variableName")`: Returns the value of an environment variable “variableName”, for use in pre-request & test scripts. You must have an environment selected for this method to work.
 * `pm.environment.has("variableName")`: Returns `true` if an environment variable by the name `"variableName"` exists.


### PR DESCRIPTION
Adds `pm.environment.name` to the documentation in the Postman -> Scripts -> Postman Sandbox section. See #1922. 
Edit: Added updates to the Postman Sandbox API References too