### PR TITLE
V3 migration for `exitCode` option

### DIFF
--- a/legacy-documentation/v5/postman/collection_runs/integration_with_jenkins.md
+++ b/legacy-documentation/v5/postman/collection_runs/integration_with_jenkins.md
@@ -54,10 +54,11 @@ Add a build step in the project. The build step executes a Shell command.
 The command is:
 
 ```bash
-$ newman jenkins_demo.postman_collection --exitCode 1
+$ newman run jenkins_demo.postman_collection --suppress-exit-code 1
 ```
 
-Note here that we are using the Newman command parameter “exitCode” with the value `1`. This denotes that Newman is going to exit with this code that will tell Jenkins that everything did not go well.
+Note here that we are using the Newman command parameter “suppress-exit-code” with the value `1`. This denotes that Newman is going to exit with this code that will tell Jenkins that everything did not go well.
+By default newman forces an exit code of 0
 
 Click the **Save** button to finish creating the project.
 

--- a/legacy-documentation/v5/postman/collection_runs/integration_with_jenkins.md
+++ b/legacy-documentation/v5/postman/collection_runs/integration_with_jenkins.md
@@ -58,7 +58,6 @@ $ newman run jenkins_demo.postman_collection --suppress-exit-code 1
 ```
 
 Note here that we are using the Newman command parameter “suppress-exit-code” with the value `1`. This denotes that Newman is going to exit with this code that will tell Jenkins that everything did not go well.
-By default newman forces an exit code of 0
 
 Click the **Save** button to finish creating the project.
 

--- a/src/pages/docs/postman/collection-runs/integration-with-jenkins.md
+++ b/src/pages/docs/postman/collection-runs/integration-with-jenkins.md
@@ -95,7 +95,7 @@ $ newman run jenkins_demo.postman_collection --suppress-exit-code 1
 ```
 
 Note here that the Newman command parameter ”suppress-exit-code” uses the value `1`. This denotes that Newman is going to exit with this code that will tell Jenkins that everything did not go well.
-By default newman forces an exit code of 0
+
 
 Click the **Save** button to finish creating the project.
 

--- a/src/pages/docs/postman/collection-runs/integration-with-jenkins.md
+++ b/src/pages/docs/postman/collection-runs/integration-with-jenkins.md
@@ -91,10 +91,11 @@ Add a build step in the project. The build step executes a Shell command.
 Here is the command:
 
 ```bash
-$ newman jenkins_demo.postman_collection --exitCode 1
+$ newman run jenkins_demo.postman_collection --suppress-exit-code 1
 ```
 
-Note here that the Newman command parameter “exitCode” uses the value `1`. This denotes that Newman is going to exit with this code that will tell Jenkins that everything did not go well.
+Note here that the Newman command parameter ”suppress-exit-code” uses the value `1`. This denotes that Newman is going to exit with this code that will tell Jenkins that everything did not go well.
+By default newman forces an exit code of 0
 
 Click the **Save** button to finish creating the project.
 

--- a/src/pages/docs/postman/collection-runs/integration-with-jenkins.md
+++ b/src/pages/docs/postman/collection-runs/integration-with-jenkins.md
@@ -96,7 +96,6 @@ $ newman run jenkins_demo.postman_collection --suppress-exit-code 1
 
 Note here that the Newman command parameter ”suppress-exit-code” uses the value `1`. This denotes that Newman is going to exit with this code that will tell Jenkins that everything did not go well.
 
-
 Click the **Save** button to finish creating the project.
 
 [![source code management](https://assets.postman.com/postman-docs/integrating_with_jenkins_6.png)](https://assets.postman.com/postman-docs/integrating_with_jenkins_6.png)


### PR DESCRIPTION
closes #1985 
- Replaces --exitCode with --supress-exit-code
- Adds missing run keyword to the example
Shown below:
![image](https://user-images.githubusercontent.com/41543649/78170284-5c2f8a00-7470-11ea-8cfc-984fae6b56fc.png)
