### PR TITLE
1998 increase spacing between buttons in navbar

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -16,7 +16,7 @@
   }
 
   .header__right-links {
-    .nav-item{
+    .nav-item {
       .nav-link {
         text-decoration: none;
         color: $gray-3;
@@ -24,6 +24,7 @@
         font-weight: 600;
         text-transform: uppercase;
         white-space: nowrap;
+        padding: 16px;
       }
       .nav-link:hover {
         color: $postman-orange;

--- a/src/components/Search/_search.scss
+++ b/src/components/Search/_search.scss
@@ -80,6 +80,7 @@ ais-highlight-0000000000 {
 
 .header__search {
   width: 100%;
+  padding: 0 16px;
   .ais-InstantSearch__root {
     width: 100%;
   }


### PR DESCRIPTION
fixes #1998 

— added 16px of padding to left and right of buttons in navbar
— also added some top and bottom padding to make them fill the height of the navbar so as to be no space where there wasn't a click area.
— checked mobile sizes
— ran linter