### PR TITLE
Added info for api builder tour

### DIFF
--- a/src/pages/docs/postman/design-and-develop-apis/the-api-workflow.md
+++ b/src/pages/docs/postman/design-and-develop-apis/the-api-workflow.md
@@ -49,6 +49,8 @@ You can connect various components of your API development and testing process t
 
 To access the API Builder, open __APIs__ from the left sidebar in the Postman app. You can open and edit any existing APIs from here—Postman will automatically open the most recent version of an API by default.
 
+> If it is your first time using the API Builder, you can take a tour of its features by clicking `Start` from the `API` tab or from the `Create new API` modal.
+
 <img alt="Create API" src="https://assets.postman.com/postman-docs/create-new-api-v7.png" width="250px"/>
 
 Click __Create an API__ or __+ New API__—_you will need to be signed into your Postman account_.

--- a/src/pages/docs/postman/design-and-develop-apis/the-api-workflow.md
+++ b/src/pages/docs/postman/design-and-develop-apis/the-api-workflow.md
@@ -49,7 +49,7 @@ You can connect various components of your API development and testing process t
 
 To access the API Builder, open __APIs__ from the left sidebar in the Postman app. You can open and edit any existing APIs from here—Postman will automatically open the most recent version of an API by default.
 
-> If it is your first time using the API Builder, you can take a tour of its features by clicking `Start` from the `API` tab or from the `Create new API` modal.
+> If it is your first time using the API Builder, you can take a tour of its features by clicking **Start** from the **API** tab or from the **Create new API** modal.
 
 <img alt="Create API" src="https://assets.postman.com/postman-docs/create-new-api-v7.png" width="250px"/>
 


### PR DESCRIPTION
So... I know I've asked before whether this should be in the docs but this isn't quite a bootcamp lesson (can't be triggered from there, and its purpose is to show features rather than teach a skill) therefore I added a little note about the tour at the top of the api worflow page. Hope that works. 😬  