### PR TITLE
Issue #2098

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -54,6 +54,18 @@ module.exports = {
       options: {
         plugins: [
           'gatsby-remark-autolink-headers',
+          {
+            resolve: 'gatsby-remark-embed-video',
+            options: {
+              width: 700,
+              ratio: 1.77, // Optional: Defaults to 16/9 = 1.77
+              height: 400, // Optional: Overrides optional.ratio
+              // Optional: Will remove related videos from the end of an embedded YouTube video.
+              related: false,
+              noIframeBorder: true, // Optional: Disable insertion of <style> border: 0
+            },
+          },
+          'gatsby-remark-responsive-iframe',
         ],
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10602,6 +10602,64 @@
         "unist-util-visit": "^1.4.1"
       }
     },
+    "gatsby-remark-embed-video": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-embed-video/-/gatsby-remark-embed-video-2.0.1.tgz",
+      "integrity": "sha512-V+cW4Ev+iXb0jmqfqKpcdPRn9vsKahIdj9sAUj26Ox4rooknWCjhayBdxT51BM2u7P2u3ck3Ty96PnqW7e/Mog==",
+      "requires": {
+        "get-video-id": "^3.1.4",
+        "remark-burger": "^1.0.1",
+        "unist-util-visit": "^2.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.1.tgz",
+          "integrity": "sha512-7NYjErP4LJtkEptPR22wO5RsCPnHZZrop7t2SoQzjvpFedCFer4WW8ujj9GI5DkUX7yVcffXLjoURf6h2QUv6Q=="
+        },
+        "unist-util-visit": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.1.tgz",
+          "integrity": "sha512-bEDa5S/O8WRDeI1mLaMoKuFFi89AjF+UAoMNxO+bbVdo06q+53Vhq4iiv1PenL6Rx1ZxIpXIzqZoc5HD2I1oMA==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0",
+            "unist-util-visit-parents": "^3.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.1.tgz",
+          "integrity": "sha512-umEOTkm6/y1gIqPrqet55mYqlvGXCia/v1FSc5AveLAI7jFmOAIbqiwcHcviLcusAkEQt1bq2hixCKO9ltMb2Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0"
+          }
+        }
+      }
+    },
+    "gatsby-remark-responsive-iframe": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-responsive-iframe/-/gatsby-remark-responsive-iframe-2.2.31.tgz",
+      "integrity": "sha512-cnL012seHTA/YxzrTrLt+0Ov2qrceEiT/z/uYN64ijOudmznSccbDminlBk5qQEfi8IhUb02MKTNjCxKXS83WA==",
+      "requires": {
+        "@babel/runtime": "^7.7.6",
+        "cheerio": "^1.0.0-rc.3",
+        "common-tags": "^1.8.0",
+        "lodash": "^4.17.15",
+        "unist-util-visit": "^1.4.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
+          "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
     "gatsby-source-filesystem": {
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.26.tgz",
@@ -11009,6 +11067,11 @@
         "npm-conf": "^1.1.0"
       }
     },
+    "get-src": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-src/-/get-src-1.0.1.tgz",
+      "integrity": "sha1-yhHb5Kk8fzqoXOyV/LCy36qVOe4="
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -11023,6 +11086,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "get-video-id": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-3.1.4.tgz",
+      "integrity": "sha512-XOZ60NZ60ozTtoWtPPpA3TC9JgDXgcd5nTfYwjBhZWAx3w48HRq6EqKp2bUJ/3F+BWgiMMHg4IkQ+acO6LxfMQ==",
+      "requires": {
+        "get-src": "^1.0.1"
+      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -18204,6 +18275,11 @@
           }
         }
       }
+    },
+    "remark-burger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/remark-burger/-/remark-burger-1.0.1.tgz",
+      "integrity": "sha512-F91SyEzat4hBkWsWElHIvMcCQuWoSeZXTuR4DmLvhUIjYkzzVLaX6GRxhkiDrZb/9asvTrYzwEr9HvxN1tqs9Q=="
     },
     "remark-parse": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "gatsby-plugin-sitemap": "^2.2.16",
     "gatsby-plugin-typography": "^2.3.8",
     "gatsby-remark-autolink-headers": "^2.1.11",
+    "gatsby-remark-embed-video": "^2.0.1",
+    "gatsby-remark-responsive-iframe": "^2.2.31",
     "gatsby-source-filesystem": "^2.1.26",
     "gatsby-transformer-remark": "^2.6.24",
     "gatsby-transformer-sharp": "^2.2.16",

