### PR TITLE
[2277] updated case study URLs, and added new ones

### DIFF
--- a/src/pages/docs/postman-for-publishers/run-in-postman/creating-run-button.md
+++ b/src/pages/docs/postman-for-publishers/run-in-postman/creating-run-button.md
@@ -15,7 +15,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Intuit"
-    url: "https://www.postman.com/case-studies/Intuit.pdf"
+    url: "https://www.postman.com/resources/case-studies/intuit/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/postman-for-publishers/run-in-postman/environments-run-button.md
+++ b/src/pages/docs/postman-for-publishers/run-in-postman/environments-run-button.md
@@ -18,7 +18,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Sikka"
-    url: "https://www.postman.com/case-studies/Sikka.pdf"
+    url: "https://www.postman.com/resources/case-studies/sikka/"
   - type: section
     name: "Next Steps"
   - type: link

--- a/src/pages/docs/postman/api-documentation/documenting-your-api.md
+++ b/src/pages/docs/postman/api-documentation/documenting-your-api.md
@@ -13,8 +13,11 @@ contextual_links:
   - type: subtitle
     name: "Case Studies"
   - type: link
-    name: "HarperDB"
-    url: "https://www.postman.com/case-studies/harperDB.pdf"
+    name: "Cisco DevNet"
+    url: "https://www.postman.com/resources/case-studies/cisco-devnet/"
+  - type: link
+    name: "Imgur"
+    url: "https://www.postman.com/resources/case-studies/imgur/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/postman/api-documentation/viewing-documentation.md
+++ b/src/pages/docs/postman/api-documentation/viewing-documentation.md
@@ -14,7 +14,10 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Cisco DevNet"
-    url: "https://www.postman.com/case-studies/CiscoDevNet.pdf"
+    url: "https://www.postman.com/resources/case-studies/cisco-devnet/"
+  - type: link
+    name: "Imgur"
+    url: "https://www.postman.com/resources/case-studies/imgur/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/postman/collection-runs/integration-with-jenkins.md
+++ b/src/pages/docs/postman/collection-runs/integration-with-jenkins.md
@@ -14,7 +14,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Sikka"
-    url: "https://www.postman.com/case-studies/Sikka.pdf"
+    url: "https://www.postman.com/resources/case-studies/sikka/"
   - type: subtitle
     name: "Related Blog Posts"
   - type: link

--- a/src/pages/docs/postman/collection-runs/integration-with-travis.md
+++ b/src/pages/docs/postman/collection-runs/integration-with-travis.md
@@ -14,7 +14,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Sikka"
-    url: "https://www.postman.com/case-studies/Sikka.pdf"
+    url: "https://www.postman.com/resources/case-studies/sikka/"
   - type: subtitle
     name: "Related Blog Posts"
   - type: link

--- a/src/pages/docs/postman/collections/creating-collections.md
+++ b/src/pages/docs/postman/collections/creating-collections.md
@@ -13,11 +13,11 @@ contextual_links:
   - type: subtitle
     name: "Case Studies"
   - type: link
-    name: "Raygun"
-    url: "https://www.postman.com/case-studies/raygun.pdf"
+    name: "AMC Theatres"
+    url: "https://www.postman.com/resources/case-studies/amc-theatres/"
   - type: link
     name: "BetterCloud"
-    url: "https://www.postman.com/case-studies/BetterCloud.pdf"
+    url: "https://www.postman.com/resources/case-studies/bettercloud/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/postman/collections/intro-to-collections.md
+++ b/src/pages/docs/postman/collections/intro-to-collections.md
@@ -13,11 +13,11 @@ contextual_links:
   - type: subtitle
     name: "Case Studies"
   - type: link
-    name: "Raygun"
-    url: "https://www.postman.com/case-studies/raygun.pdf"
+    name: "AMC Theatres"
+    url: "https://www.postman.com/resources/case-studies/amc-theatres/"
   - type: link
-    name: "BetterCloud"
-    url: "https://www.postman.com/case-studies/BetterCloud.pdf"
+    name: "iQmetrix"
+    url: "https://www.postman.com/resources/case-studies/iqmetrix/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/postman/mock-servers/intro-to-mock-servers.md
+++ b/src/pages/docs/postman/mock-servers/intro-to-mock-servers.md
@@ -4,6 +4,33 @@ order: 141
 page_id: "intro_to_mock_servers"
 search_keyword: "x-api-key"
 warning: false
+contextual_links:
+  - type: section
+    name: "Prerequisites"
+  - type: link
+    name: "Requests"
+    url: "/docs/postman/sending-api-requests/requests/"
+  - type: link
+    name: "Intro to collections"
+    url: "/docs/postman/collections/intro-to-collections/"
+  - type: link
+    name: "Intro to the Postman API"
+    url: "/docs/postman/postman-api/intro-api/"
+  - type: section
+    name: "Additional Resources"
+  - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "Gear4Music"
+    url: "https://www.postman.com/resources/case-studies/gear4music/"
+  - type: link
+    name: "Giant Machines"
+    url: "https://www.postman.com/resources/case-studies/giant-machines/"
+  - type: subtitle
+    name: "Related Blog Posts"
+  - type: link
+    name: "Mock responses in Postman by using Examples"
+    url: "https://blog.postman.com/2017/05/17/mock-responses-in-postman-by-using-examples/"
 ---
 
 ## What are mock servers

