### PR TITLE
Update mock docs for API Dev 

### DIFF
--- a/src/pages/docs/postman/design-and-develop-apis/the-api-workflow.md
+++ b/src/pages/docs/postman/design-and-develop-apis/the-api-workflow.md
@@ -74,16 +74,20 @@ After adding a schema, you can develop your API by using version tagging to link
 This section describes the following topics:
 
 * [Adding a mock server](#adding-a-mock-server)
+
+    * [Creating new mock server](#creating-new-mock-server)
+
+    * [Adding existing mock server](#adding-existing-mock-server)
+
+    * [Editing a mock server](#editing-a-mock-server)
+
 * [Adding documentation](#adding-documentation)
+
 * [Adding an environment](#adding-an-environment)
 
 ### Adding a mock server
 
-You can link mock servers running on a collection to an API. From the **Develop** tab, you can either create a new mock server, add an existing mock server or edit a mock server. This section describes the following topics:
-
-* [Creating new mock server](#creating-new-mock-server)
-* [Adding existing mock server](#adding-existing-mock-server)
-* [Editing a mock server](#editing-a-mock-server)
+You can link mock servers running on a collection to an API. From the **Develop** tab, you can either create a new mock server, add an existing mock server, or edit a mock server. This section describes the following topics:
 
 #### Creating new mock server
 
@@ -119,26 +123,26 @@ To add a mock server to a specific version of your collection, refer to the sect
 
 #### Editing a mock server
 
-You can edit the mock servers that you have already added to your API. From the **Develop** tab, under the **Mock Servers** section, hover on the mock you want to edit and click on the pencil icon (circled in red below).
+You can edit existing mock servers by navigating to the **API** > **Develop** > **Mock Servers** Servers, then hovering on the mock you'd like to edit and selecting the pencil icon.
 
-[![api edit mock](https://user-images.githubusercontent.com/5029719/71182813-b7958d80-226e-11ea-9b39-90d07063b959.png)](https://user-images.githubusercontent.com/5029719/71182813-b7958d80-226e-11ea-9b39-90d07063b959.png)
+[![api edit mock](https://user-images.githubusercontent.com/5029719/71824950-9caa8200-3092-11ea-8871-09fd6d1706d4.png)](https://user-images.githubusercontent.com/5029719/71824950-9caa8200-3092-11ea-8871-09fd6d1706d4.png)
 
-This will open a webpage on the Postman Dashboard where you can edit the following parameters of your mock server (as shown in 1 on the image below):
+This will open a web page on the Postman Dashboard where you can edit the following parameters of your mock server:
 
 * the name of the mock server
 * the collection to mock
 * the version tag
 * the environment
 
-You can also make the mock server private by ticking the **Make this mock server private** box (as shown in 2 on the image below).
+You can also make the mock server private by ticking the **Make this mock server private** box.
 
-Click **Save changes** to save your changes or **Cancel** if you want to cancel (as shown in 3 on the image below).
+Click **Save changes** to save your changes or **Cancel** if you want to cancel.
 
 [![api edit mock web](https://user-images.githubusercontent.com/5029719/71361434-410cce80-2593-11ea-995d-68fdd27a282e.png)](https://user-images.githubusercontent.com/5029719/71361434-410cce80-2593-11ea-995d-68fdd27a282e.png)
 
-You can also copy the URL of your mock server directly to your clipboard by clicking on the **Copy URL** button (circled in red below).
+You can also copy the URL of your mock server directly to your clipboard by clicking **Copy URL**.
 
-[![api copy mock url](https://user-images.githubusercontent.com/5029719/71183172-64700a80-226f-11ea-98e0-bd3c0639e837.png)](https://user-images.githubusercontent.com/5029719/71183172-64700a80-226f-11ea-98e0-bd3c0639e837.png)
+[![api copy mock url](https://user-images.githubusercontent.com/5029719/71824877-6a008980-3092-11ea-9c61-f5f82ccd8ea1.png)](https://user-images.githubusercontent.com/5029719/71824877-6a008980-3092-11ea-9c61-f5f82ccd8ea1.png)
 
 ## Adding documentation
 

--- a/src/pages/docs/postman/design-and-develop-apis/the-api-workflow.md
+++ b/src/pages/docs/postman/design-and-develop-apis/the-api-workflow.md
@@ -79,10 +79,11 @@ This section describes the following topics:
 
 ### Adding a mock server
 
-You can link mock servers running on a collection to an API. From the **Develop** tab, you can either create a new mock server or add an existing mock server. This section describes the following two topics:
+You can link mock servers running on a collection to an API. From the **Develop** tab, you can either create a new mock server, add an existing mock server or edit a mock server. This section describes the following topics:
 
 * [Creating new mock server](#creating-new-mock-server)
 * [Adding existing mock server](#adding-existing-mock-server)
+* [Editing a mock server](#editing-a-mock-server)
 
 #### Creating new mock server
 
@@ -115,6 +116,29 @@ To understand how versioning influences mock servers, refer to the section
 [Versioning an API](/docs/postman/design-and-develop-apis/versioning-an-api/).
 
 To add a mock server to a specific version of your collection, refer to the section [Setting up a mock server](/docs/postman/mock-servers/setting-up-mock/)
+
+#### Editing a mock server
+
+You can edit the mock servers that you have already added to your API. From the **Develop** tab, under the **Mock Servers** section, hover on the mock you want to edit and click on the pencil icon (circled in red below).
+
+[![api edit mock](https://user-images.githubusercontent.com/5029719/71182813-b7958d80-226e-11ea-9b39-90d07063b959.png)](https://user-images.githubusercontent.com/5029719/71182813-b7958d80-226e-11ea-9b39-90d07063b959.png)
+
+This will open a webpage on the Postman Dashboard where you can edit the following parameters of your mock server (as shown in 1 on the image below):
+
+* the name of the mock server
+* the collection to mock
+* the version tag
+* the environment
+
+You can also make the mock server private by ticking the **Make this mock server private** box (as shown in 2 on the image below).
+
+Click **Save changes** to save your changes or **Cancel** if you want to cancel (as shown in 3 on the image below).
+
+[![api edit mock web](https://user-images.githubusercontent.com/5029719/71361434-410cce80-2593-11ea-995d-68fdd27a282e.png)](https://user-images.githubusercontent.com/5029719/71361434-410cce80-2593-11ea-995d-68fdd27a282e.png)
+
+You can also copy the URL of your mock server directly to your clipboard by clicking on the **Copy URL** button (circled in red below).
+
+[![api copy mock url](https://user-images.githubusercontent.com/5029719/71183172-64700a80-226f-11ea-98e0-bd3c0639e837.png)](https://user-images.githubusercontent.com/5029719/71183172-64700a80-226f-11ea-98e0-bd3c0639e837.png)
 
 ## Adding documentation
 

--- a/src/pages/docs/postman/mock-servers/setting-up-mock.md
+++ b/src/pages/docs/postman/mock-servers/setting-up-mock.md
@@ -100,7 +100,7 @@ In the **Next steps** tab, you will see a list of suggested next steps to maximi
 
 ### Mocking from the Launchpad
 
-The **Launchpad** tab appears by default when you launch Postman. Open the Postman app and under the **Start something new** section, select **View More** and then **Create a mock server**.
+**Launchpad** appears by default when you launch the Postman app. To create a mock server, open the Postman app, navigate to **Start something new** > **... View More** > **Create a mock server**.
 
 Follow the process [outlined in the New Button section](#mocking-from-the-new-button) to complete the mock server setup steps.
 
@@ -108,9 +108,9 @@ Follow the process [outlined in the New Button section](#mocking-from-the-new-bu
 
 ### Mocking from an API
 
-You can create a mock server from an existing API. Navigate to the API on which you want to add a mock server and switch to the **Develop** tab. On the new tab, select **Add Mock Server** on the right-hand side and choose between creating a new mock server or adding an existing one.
+You can create a mock server from an existing API. Navigate to the API you'd like to add a mock server to, then click **Develop**. Select **Add Mock Server**, then choose between creating a new mock server or adding an existing one.
 
-This will launch the **Create mock server** modal. Follow the process [outlined in the New Button section](#mocking-from-the-new-button) to complete the mock server setup steps.
+This will launch the **Create mock server** modal. Follow the process [outlined in the New button section](#mocking-from-the-new-button) to complete the mock server setup.
 
 ![Create mock from API Dev](https://user-images.githubusercontent.com/5029719/71178158-78167380-2265-11ea-908e-70199ea6a272.png)
 

--- a/src/pages/docs/postman/mock-servers/setting-up-mock.md
+++ b/src/pages/docs/postman/mock-servers/setting-up-mock.md
@@ -43,7 +43,8 @@ Mocks in Postman are tied to a collection. Postman matches requests and generate
 
 * [Creating mock servers in-app](#creating-mock-servers-in-app)
     * [Mocking from the New button](#mocking-from-the-new-button)
-    * [Mocking from the launch screen](#mocking-from-the-launch-screen)
+    * [Mocking from the Launchpad](#mocking-from-the-launchpad)
+    * [Mocking from an API](#mocking-from-an-api)
     * [Mocking from the Collections sidebar](#mocking-from-the-collections-sidebar)
     * [Mocking a request from History](#mocking-a-request-from-history)
     * [Mocking from Collections in Browse view](#mocking-from-collections-in-browse-view)
@@ -97,13 +98,21 @@ In the **Next steps** tab, you will see a list of suggested next steps to maximi
 
 ![Next steps after mock is created](https://assets.postman.com/postman-docs/mock-cnx-next-steps.png)
 
-### Mocking from the launch screen
+### Mocking from the Launchpad
 
-The **Create New** tab appears by default when you launch Postman. Open the Postman app and in the **Create New** tab, click **Mock Server**.
+The **Launchpad** tab appears by default when you launch Postman. Open the Postman app and under the **Start something new** section, select **View More** and then **Create a mock server**.
 
 Follow the process [outlined in the New Button section](#mocking-from-the-new-button) to complete the mock server setup steps.
 
-> At the bottom, you can select **Show this window at launch** to indicate whether you want the Create New tab to display each time you open Postman.
+> At the bottom, you can choose whether you want the Launchpad tab to display each time you open Postman by toggling the **Open Launchpad** option on or off.
+
+### Mocking from an API
+
+You can create a mock server from an existing API. Navigate to the API on which you want to add a mock server and switch to the **Develop** tab. On the new tab, select **Add Mock Server** on the right-hand side and choose between creating a new mock server or adding an existing one.
+
+This will launch the **Create mock server** modal. Follow the process [outlined in the New Button section](#mocking-from-the-new-button) to complete the mock server setup steps.
+
+![Create mock from API Dev](https://user-images.githubusercontent.com/5029719/71178158-78167380-2265-11ea-908e-70199ea6a272.png)
 
 ### Mocking from the Collections sidebar
 


### PR DESCRIPTION
Completes #1955 with the new flow of creating a Mock from the API section of the app. 

- Added a create Mock from API Dev in Setting up a Mock https://learning.getpostman.com/docs/postman/mock-servers/setting-up-mock/

- Added Actions on Mock servers in Developing an API https://learning.getpostman.com/docs/postman/design-and-develop-apis/the-api-workflow/#developing-an-api