### PR TITLE
Update : Options --data [file] & --no-color + tips on --suppress-exit-code for CI/CD

### DIFF
--- a/src/pages/docs/postman/collection-runs/command-line-integration-with-newman.md
+++ b/src/pages/docs/postman/collection-runs/command-line-integration-with-newman.md
@@ -120,6 +120,7 @@ $ newman run -h
 | `-k`, `--insecure` | Disable strict ssl |
 | `-x`, `--suppress-exit-code` | Continue running tests even after a failure, but exit with `code=0` |
 | `--ignore-redirects` | Disable automatic following of `3XX` responses |
+| `--verbose` | Show detailed information of collection run and each request sent |
 
 Use the ``-n`` option to set the number of iterations to run the collection.
 
@@ -161,6 +162,8 @@ http://postman-echo.com, 2, 2, 899899
 Newman, by default, exits with a status code of 0 if everything runs well, such as without any exceptions.
 
 Continuous integration tools respond to these exit codes and correspondingly pass or fail a build.
+
+You can use `-x` or `--suppress-exit-code` to override the exit code and have newman exit with a status code of 0, event if tests fails.
 
 You can use the `--bail` flag to tell Newman to halt on a test case error with a status code of 1, which can then be picked up by a CI tool or build system.
 

--- a/src/pages/docs/postman/collection-runs/command-line-integration-with-newman.md
+++ b/src/pages/docs/postman/collection-runs/command-line-integration-with-newman.md
@@ -99,7 +99,7 @@ $ newman run -h
 |:--|:--|
 | `--folder [folderName]` | Specify a single folder to run from a collection. |
 | `-e`, `--environment [file|URL]` | Specify a Postman environment as a JSON [file] |
-| `-d`, `--data [file]` | Specify a data file to use either json or csv |
+| `-d`, `--iteration-data [file]` | Specify a data file to use either json or csv |
 | `-g`, `--globals [file]` | Specify a Postman globals file as JSON [file] |
 | `-n`, `--iteration-count [number]` | Define the number of iterations to run |
 

--- a/src/pages/docs/postman/collection-runs/command-line-integration-with-newman.md
+++ b/src/pages/docs/postman/collection-runs/command-line-integration-with-newman.md
@@ -116,7 +116,7 @@ $ newman run -h
 |:--|:--|
 | `--bail` | Stops the runner when a test case fails |
 | `--silent` | Disable terminal output |
-| `--no-color` | Disable colored output |
+| `--color off` | Disable colored output (auto|on|off) (default: "auto")|
 | `-k`, `--insecure` | Disable strict ssl |
 | `-x`, `--suppress-exit-code` | Continue running tests even after a failure, but exit with `code=0` |
 | `--ignore-redirects` | Disable automatic following of `3XX` responses |


### PR DESCRIPTION
The `--data` option doesn't exist (newman --version : 4.5.7)

```bash
$ newman run mycollection.json --data data.json
error: unknown option '--data'
```

Works well with `--iteration-data` as specified in the help of newman :
```
$ newman run --help |grep "data file"
  -d, --iteration-data <path>     Specify a data file to use for iterations (either json or csv).
```