### PR TITLE
Added release version for schema validation

### DIFF
--- a/src/pages/docs/postman/design-and-develop-apis/validating-elements-against-schema.md
+++ b/src/pages/docs/postman/design-and-develop-apis/validating-elements-against-schema.md
@@ -7,7 +7,7 @@ warning: false
 
 You can validate your API elements (documentation, tests, mock servers, or monitors) against the API schema. This helps keep your elements in sync with your API specification. If they do not match, you can see the list of issues that have been found in order to fix them.
 
-> This feature is only available for OpenAPI 3.0 at this time.
+> This feature is available from Postman 7.15.0 and for OpenAPI 3.0 schemas only at this time.
 
 This section outlines the following topics:
 

--- a/src/pages/docs/postman/sending-api-requests/validating-requests-against-schema.md
+++ b/src/pages/docs/postman/sending-api-requests/validating-requests-against-schema.md
@@ -7,7 +7,7 @@ warning: false
 
 Postman can validate your requests against a linked API schema. This helps keep your documentation, tests, and other linked resources in sync with your API specification. If a request doesn't conform to the schema, you can see a list of issues, and fix them as you go.
 
-> This feature is only available for OpenAPI 3.0 at this time.
+> This feature is available from Postman 7.15.0 and for OpenAPI 3.0 schemas only at this time.
 
 This section outlines the following topics:
 


### PR DESCRIPTION
Some users were surprised that nothing was happening when validating their schema/requests (https://github.com/postmanlabs/postman-app-support/issues/6614#issuecomment-580116252) so I've added the release version from which this is available in the documentation.

cc @dushyantchillale 