### PR TITLE
Clarify prereqs for pm.cookies.jar usage

### DIFF
--- a/src/pages/docs/postman/scripts/postman-sandbox-api-reference.md
+++ b/src/pages/docs/postman/scripts/postman-sandbox-api-reference.md
@@ -286,6 +286,8 @@ The `cookies` object contains a list of cookies that are associated with the dom
 
 ### pm.cookies.jar
 
+To enable programmatic access via the methods below, the cookie `url` must be [whitelisted](/docs/postman/sending-api-requests/cookies/#whitelisting-domains-for-programmatic-access-of-cookies).
+
 * `pm.cookies.jar():Function → Object`
 
   Access the cookie jar object.


### PR DESCRIPTION
Describe the need to whitelist domains when using `pm.cookies.jar`. Prevents running into this unclear error (fixing this separately):

![image](https://user-images.githubusercontent.com/8490181/72472199-fa2c8600-3798-11ea-8f31-1ca9f3084b27.png)
