### PR TITLE
added precision for dynamic variables

### DIFF
--- a/src/pages/docs/postman/variables-and-environments/variables-list.md
+++ b/src/pages/docs/postman/variables-and-environments/variables-list.md
@@ -8,6 +8,8 @@ warning: false
 
 The following is a list of dynamic variables whose values are randomly generated during the request/collection run.
 
+> Dynamic variables can't be used in pre-request or test scripts.
+
 ### Common
 
 | **Variable Name**         | **Description**                               | **Examples**                               |

--- a/src/pages/docs/postman/variables-and-environments/variables-list.md
+++ b/src/pages/docs/postman/variables-and-environments/variables-list.md
@@ -8,7 +8,7 @@ warning: false
 
 The following is a list of dynamic variables whose values are randomly generated during the request/collection run.
 
-> Dynamic variables can't be used in pre-request or test scripts.
+> To use dynamic variables in pre-request or test scripts, you need to use `pm.variables.replaceIn()`, e.g. `pm.variables.replaceIn('{{$randomFirstName}}')`.
 
 ### Common
 

--- a/src/pages/docs/postman/variables-and-environments/variables.md
+++ b/src/pages/docs/postman/variables-and-environments/variables.md
@@ -345,7 +345,7 @@ Examples of dynamic variables are as follows:
 
 See the [Dynamic Variables](/docs/postman/variables-and-environments/variables-list/) section for a full list.
 
-> Dynamic variables can't be used in pre-request or test scripts.
+> To use dynamic variables in pre-request or test scripts, you need to use `pm.variables.replaceIn()`, e.g. `pm.variables.replaceIn('{{$randomFirstName}}')`.
 
 ![Dynamic Variable](https://assets.postman.com/postman-docs/dynamic-var.jpg)
 

--- a/src/pages/docs/postman/variables-and-environments/variables.md
+++ b/src/pages/docs/postman/variables-and-environments/variables.md
@@ -345,6 +345,8 @@ Examples of dynamic variables are as follows:
 
 See the [Dynamic Variables](/docs/postman/variables-and-environments/variables-list/) section for a full list.
 
+> Dynamic variables can't be used in pre-request or test scripts.
+
 ![Dynamic Variable](https://assets.postman.com/postman-docs/dynamic-var.jpg)
 
 ## Next steps


### PR DESCRIPTION
There's a few github issues/topics on discourse (https://github.com/postmanlabs/postman-app-support/issues/7868#issuecomment-608340391, https://github.com/postmanlabs/postman-app-support/issues/886, https://community.postman.com/t/using-dynamic-variable-values-in-tests/959) around being able to use dynamic variables from the pre-request or test scripts so I thought we could add that as a note to the docs to make it clearer. 