--- a/src/pages/docs/postman/mock-servers/mock-with-api.md
+++ b/src/pages/docs/postman/mock-servers/mock-with-api.md
@@ -18,6 +18,14 @@ contextual_links:
   - type: section
     name: "Additional Resources"
   - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "Gear4Music"
+    url: "https://www.postman.com/resources/case-studies/gear4music/"
+  - type: link
+    name: "Giant Machines"
+    url: "https://www.postman.com/resources/case-studies/giant-machines/"
+  - type: subtitle
     name: "Related Blog Posts"
   - type: link
     name: "Mock responses in Postman by using Examples"

--- a/src/pages/docs/postman/monitors/intro-monitors.md
+++ b/src/pages/docs/postman/monitors/intro-monitors.md
@@ -14,7 +14,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Monetary"
-    url: "https://www.postman.com/case-studies/monetary.pdf"
+    url: "https://www.postman.com/resources/case-studies/monetary/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/postman/monitors/viewing-monitor-results.md
+++ b/src/pages/docs/postman/monitors/viewing-monitor-results.md
@@ -14,7 +14,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Monetary"
-    url: "https://www.postman.com/case-studies/monetary.pdf"
+    url: "https://www.postman.com/resources/case-studies/monetary/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/postman/postman-api/continuous-integration.md
+++ b/src/pages/docs/postman/postman-api/continuous-integration.md
@@ -17,7 +17,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Sikka"
-    url: "https://www.postman.com/case-studies/Sikka.pdf"
+    url: "https://www.postman.com/resources/case-studies/sikka/"
   - type: subtitle
     name: "Related Blog Posts"
   - type: link

--- a/src/pages/docs/postman/scripts/intro-to-scripts.md
+++ b/src/pages/docs/postman/scripts/intro-to-scripts.md
@@ -15,6 +15,11 @@ contextual_links:
   - type: section
     name: "Additional Resources"
   - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "Giant Machines"
+    url: "https://www.postman.com/resources/case-studies/giant-machines/"
+  - type: subtitle
     name: "Related Blog Posts"
   - type: link
     name: "Keep it DRY with collection and folder elements"

--- a/src/pages/docs/postman/scripts/test-examples.md
+++ b/src/pages/docs/postman/scripts/test-examples.md
@@ -20,8 +20,8 @@ contextual_links:
     name: "Lucid"
     url: "https://www.postman.com/case-studies/Lucid.pdf"
   - type: link
-    name: "Movember"
-    url: "https://www.postman.com/case-studies/movember.pdf"
+    name: "Movember Foundation"
+    url: "https://www.postman.com/resources/case-studies/movember-foundation/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/postman/scripts/test-scripts.md
+++ b/src/pages/docs/postman/scripts/test-scripts.md
@@ -15,6 +15,11 @@ contextual_links:
   - type: section
     name: "Additional Resources"
   - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "iQmetrix"
+    url: "https://www.postman.com/resources/case-studies/iqmetrix/"
+  - type: subtitle
     name: "Videos"
   - type: link
     name: "Intro to Postman: Writing API tests"

--- a/src/pages/docs/postman/sending-api-requests/authorization.md
+++ b/src/pages/docs/postman/sending-api-requests/authorization.md
@@ -15,6 +15,11 @@ contextual_links:
   - type: section
     name: "Additional Resources"
   - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "Intuit"
+    url: "https://www.postman.com/resources/case-studies/intuit/"
+  - type: subtitle
     name: "Videos"
   - type: link
     name: "Intro to Postman: Authorizing a request"

--- a/src/pages/docs/postman/sending-api-requests/generate-code-snippets.md
+++ b/src/pages/docs/postman/sending-api-requests/generate-code-snippets.md
@@ -14,7 +14,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Intuit"
-    url: "https://www.postman.com/case-studies/Intuit.pdf"
+    url: "https://www.postman.com/resources/case-studies/intuit/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/postman/workspaces/creating-workspaces.md
+++ b/src/pages/docs/postman/workspaces/creating-workspaces.md
@@ -13,8 +13,8 @@ contextual_links:
   - type: subtitle
     name: "Case Studies"
   - type: link
-    name: "Movember"
-    url: "https://www.postman.com/case-studies/movember.pdf"
+    name: "Movember Foundation"
+    url: "https://www.postman.com/resources/case-studies/movember-foundation/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/postman/workspaces/using-workspaces.md
+++ b/src/pages/docs/postman/workspaces/using-workspaces.md
@@ -13,8 +13,11 @@ contextual_links:
   - type: subtitle
     name: "Case Studies"
   - type: link
-    name: "Coursera"
-    url: "https://www.postman.com/case-studies/Coursera.pdf"
+    name: "Gear4Music"
+    url: "https://www.postman.com/resources/case-studies/gear4music/"
+  - type: link
+    name: "Giant Machines"
+    url: "https://www.postman.com/resources/case-studies/giant-machines/"
   - type: subtitle
     name: "Videos"
   - type: link


### PR DESCRIPTION
This fixes #2277 

— updated 404 and 301 links to case studies
— added in links to new case studies
— added right sidebar to page where it was missing.