### PR TITLE
Add bgcolor to html table for dark mode support

### DIFF
--- a/src/pages/docs/postman/sending-api-requests/visualizer.md
+++ b/src/pages/docs/postman/sending-api-requests/visualizer.md
@@ -89,7 +89,7 @@ The visualizer code creates a Handlebars template to render a table displaying t
 
 ```js
 var template = `
-    <table>
+    <table bgcolor="#FFFFFF">
         <tr>
             <th>Name</th>
             <th>Email</th>


### PR DESCRIPTION
The table rendered in dark mode has poor contrast as the text and background are black in color.  

Hardcoding the `bgcolor` for the table will ensure proper contrast for the table.