### PR TITLE
Correcting a typo on link to youtube video on test script doc

### DIFF
--- a/src/pages/docs/postman/scripts/test-scripts.md
+++ b/src/pages/docs/postman/scripts/test-scripts.md
@@ -30,7 +30,7 @@ contextual_links:
     name: "How to add tests to a Postman Collection"
     url: "https://www.youtube.com/watch?v=ElJBJIeJ90o"
   - type: link
-    name: "New to Postman PArt 3: writing a test"
+    name: "New to Postman Part 3: writing a test"
     url: "https://www.youtube.com/watch?v=6Cp4Ez5dwbM"
   - type: link
     name: "New to Postman Part 5: chaining requests"


### PR DESCRIPTION
While using the documentation I noticed an typo so I fixed it :)