### PR TITLE
[DEVREL-71] Document remaining mock server creation flows

### DIFF
--- a/src/pages/docs/postman/mock-servers/setting-up-mock.md
+++ b/src/pages/docs/postman/mock-servers/setting-up-mock.md
@@ -35,11 +35,25 @@ contextual_links:
 warning: false
 ---
 
-[Mock Servers](/docs/postman/mock-servers/intro-to-mock-servers) in Postman let you simulate APIs. You can create mock servers from the Postman app, from the web dasboard and using the Postman API. You will need a Postman account to set up a mock server.
+[Mock Servers](/docs/postman/mock-servers/intro-to-mock-servers) in Postman let you simulate APIs. You can create mock servers from the Postman app, from the web dasboard, and using the Postman API. You will need a Postman account to set up a mock server.
 
 Mocks in Postman are tied to a collection. Postman matches requests and generates responses for mocks from the Examples in the requests of a collection. You can create a mock server even if you don't have an existing collection.
 
-## In-app
+## Contents
+
+* [Creating mock servers in-app](#creating-mock-servers-in-app)
+    * [Mocking from the New button](#mocking-from-the-new-button)
+    * [Mocking from the launch screen](#mocking-from-the-launch-screen)
+    * [Mocking from the Collections sidebar](#mocking-from-the-collections-sidebar)
+    * [Mocking a request from History](#mocking-a-request-from-history)
+    * [Mocking from Collections in Browse view](#mocking-from-collections-in-browse-view)
+* [Creating mock servers in the web dashboard](#creating-mock-servers-in-the-web-dashboard)
+* [Using HTTP access control for a mock](#using-http-access-control-for-a-mock)
+* [Using free mock server calls](#using-free-mock-server-calls)
+* [Editing mock servers](#editing-mock-servers)
+* [Next steps](#next-steps)
+
+## Creating mock servers in-app
 
 You can create a mock in several ways in the Postman app:
 
@@ -47,147 +61,143 @@ You can create a mock in several ways in the Postman app:
 * From the Launch screen
 * Using [Examples in an existing collection](/docs/postman/mock-servers/mocking-with-examples)
 
-### New button
+### Mocking from the New button
 
-The video below runs you through the step of creating a mock server from the **New** button in the Postman app.
+The video below runs you through the steps in creating a mock server from the **New** button in the Postman app.
 
 ![Mock creation flow using New button](https://assets.postman.com/postman-docs/mock-creation-app-cnx.gif)
 
-Here are the steps you need to follow:
+To create your mock server, click the **New** button in the top left of the header toolbar.
 
 ![Start by clicking the New button](https://assets.postman.com/postman-docs/mock-cnx-new-button.png)
 
-In the header toolbar, click the **New** button. It is located in the top-left of the Postman app. Click **Mock Server** in the **Create New** tab.
+Click **Mock Server** in the **Create New** tab.
 
 ![Choose "Mock Server" from the dialog box](https://assets.postman.com/postman-docs/mock-cnx-modal.png)
 
-Select if you want to mock a new API or an existing collection. If you create a new API to mock, you have to select a request method and enter the request path, response code, and response body. If you use an existing collection to mock, you must select a collection from a list of existing or team collections.
+Choose whether you want to mock a new API or an existing collection. If you create a new API to mock, you will select a request method and enter the request path, response code, and response body. If you use an existing collection to mock, you will select a collection from a list of existing or team collections.
 
 ![Set request path and response body](https://assets.postman.com/postman-docs/mock-cnx-config.png)
 
-After you select or create the request you want to mock, click the **Next** button.
+When you have selected or created the request you want to mock, click **Next**.
 
-In the **Set up the mock server** tab, you can fill in mock server specific information:
+In the **Set up the mock server** tab, you can configure your mock server.
+
+1. Enter the name of the mock.
+2. Select an environment (optional).
+3. Check the checkbox if you want to make the mock server private.
+4. Check the checkbox if you want to save the mock server URL as an environment variable.
+5. Click **Next** to continue.
 
 ![Set mock server configuration](https://assets.postman.com/postman-docs/mock-cnx-config-continued.png)
 
-1. Enter the name of the mock
-2. Select an environment (optional)
-3. Select the checkbox if you want to make the mock server private
-4. Select the checkbox if you want to save the mock server URL as an environment variable
-5. Click **Next** to continue
+> The number of calls made to mock servers may be limited by your Postman account. Check your [usage limits](https://go.postman.co/usage).
 
-**Note**: The number of calls made to mock servers may be limited by your Postman account. Check your [usage limits](https://go.postman.co/usage).
-
-In the **Next steps** tab, see a list of suggested next steps to maximize the effectiveness of your mock server.
+In the **Next steps** tab, you will see a list of suggested next steps to maximize the effectiveness of your mock server.
 
 ![Next steps after mock is created](https://assets.postman.com/postman-docs/mock-cnx-next-steps.png)
 
-### Launch screen
+### Mocking from the launch screen
 
-The **Create New** tab appears by default when you launch Postman.
+The **Create New** tab appears by default when you launch Postman. Open the Postman app and in the **Create New** tab, click **Mock Server**.
 
-Open the Postman app.
+Follow the process [outlined in the New Button section](#mocking-from-the-new-button) to complete the mock server setup steps.
 
-In the **Create New** tab, click **Mock Server**.
+> At the bottom, you can select **Show this window at launch** to indicate whether you want the Create New tab to display each time you open Postman.
 
-Follow the same process [shown in the New Button section](#new-button) to complete the mock server setup steps.
-
-**Note**: At the bottom, you can select **Show this window at launch** to indicate whether you want the Create New tab to display each time you open Postman.
-
-### Collection sidebar
+### Mocking from the Collections sidebar
 
 You can create a mock server from an existing collection in the left sidebar. To do that, expand the collection details pane, switch over to the **Mocks** tab in the pane, and click **Create a mock server**.
 
 ![Create new mock server from collection sidebar](https://assets.postman.com/postman-docs/mock-cnx-collection-sidebar.png)
 
-This will launch the **Create mock server** modal. Follow the same process [shown in the New Button section](#new-button) to complete the mock server setup steps.
+This will launch the **Create mock server** modal. Follow the process [outlined in the New Button section](#mocking-from-the-new-button) to complete the mock server setup steps.
 
 If you already have mock servers created from the same collection, you will see an **Add mock** button instead of **Create a mock server**.
 
 ![Create new mock server from collection sidebar when there are existing mock servers](https://assets.postman.com/postman-docs/mock-cnx-collection-sidebar-existing.png)
 
-### History request
+### Mocking a request from History
 
-You can mock a single request from the History tab in the left sidebar. To do that, switch to the **History** tab in the left sidebar, hover on an entry, and click on the button with three dots to expand the dropdown menu. Choose **Mock Request** from the dropdown.
+You can mock a single request from the **History** tab in the left sidebar. Hover over an entry, and click **View more actions** (**...**) to expand the dropdown menu. Choose **Mock Request**.
 
 ![Create new mock server from history request](https://assets.postman.com/postman-docs/mock-cnx-history-request.png)
 
-This will open up a modal with the screen titled "2. Set up the mock server". Pass the values similar to the previous steps. Click **Create Mock Server**.
+This will open the **Set up the mock server** modal. Pass the values outlined in the [New button section](#mocking-from-the-new-button). Click **Create Mock Server**.
 
-This process of creating a mock server will also create a collection with the same title as the mock server. This collection will have a copy of the same request that you chose from the History sidebar. The mock server created is tied to this new collection.
+This process of creating a mock server will also create a collection with the same title as the mock server. This collection will have a copy of the same request that you chose from the **History** sidebar. The mock server created is tied to this new collection.
 
 ![New collection created when creating mock server from history request](https://assets.postman.com/postman-docs/mock-cnx-history-request-created.png)
 
-### Collections in Browse view
+### Mocking from Collections in Browse view
 
-You can create a mock from an existing collection from the "Browse" view as well. Switch over to the "Browse" view by clicking the toggle button on the bottom right hand side of the Postman app. Change to the "Collections" tab for the current workspace. Click the button with the three dots called "View more actions" for the corresponding collection. Select "Mock Collection" from the dropdown.
+You can create a mock from an existing collection from the **Browse** view. Click the **Browse** toggle button on the bottom right of the Postman app. Change to the **Collections** tab for the current workspace. Click the **View more actions**  (**...**) button for the corresponding collection. Select **Mock Collection** from the dropdown.
 
 ![Create new mock server from browse view](https://assets.postman.com/postman-docs/mock-cnx-browse-view.png)
 
-This will open up the "Create mock server" modal. Follow the steps to finish creating the mock server.
+This will open the **Create mock server** modal. Follow the steps to finish creating the mock server.
 
-## In web dashboard
+## Creating mock servers in the web dashboard
 
-You can create a mock server from the Web dashboard with existing collections and environments. To do that, login to your [Postman team dashboard](https://go.postman.co), navigate to your workspace by clicking on your workspace name. In the workspace dashboard, click on the "Mock servers" tab.
+You can create a mock server from the Web dashboard with existing collections and environments. Login to your [Postman team dashboard](https://go.postman.co), and navigate to your workspace by clicking your workspace name. In the workspace dashboard, click the **Mock servers** tab.
 
 ![Mock servers web dashboard](https://assets.postman.com/postman-docs/mock-web-dashboard.png)
 
-Click on the button to create new mock server, and you will see the mock server configuration screen. Set the relevant configuration.
+Click the button to create a new mock server, and you will see the configuration screen. Set the relevant configuration.
 
 ![Mock servers web dashboard configuration](https://assets.postman.com/postman-docs/mock-web-config.png)
 
-1. Enter the name of the mock
-2. Select a collection to mock
-3. Select a version tag of the collection to use for the mock. Leave it to "CURRENT" if you want to the mock server to use the latest version of your collection
-4. Select an environment to use with the mock (optional)
-5. Select the checkbox if you want to make the mock server private
-6. Click "Create Mock Server" to create the mock and go back to the "Mock servers" dashboard
+1. Enter the name of the mock.
+2. Select a collection to mock.
+3. Select a version tag of the collection to use for the mock. Leave it to **CURRENT** if you want to the mock server to use the latest version of your collection.
+4. Select an environment to use with the mock (optional).
+5. Select the checkbox if you want to make the mock server private.
+6. Click **Create Mock Server** to create the mock and go back to the **Mock servers** dashboard.
 
 ## Using HTTP access control for a mock
 
-In addition to using the [Postman app](/docs/postman/mock-servers/mocking-with-examples/) to make requests to mock endpoints, you also can make those requests in a browser.
+In addition to using the [Postman app](/docs/postman/mock-servers/mocking-with-examples/) to make requests to mock endpoints, you can also make those requests in a browser.
 
 A web browser makes a cross-origin HTTP request when it requests a resource from a domain, protocol, or port that's different from its own.
 
 [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access-control-CORS) is a standard that defines a way in which a browser and server can interact securely. In this case, we are referring to how a web browser interacts with the mock endpoints hosted on the Postman server.
 
-CORS is enabled for Postman mock servers. As a result, you can stub your web apps with mocked data using the mock endpoints. So development or production web apps can make requests to the Postman mock endpoint you just created and receive an example response.
+CORS is enabled for Postman mock servers. As a result, you can stub your web apps with mocked data using the mock endpoints. Development or production web apps can then make requests to your Postman mock endpoint and receive an example response.
 
 ## Using free mock server calls
 
 Your Postman account gives you a limited number of free mock server calls per month.
 
-You can check your usage limits in the [Postman API](https://docs.api.getpostman.com) or in the [account usage page](https://go.pstmn.io/postman-account-limits).
+You can check your usage limits in the [Postman API](https://docs.api.getpostman.com) or [account usage page](https://go.pstmn.io/postman-account-limits).
 
-## Editing Mock Servers
+## Editing mock servers
 
-You can edit existing Mock Servers in Postman since version `7.7.0`. These are the properties of a Mock Server that can be updated through the Postman app and web dashboard:
+You can edit existing mock servers in Postman since version `7.7.0`. The following properties of a mock server can be updated through the Postman app and web dashboard:
 
-* Name of the Mock Server
+* Name of the mock server
 * Version tag of the underlying collection
-* Environment associated with the Mock Server
-* Make the Mock Server private or public
+* Environment associated with the mock server
+* Private or public status of the mock server
 
 ![Postman Mock Server edit options](https://assets.postman.com/postman-docs/mocks/mock-edit-modal.png)
 
-There are three ways you can edit a mock server. You can either edit a Mock Server from the Collection pane, through the Mock Server listing in Browse mode, or through the web dashboard of your Workspace's Mock Servers section.
+There are three ways to edit a mock server. You can edit from the Collection pane, through the **Mock Server** listing in **Browse** mode, or through the web dashboard of your workspace **Mock Servers** section.
 
-Editing Mocks in Build mode:
+Editing mocks in Build mode:
 
 ![Postman Mock Server edit in Build mode](https://assets.postman.com/postman-docs/mocks/mock-edit-build.png)
 
-Editing Mocks in Browse mode:
+Editing mocks in Browse mode:
 
 ![Postman Mock Server edit in Browse mode](https://assets.postman.com/postman-docs/mocks/mock-edit-browse.png)
 
-Editing Mocks from the Web Dashboard:
+Editing mocks from the Web Dashboard:
 
 ![Postman Mock Server edit in Build mode](https://assets.postman.com/postman-docs/mocks/mock-edit-web-dashboard.png)
 
-## Further reading
+## Next steps
 
-For more information about mock servers, see:
+For more information about mock servers, see the following resources:
 
 * [Intro to mock servers](/docs/postman/mock-servers/intro-to-mock-servers/)
 * [Mocking with examples](/docs/postman/mock-servers/mocking-with-examples/)

--- a/src/pages/docs/postman/mock-servers/setting-up-mock.md
+++ b/src/pages/docs/postman/mock-servers/setting-up-mock.md
@@ -109,7 +109,7 @@ If you already have mock servers created from the same collection, you will see 
 
 ### History request
 
-You can also mock a single request from the History tab in the left sidebar. To do that, switch to the "History" tab in the left sidebar, hover on an entry, and click on the button with three dots to expand the dropdown menu. Choose "Mock Request" from the dropdown.
+You can mock a single request from the History tab in the left sidebar. To do that, switch to the "History" tab in the left sidebar, hover on an entry, and click on the button with three dots to expand the dropdown menu. Choose "Mock Request" from the dropdown.
 
 ![Create new mock server from history request](https://assets.postman.com/postman-docs/mock-cnx-history-request.png)
 
@@ -118,6 +118,14 @@ This will open up a modal with the screen titled "2. Set up the mock server". Pa
 This process of creating a mock server will also create a collection with the same title as the mock server. This collection will have a copy of the same request that you chose from the History sidebar. The mock server created is tied to this new collection.
 
 ![New collection created when creating mock server from history request](https://assets.postman.com/postman-docs/mock-cnx-history-request-created.png)
+
+### Collections in Browse view
+
+You can create a mock from an existing collection from the "Browse" view as well. Switch over to the "Browse" view by clicking the toggle button on the bottom right hand side of the Postman app. Change to the "Collections" tab for the current workspace. Click the button with the three dots called "View more actions" for the corresponding collection. Select "Mock Collection" from the dropdown.
+
+![Create new mock server from browse view](https://assets.postman.com/postman-docs/mock-cnx-browse-view.png)
+
+This will open up the "Create mock server" modal. Follow the steps to finish creating the mock server.
 
 ## In web dashboard
 

--- a/src/pages/docs/postman/mock-servers/setting-up-mock.md
+++ b/src/pages/docs/postman/mock-servers/setting-up-mock.md
@@ -95,6 +95,30 @@ Follow the steps in the previous section.
 
 **Note**: At the bottom, you can select "Show this window at launch" to indicate whether you want the Create New tab to display each time you open Postman.
 
+### Collection sidebar
+
+You can create a mock server from an existing collection in the left sidebar. To do that, expand the collection details pane, switch over to the "Mocks" tab in the pane, and click on the "Create a mock server" button.
+
+![Create new mock server from collection sidebar](https://assets.postman.com/postman-docs/mock-cnx-collection-sidebar.png)
+
+This will launch the "Create mock server" modal. Follow the same steps as earlier to complete the process.
+
+If you already have mock servers created from the same collection, you will see a button called "Add mock", instead of the "Create a mock server" button.
+
+![Create new mock server from collection sidebar when there are existing mock servers](https://assets.postman.com/postman-docs/mock-cnx-collection-sidebar-existing.png)
+
+### History request
+
+You can also mock a single request from the History tab in the left sidebar. To do that, switch to the "History" tab in the left sidebar, hover on an entry, and click on the button with three dots to expand the dropdown menu. Choose "Mock Request" from the dropdown.
+
+![Create new mock server from history request](https://assets.postman.com/postman-docs/mock-cnx-history-request.png)
+
+This will open up a modal with the screen titled "2. Set up the mock server". Pass the values similar to the previous steps. Click "Create Mock Server".
+
+This process of creating a mock server will also create a collection with the same title as the mock server. This collection will have a copy of the same request that you chose from the History sidebar. The mock server created is tied to this new collection.
+
+![New collection created when creating mock server from history request](https://assets.postman.com/postman-docs/mock-cnx-history-request-created.png)
+
 ## In web dashboard
 
 You can create a mock server from the Web dashboard with existing collections and environments. To do that, login to your [Postman team dashboard](https://go.postman.co), navigate to your workspace by clicking on your workspace name. In the workspace dashboard, click on the "Mock servers" tab.

--- a/src/pages/docs/postman/mock-servers/setting-up-mock.md
+++ b/src/pages/docs/postman/mock-servers/setting-up-mock.md
@@ -49,7 +49,7 @@ You can create a mock in several ways in the Postman app:
 
 ### New button
 
-The video below runs you through the step of creating a mock server from the "New" button in the Postman app.
+The video below runs you through the step of creating a mock server from the **New** button in the Postman app.
 
 ![Mock creation flow using New button](https://assets.postman.com/postman-docs/mock-creation-app-cnx.gif)
 
@@ -57,7 +57,7 @@ Here are the steps you need to follow:
 
 ![Start by clicking the New button](https://assets.postman.com/postman-docs/mock-cnx-new-button.png)
 
-In the header toolbar, click the **New** button. It is located in the top-left of the Postman app. Click "Mock Server" in the "Create New" tab.
+In the header toolbar, click the **New** button. It is located in the top-left of the Postman app. Click **Mock Server** in the **Create New** tab.
 
 ![Choose "Mock Server" from the dialog box](https://assets.postman.com/postman-docs/mock-cnx-modal.png)
 
@@ -67,7 +67,7 @@ Select if you want to mock a new API or an existing collection. If you create a 
 
 After you select or create the request you want to mock, click the **Next** button.
 
-In the "Set up the mock server" tab, you can fill in mock server specific information:
+In the **Set up the mock server** tab, you can fill in mock server specific information:
 
 ![Set mock server configuration](https://assets.postman.com/postman-docs/mock-cnx-config-continued.png)
 
@@ -75,45 +75,45 @@ In the "Set up the mock server" tab, you can fill in mock server specific inform
 2. Select an environment (optional)
 3. Select the checkbox if you want to make the mock server private
 4. Select the checkbox if you want to save the mock server URL as an environment variable
-5. Click "Next" to continue
+5. Click **Next** to continue
 
 **Note**: The number of calls made to mock servers may be limited by your Postman account. Check your [usage limits](https://go.postman.co/usage).
 
-In the Next steps tab, see a list of suggested next steps to maximize the effectiveness of your mock server.
+In the **Next steps** tab, see a list of suggested next steps to maximize the effectiveness of your mock server.
 
 ![Next steps after mock is created](https://assets.postman.com/postman-docs/mock-cnx-next-steps.png)
 
 ### Launch screen
 
-The "Create New" tab appears by default when you launch Postman.
+The **Create New** tab appears by default when you launch Postman.
 
 Open the Postman app.
 
-In the "Create New" tab, click "Mock Server".
+In the **Create New** tab, click **Mock Server**.
 
-Follow the steps in the previous section.
+Follow the same process [shown in the New Button section](#new-button) to complete the mock server setup steps.
 
-**Note**: At the bottom, you can select "Show this window at launch" to indicate whether you want the Create New tab to display each time you open Postman.
+**Note**: At the bottom, you can select **Show this window at launch** to indicate whether you want the Create New tab to display each time you open Postman.
 
 ### Collection sidebar
 
-You can create a mock server from an existing collection in the left sidebar. To do that, expand the collection details pane, switch over to the "Mocks" tab in the pane, and click on the "Create a mock server" button.
+You can create a mock server from an existing collection in the left sidebar. To do that, expand the collection details pane, switch over to the **Mocks** tab in the pane, and click **Create a mock server**.
 
 ![Create new mock server from collection sidebar](https://assets.postman.com/postman-docs/mock-cnx-collection-sidebar.png)
 
-This will launch the "Create mock server" modal. Follow the same steps as earlier to complete the process.
+This will launch the **Create mock server** modal. Follow the same process [shown in the New Button section](#new-button) to complete the mock server setup steps.
 
-If you already have mock servers created from the same collection, you will see a button called "Add mock", instead of the "Create a mock server" button.
+If you already have mock servers created from the same collection, you will see an **Add mock** button instead of **Create a mock server**.
 
 ![Create new mock server from collection sidebar when there are existing mock servers](https://assets.postman.com/postman-docs/mock-cnx-collection-sidebar-existing.png)
 
 ### History request
 
-You can mock a single request from the History tab in the left sidebar. To do that, switch to the "History" tab in the left sidebar, hover on an entry, and click on the button with three dots to expand the dropdown menu. Choose "Mock Request" from the dropdown.
+You can mock a single request from the History tab in the left sidebar. To do that, switch to the **History** tab in the left sidebar, hover on an entry, and click on the button with three dots to expand the dropdown menu. Choose **Mock Request** from the dropdown.
 
 ![Create new mock server from history request](https://assets.postman.com/postman-docs/mock-cnx-history-request.png)
 
-This will open up a modal with the screen titled "2. Set up the mock server". Pass the values similar to the previous steps. Click "Create Mock Server".
+This will open up a modal with the screen titled "2. Set up the mock server". Pass the values similar to the previous steps. Click **Create Mock Server**.
 
 This process of creating a mock server will also create a collection with the same title as the mock server. This collection will have a copy of the same request that you chose from the History sidebar. The mock server created is tied to this new collection.
 


### PR DESCRIPTION
Documented remaining mock server flows through collection sidebar and history request.

**[Rendered](https://github.com/postmanlabs/postman-docs/blob/feature/devrel-71-mock-creation-gaps/src/pages/docs/postman/mock-servers/setting-up-mock.md#collection-sidebar)**

Fixes #1498 