--- a/src/components/LeftNav/__snapshots__/LeftNav.spec.jsx.snap
+++ b/src/components/LeftNav/__snapshots__/LeftNav.spec.jsx.snap
@@ -16,6 +16,7 @@ exports[`ContextualLinks renders correctly 1`] = `
       <img
         alt=""
         className="caret"
+        onClick={[Function]}
         src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3IiBoZWlnaHQ9IjQiIHZpZXdCb3g9IjAgMCA3IDQiPgogICAgPHBhdGggZmlsbD0iIzI4MjgyOCIgZmlsbC1vcGFjaXR5PSIuOCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNyAwTDMuNSA0IDAgMHoiLz4KPC9zdmc+Cg=="
       />
       <button
@@ -38,6 +39,7 @@ exports[`ContextualLinks renders correctly 1`] = `
         <img
           alt=""
           className="caret"
+          onClick={[Function]}
           src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3IiBoZWlnaHQ9IjQiIHZpZXdCb3g9IjAgMCA3IDQiPgogICAgPHBhdGggZmlsbD0iIzI4MjgyOCIgZmlsbC1vcGFjaXR5PSIuOCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNyAwTDMuNSA0IDAgMHoiLz4KPC9zdmc+Cg=="
         />
         <button
@@ -72,6 +74,7 @@ exports[`ContextualLinks renders correctly 1`] = `
           <img
             alt=""
             className="caret"
+            onClick={[Function]}
             src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3IiBoZWlnaHQ9IjQiIHZpZXdCb3g9IjAgMCA3IDQiPgogICAgPHBhdGggZmlsbD0iIzI4MjgyOCIgZmlsbC1vcGFjaXR5PSIuOCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNyAwTDMuNSA0IDAgMHoiLz4KPC9zdmc+Cg=="
           />
           <button
@@ -108,6 +111,7 @@ exports[`ContextualLinks renders correctly 1`] = `
         <img
           alt=""
           className="caret"
+          onClick={[Function]}
           src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3IiBoZWlnaHQ9IjQiIHZpZXdCb3g9IjAgMCA3IDQiPgogICAgPHBhdGggZmlsbD0iIzI4MjgyOCIgZmlsbC1vcGFjaXR5PSIuOCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNyAwTDMuNSA0IDAgMHoiLz4KPC9zdmc+Cg=="
         />
         <button

--- a/src/pages/docs/postman/sending-api-requests/visualizer.md
+++ b/src/pages/docs/postman/sending-api-requests/visualizer.md
@@ -165,6 +165,7 @@ You can debug a visualization in Postman by right-clicking in the __Visualize__ 
 
 ## Next steps
 
-The [visualizer demo video](https://www.youtube.com/watch?v=Qj7j3QsY2ok) walks through the process of building visualizations in Postman.
+The visualizer demo video walks through the process of building visualizations in Postman.
+`video: https://www.youtube.com/watch?v=i1jU-kivApg`
 
 You can try experimenting with visualizations using the collections [listed above](#try-it-out) as a starting point and tweak the code to get the results you need for your own data. For more on how Postman provides access to your response data inside scripts, check out the [Test Examples](/docs/postman/scripts/test-examples/).

--- a/src/pages/docs/postman/sending-api-requests/visualizer.md
+++ b/src/pages/docs/postman/sending-api-requests/visualizer.md
@@ -54,6 +54,8 @@ Visualizers let you present your response data in ways that help to make sense o
 
 ## Visualizing response data
 
+`video: https://www.youtube.com/watch?v=i1jU-kivApg`
+
 To visualize your response data, add code to the __Pre-request__ or __Tests__ [script](/docs/postman/scripts/intro_to_scripts/) for the request. The `pm.visualizer.set()` method will apply your visualizer code to the data and present it in the __Visualize__ tab when the request runs.
 
 ### Adding visualizer code
@@ -164,8 +166,5 @@ You can debug a visualization in Postman by right-clicking in the __Visualize__ 
 ![Debugging Visualizers in Postman](https://assets.postman.com/postman-docs/visualizer-debugging.gif)
 
 ## Next steps
-
-The visualizer demo video walks through the process of building visualizations in Postman.
-`video: https://www.youtube.com/watch?v=i1jU-kivApg`
 
 You can try experimenting with visualizations using the collections [listed above](#try-it-out) as a starting point and tweak the code to get the results you need for your own data. For more on how Postman provides access to your response data inside scripts, check out the [Test Examples](/docs/postman/scripts/test-examples/).

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -24,7 +24,7 @@ export default ({ data }) => {
           </div>
           <div className="col-sm-10 col-md-6 doc-page">
             <div className="text-right">
-            <EditDoc className={'btn btn__small btn__secondary-light'} />
+              <EditDoc className={'btn btn__small btn__secondary-light'} />
             </div>
             <h1>{post.frontmatter.title}</h1>
             <span dangerouslySetInnerHTML={{ __html: post.html }} />


### PR DESCRIPTION
@SueSmith  Markdown does not support iFrames and therefore a Youtube video cannot be embedded with the iFrame code.

I included two Gatsby plugins: gatsby-remark-embed-video and gatsby-remark-responsive-iframe.

This allows very easy embedding in Markdown with this syntax: 

`video: <url to video>`

