### PR TITLE
added code_keyword to frontmatter

### DIFF
--- a/src/pages/docs/postman/variables-and-environments/variables.md
+++ b/src/pages/docs/postman/variables-and-environments/variables.md
@@ -2,6 +2,7 @@
 title: "Using variables"
 order: 48
 page_id: "variables"
+code_keyword: "collectionVariables, iterationData, collectionVariables.set, collectionVariables.get" 
 contextual_links:
   - type: section
     name: "Prerequisites"

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -17,6 +17,7 @@ const pageQuery = `{
       node {
         frontmatter {
           title
+          code_keyword
           contextual_links {
             type
             name


### PR DESCRIPTION
added a code_keyword to frontmatter in docs yml file. That way we can capture terms from within <code> and <pre> tags that we want to have indexed by Algolia