### PR TITLE
Updates to the importing and exporting collection runs

### DIFF
--- a/src/pages/docs/postman/collection-runs/sharing-a-collection-run.md
+++ b/src/pages/docs/postman/collection-runs/sharing-a-collection-run.md
@@ -16,8 +16,7 @@ contextual_links:
 
 warning: false
 ---
-You can share the run results for a collection
-, by [exporting them from the Collection Runner](#exporting-collection-runs) so that other people can [import them into Postman](#importing-a-run).
+You can share the run results for a collection, by [exporting them from the Collection Runner](#exporting-collection-runs) so that other people can [import them into Postman](#importing-a-run).
 
 ## Exporting collection runs
 

--- a/src/pages/docs/postman/collection-runs/sharing-a-collection-run.md
+++ b/src/pages/docs/postman/collection-runs/sharing-a-collection-run.md
@@ -1,5 +1,5 @@
 ---
-title: "Sharing a collection run"
+title: "Sharing collection runs"
 order: 116
 page_id: "sharing_a_collection_run"
 contextual_links:
@@ -9,13 +9,6 @@ contextual_links:
     name: "Intro to collection runs"
     url: "/docs/postman/collection-runs/intro-to-collection-runs/"
   - type: section
-    name: "Additional Resources"
-  - type: subtitle
-    name: "Case Studies"
-  - type: link
-    name: "Tyk"
-    url: "https://www.postman.com/case-studies/Tyk.pdf"
-  - type: section
     name: "Next Steps"
   - type: link
     name: "Intro to Workspaces"
@@ -23,36 +16,34 @@ contextual_links:
 
 warning: false
 ---
-To share a Collections run results, you can export them from the Collection Runner so that they can be imported into another users Postman application.
+You can share the run results for a collection
+, by [exporting them from the Collection Runner](#exporting-collection-runs) so that other people can [import them into Postman](#importing-a-run).
 
-This topic will describe how to [export](#exporting-single-or-multipe-collection-runs) and [import](#importing-a-run) a collection run.
+## Exporting collection runs
 
-## Exporting single or multiple collection runs
+To export a collection run, click __Runner__ and find the run you want to export in the __Recent Runs__ list. You will see the __Export run__ icon appear on hover—click it to download the run.
 
-To export a collection run, select the _Download_ icon. This will appear when you hover over a specific item in the _Recent Runs_ list.
+![Export Collection Run](https://assets.postman.com/postman-docs/export-collection-run.png)
 
-This will open an explorer window, you can then save the generated JSON file to a local file directory.
+Choose a location to save your downloaded collection run.
 
-[![export collection run](https://assets.postman.com/postman-docs/Collection_Run_Export.png)](https://assets.postman.com/postman-docs/Collection_Run_Export.png)
+You also can select a collection run from the __Recent Runs__ list and download it from there by clicking **Export Results** at the top.
 
-You also can select a collection run from the _Recent Runs_ list and click the **Export Results** button in the Runner's header. This will open an explorer window, you can then save the generated JSON file to a local file directory.
+![Export Collection Run](https://assets.postman.com/postman-docs/export-run-results.png)
 
-[![export results](https://assets.postman.com/postman-docs/Collection_Run_Export_Results.png)](https://assets.postman.com/postman-docs/Collection_Run_Export_Results.png)
+To export multiple collection run results from the __Recent Runs__ list, hold down the command or control key and select the items from the list that you want to export. Click the __Download__ icon in the menu bar at the top.
 
-To export multiple collections run results from the _Recent Runs_ list, hold down the command key and select the items from the list that you want to export. Select the _Download_ icon, this can be found on the right side of the _Recent Runs_ menu bar.
-
-This will open an explorer window, you can then save the generated .zip file of all the selected collection runs to a local file directory.
-
-[![export multiple results](https://assets.postman.com/postman-docs/Collection_Run_Export_Multiple_Results.png)](https://assets.postman.com/postman-docs/Collection_Run_Export_Multiple_Results.png)
+![Export Multiple Runs](https://assets.postman.com/postman-docs/export-multiple-runs.png)
 
 ## Importing a run
 
-To import a run, select the **Import Runs** button on the _Recent Runs_ menu bar. An explorer window will open, this can be used to navigate your local file directory and import either a JSON collection run file or a .zip file of multiple collections run results into Postman.
+To import a collection run, open the __Runner__ and click **Import Runs** at the top. Navigate your local file directory and import either a JSON collection run file or a .zip file containing multiple collection run results.
 
-[![import collection run](https://assets.postman.com/postman-docs/Collection_Run_Import_Results.png)](https://assets.postman.com/postman-docs/Collection_Run_Import_Results.png)
+![Import Collection Runs](https://assets.postman.com/postman-docs/import-collection-runs.png)
 
----
-For more information about collection runs, see:
+## Next steps
+
+For more information about collection runs, check out the following resources:
 
 * [Starting a collection run](/docs/postman/collection-runs/starting-a-collection-run/)
 * [Using environments in collection runs](/docs/postman/collection-runs/using-environments-in-collection-runs/)

--- a/src/pages/docs/postman/collection-runs/sharing-a-collection-run.md
+++ b/src/pages/docs/postman/collection-runs/sharing-a-collection-run.md
@@ -23,25 +23,31 @@ contextual_links:
 
 warning: false
 ---
-To share a Collection, you can export a collection run to recipients who can import it in their Postman app.
+To share a Collections run results, you can export them from the Collection Runner so that they can be imported into another users Postman application.
 
-This topic describes how to [export](#exporting-a-run) and [import](#importing-a-run) a collection run.
+This topic will describe how to [export](#exporting-single-or-multipe-collection-runs) and [import](#importing-a-run) a collection run.
 
-## Exporting a run
+## Exporting single or multiple collection runs
 
-To export a collection run, click the download icon that appears when you hover over a run.
+To export a collection run, select the _Download_ icon. This will appear when you hover over a specific item in the _Recent Runs_ list.
 
-You can then save the generated JSON file wherever you want.
+This will open an explorer window, you can then save the generated JSON file to a local file directory.
 
 [![export collection run](https://assets.postman.com/postman-docs/Collection_Run_Export.png)](https://assets.postman.com/postman-docs/Collection_Run_Export.png)
 
-You also can select a collection run and click the **Export Results** button in the Runner's header. Then save the generated JSON file wherever you want.
+You also can select a collection run from the _Recent Runs_ list and click the **Export Results** button in the Runner's header. This will open an explorer window, you can then save the generated JSON file to a local file directory.
 
 [![export results](https://assets.postman.com/postman-docs/Collection_Run_Export_Results.png)](https://assets.postman.com/postman-docs/Collection_Run_Export_Results.png)
 
+To export multiple collections run results from the _Recent Runs_ list, hold down the command key and select the items from the list that you want to export. Select the _Download_ icon, this can be found on the right side of the _Recent Runs_ menu bar.
+
+This will open an explorer window, you can then save the generated .zip file of all the selected collection runs to a local file directory.
+
+[![export multiple results](https://assets.postman.com/postman-docs/Collection_Run_Export_Multiple_Results.png)](https://assets.postman.com/postman-docs/Collection_Run_Export_Multiple_Results.png)
+
 ## Importing a run
 
-To import a run, click the orange **Import Test Run** button on the Runner's selection screen. This action opens an explorer you can use to navigate and import a JSON collection run.
+To import a run, select the **Import Runs** button on the _Recent Runs_ menu bar. An explorer window will open, this can be used to navigate your local file directory and import either a JSON collection run file or a .zip file of multiple collections run results into Postman.
 
 [![import collection run](https://assets.postman.com/postman-docs/Collection_Run_Import_Results.png)](https://assets.postman.com/postman-docs/Collection_Run_Import_Results.png)
 


### PR DESCRIPTION
Mainly copy changes and image updates (all attached) but also added additional information around exporting/imported multiple collections run results.

There's a broken image link on the page, this is for a new image of the multiple exports that would need to be uploaded before publishing.

![Export_Multiple_Results](https://user-images.githubusercontent.com/17089546/74863035-1ba70180-5345-11ea-9198-a9f80a1cec21.png)
![Export_Results](https://user-images.githubusercontent.com/17089546/74863043-1e095b80-5345-11ea-880c-d7c92b745ff1.png)
![Export_Single_Result](https://user-images.githubusercontent.com/17089546/74863046-1f3a8880-5345-11ea-8df3-65dfb7d80c05.png)
![Import_Runs](https://user-images.githubusercontent.com/17089546/74863047-206bb580-5345-11ea-8d34-e19fbfdf6f36.png)
