### PR TITLE
Update to the description on the `timestamp` dynamic variable

### DIFF
--- a/legacy-documentation/v5/api_testing_and_collection_runner/sandbox.md
+++ b/legacy-documentation/v5/api_testing_and_collection_runner/sandbox.md
@@ -45,7 +45,7 @@ Note: jQuery support has been discontinued since version 4.6.0, in favour of [ch
 Postman also has a few dynamic variables which you can use in your requests. This is primarily an experiment right now. More functions would be added soon. Note that dynamic variables cannot be used in the Sandbox. You can only use them in the `{{..}}` format in the request URL / headers / body.
 
 * `{{$guid}}`: Adds a v4 style guid
-* `{{$timestamp}}`: Adds the current timestamp.
+* `{{$timestamp}}`: Adds the current timestamp (Unix timestamp in seconds)
 * `{{$randomInt}}`: Adds a random integer between 0 and 1000
 
 ### Cookies

--- a/legacy-documentation/v5/postman/environments_and_globals/variables.md
+++ b/legacy-documentation/v5/postman/environments_and_globals/variables.md
@@ -94,7 +94,7 @@ Learn more about [working with data files](https://learning.getpostman.com/docs
 Postman has a few dynamic variables which you can use in your requests. Dynamic variables cannot be used in the Sandbox. You can only use them in the `{{..}}` format in the request URL / headers / body.
 
    *   {% raw %} `{{$guid}}`{% endraw %} : Adds a v4 style guid
-   *   {% raw %} `{{$timestamp}}`{% endraw %}: Adds the current timestamp
+   *   {% raw %} `{{$timestamp}}`{% endraw %}: Adds the current timestamp (Unix timestamp in seconds)
    *   {% raw %} `{{$randomInt}}`{% endraw %}: Adds a random integer between 0 and 1000
 
 [![dynamic variables](https://assets.postman.com/postman-docs/WS-var_dynamic.png)](https://assets.postman.com/postman-docs/WS-var_dynamic.png)

--- a/legacy-documentation/v5/postman/scripts/postman_sandbox.md
+++ b/legacy-documentation/v5/postman/scripts/postman_sandbox.md
@@ -40,7 +40,7 @@ Note: jQuery support has been discontinued since version 4.6.0, in favor of [ch
 Postman also has a few dynamic variables which you can use in your requests. This is primarily an experiment right now. More functions would be added soon. Note that dynamic variables cannot be used in the Sandbox. You can only use them in the `{{..}}` format in the request URL / headers / body.
 
 *   `{{$guid}}`: Adds a v4 style guid
-*   `{{$timestamp}}`: Adds the current timestamp.
+*   `{{$timestamp}}`: Adds the current timestamp (Unix timestamp in seconds)
 *   `{{$randomInt}}`: Adds a random integer between 0 and 1000
 
 ### Cookies

--- a/legacy-documentation/v5/variables_and_environments/environments.md
+++ b/legacy-documentation/v5/variables_and_environments/environments.md
@@ -49,7 +49,7 @@ Postman also has a few dynamic variables which you can use in your requests. Thi
 You can only use them in the `{{..}}` format in the request URL / headers / body.
 
 * `{{$guid}}`: Adds a v4 style guid
-* `{{$timestamp}}`: Adds the current timestamp
+* `{{$timestamp}}`: Adds the current timestamp (Unix timestamp in seconds)
 * `{{$randomInt}}`: Adds a random integer between 0 and 1000
 
 

--- a/src/pages/docs/postman/environments-and-globals/variables.md
+++ b/src/pages/docs/postman/environments-and-globals/variables.md
@@ -157,7 +157,7 @@ Postman has a few dynamic variables that you can use in your requests.
 Dynamic variables cannot be used in the Sandbox. You can only use them in the `{{..}}` format in the request URL / headers / body.
 
 * `{{$guid}}` : Adds a v4 style guid
-* `{{$timestamp}}`: Adds the current timestamp
+* `{{$timestamp}}`: Adds the current timestamp (Unix timestamp in seconds)
 * `{{$randomInt}}`: Adds a random integer between 0 and 1000
 
    For a complete list of dynamic variables, refer to the section [Dynamic Variables List](/docs/postman/scripts/postman-sandbox-api-reference/#dynamic-variables).

--- a/src/pages/docs/postman/scripts/postman-sandbox-api-reference.md
+++ b/src/pages/docs/postman/scripts/postman-sandbox-api-reference.md
@@ -436,7 +436,7 @@ The following is a list of dynamic variables whose values are randomly generated
 | **`$guid`**               | A `uuid-v4` style guid                        | `"611c2e81-2ccb-42d8-9ddc-2d0bfa65c1b4"`   |
 |                           |                                               | `"3a721b7f-7dc9-4c45-9777-516942b98e0d"`   |
 |                           |                                               | `"22eca807-006b-47df-9511-e92e37f5071a"`   |
-| **`$timestamp`**          | The current UNIX timestamp                    | `1562757107`, `1562757108`, `1562757109`   |
+| **`$timestamp`**          | The current UNIX timestamp in seconds                   | `1562757107`, `1562757108`, `1562757109`   |
 | **`$randomUUID`**         | A random 36-character UUID                    | `"6929bb52-3ab2-448a-9796-d6480ecad36b"`   |
 |                           |                                               | `"53151b27-034f-45a0-9f0a-d7b6075b67d0"`   |
 |                           |                                               | `"727131a2-2717-44ad-ab02-006587e947dc"`   |

--- a/src/pages/docs/postman/scripts/postman-sandbox.md
+++ b/src/pages/docs/postman/scripts/postman-sandbox.md
@@ -63,7 +63,7 @@ Note: jQuery support has been discontinued since version 4.6.0, in favor of [ch
 Postman also has a few dynamic variables which you can use in your requests. This is primarily an experiment right now. More functions would be added soon. Note that dynamic variables cannot be used in the Sandbox. You can only use them in the `{{..}}` format in the request URL / headers / body.
 
 * `{{$guid}}`: Adds a v4 style guid
-* `{{$timestamp}}`: Adds the current timestamp
+* `{{$timestamp}}`: Adds the current timestamp (Unix timestamp in seconds)
 * `{{$randomInt}}`: Adds a random integer between 0 and 1000
 
 For full list of available dynamic variables, see the [Postman Sandbox API Reference](/docs/postman/scripts/postman-sandbox-api-reference/).


### PR DESCRIPTION
After some initial confusion over this value being displayed in seconds or milliseconds, I've updated the learning docs in various places, to include `(Unix timestamp in seconds)` as part of the description.