### PR TITLE
1802 updated redirects for old page

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -36,6 +36,10 @@
     "to": "/docs/postman-pro/managing-pro/managing-your-team/"
   },
   {
+    "from": "/docs/api_testing_and_collection_runner/writing_tests",
+    "to": "/docs/postman/scripts/test-scripts/"
+  },
+  {
     "from": "/docs/postman_pro/managing_postman_pro/migrating_to_v7/#team-user-on-postman-v7",
     "to": "/docs/postman-pro/managing-pro/migrating-to-v7/#update-to-postman-v7"
   }


### PR DESCRIPTION
fixes #1802 

The app points to an old URL that does not self-resolve using the built-in logic we set up.

I added a redirect to resolve to the latest and most-similar page: "Test Scripts" https://learning.getpostman.com/docs/postman/scripts/test-scripts/