### PR TITLE
Viewing monitor results

### DIFF
--- a/src/pages/docs/postman/monitors/intro-monitors.md
+++ b/src/pages/docs/postman/monitors/intro-monitors.md
@@ -67,8 +67,6 @@ Postman Monitoring helps you to stay up to date on the health and performance of
 
     * [Accessible APIs](#accessible-apis)
 
-* [Monitor dashboard](#monitor-dashboard)
-
 * [Next steps](#next-steps)
 
 ## What is monitoring?

--- a/src/pages/docs/postman/monitors/intro-monitors.md
+++ b/src/pages/docs/postman/monitors/intro-monitors.md
@@ -166,16 +166,6 @@ There are a few differences between running collections in a Postman monitor and
 
 * Monitors require all URLs to be publicly available on the internet as they run in the Postman cloud. A monitor cannot directly access your localhost or run requests behind a firewall. However, to overcome this issue, static IPs are available on [Postman Business and Enterprise plans](https://www.postman.com/pricing).
 
-## Monitor dashboard
-
-Each workspace has its own monitor dashboard, which you can navigate to by visiting your [web dashboard](https://go.postman.co/), selecting a workspace > **Monitors**.
-
-This dashboard provides a high-level overview of the monitors you have available in your workspace, including status, success rate, and average response time.
-
-[![monitoring dashboard](https://assets.postman.com/postman-docs/monitor-dashboard1.jpg)](https://assets.postman.com/postman-docs/monitor-dashboard.jpg)
-
-Hovering over a monitor in the list allows you to run it outside of its predetermined schedule by clicking **▶**. To pause, resume, edit, and delete monitors, select the **...** icon.
-
 ## Next steps
 
 Learn how to [set up a monitor](/docs/postman/monitors/setting-up-monitor/) and check out [monitoring APIs and websites](/docs/postman/monitors/monitoring-apis-websites/) to get started.

--- a/src/pages/docs/postman/monitors/setting-up-monitor.md
+++ b/src/pages/docs/postman/monitors/setting-up-monitor.md
@@ -149,7 +149,7 @@ You can find detailed information on your monitor results by navigating to your 
 
 ### Using retry on failure
 
-You have the option to **Retry if run fails**. If this is enabled and a failure occurs during a run, Postman will automatically re-run the failed request to avoid false alarms due to transient issues. Postman will still log the initial failure, but will only notify you if the run continues to fail.
+You have the option to **Retry if run fails**. If this is enabled and a failure occurs during a run, Postman will automatically rerun the failed request to avoid false alarms due to transient issues. Postman will still log the initial failure, but will only notify you if the run continues to fail.
 
 > If you choose to enable this option, it will affect your monitoring usage and the resulting billing. For example, if a collection of three requests fails on the first request, but retries successfully, the run will count as four total requests.
 

--- a/src/pages/docs/postman/monitors/viewing-monitor-results.md
+++ b/src/pages/docs/postman/monitors/viewing-monitor-results.md
@@ -4,11 +4,6 @@ order: 163
 page_id: "viewing_monitor_results"
 contextual_links:
   - type: section
-    name: "Prerequisites"
-  - type: link
-    name: "Intro to monitors"
-    url: "/docs/postman/monitors/intro-monitors/"
-  - type: section
     name: "Additional Resources"
   - type: subtitle
     name: "Case Studies"
@@ -20,16 +15,6 @@ contextual_links:
   - type: link
     name: "API monitoring with Postman"
     url: "https://www.youtube.com/watch?v=3nOP_TYTuA8"
-  - type: subtitle
-    name: "Related Blog Posts"
-  - type: link
-    name: "\"Daily Mix\" with Postman Monitors and Spotify"
-    url: "https://blog.postman.com/2017/03/28/daily-mix-with-postman-monitors-and-spotify/"
-  - type: section
-    name: "Next Steps"
-  - type: link
-    name: "Intro to collection runs"
-    url: "/docs/postman/collection-runs/intro-to-collection-runs/"
 
 warning: false
 ---
@@ -60,7 +45,7 @@ Your Postman Dashboard allows you to track the health and performance of your AP
 
     * [Console log](#console-log)
 
-    * [Next steps](#next-steps)
+* [Next steps](#next-steps)
 
 ## Viewing monitors in the Dashboard
 

--- a/src/pages/docs/postman/monitors/viewing-monitor-results.md
+++ b/src/pages/docs/postman/monitors/viewing-monitor-results.md
@@ -41,6 +41,8 @@ Your Postman Dashboard allows you to track the health and performance of your AP
 
         * [Filtering by region](#filtering-by-region)
 
+        * [Filtering by formula](#filtering-by-formula)
+
     * [Test results](#test-results)
 
     * [Console log](#console-log)
@@ -109,6 +111,17 @@ You can filter by run result to compare how your runs with the same result have 
 #### Filtering by region
 
 You can filter by [region](/docs/postman/monitors/setting-up-monitor/#adding-regions) to compare how runs within different regions have varied. Click to open the drop-down menu **All Regions**, then select a region to view.
+
+#### Filtering by formula
+
+You can filter by mathematical formula to view the average, sum, minimum, and maximum response time for each run:
+
+* **Average**: The average of the total response time across all regions.
+* **Sum**: The sum of the response time across all regions.
+* **Minimum**: The minimum total response time for a run across all regions.
+* **Maximum**: The maximum total response time for a run across all regions.
+
+Click to open the drop-down menu **Average**, then select an option. To view the newly calculated response time value, you can hover over each run individually.
 
 ### Test results
 

--- a/src/pages/docs/postman/monitors/viewing-monitor-results.md
+++ b/src/pages/docs/postman/monitors/viewing-monitor-results.md
@@ -19,7 +19,7 @@ contextual_links:
 warning: false
 ---
 
-Your Postman Dashboard allows you to track the health and performance of your APIs. With the Dashboard, you can stay up to date on what's happening across multiple monitors, as well as dive into an individual monitor's performance over time.
+Your Postman Dashboard allows you to track the health and performance of your APIs. With the Dashboard, you can stay up to date on what's happening across all monitors in your workspace and dive into individual monitors to examine test results and performance over time.
 
 ## Contents
 
@@ -53,9 +53,9 @@ Each workspace has its own monitoring space within the Postman Dashboard, which 
 
 The Dashboard provides a high-level overview of the monitors you have available in your workspace, including status, average success rate, and average response time within the given timeframe.
 
-[![monitoring dashboard](https://assets.postman.com/postman-docs/monitor-dashboard1.jpg)](https://assets.postman.com/postman-docs/monitor-dashboard.jpg)
+[![monitoring dashboard](https://assets.postman.com/postman-docs/monitor-dashboard1.jpg)](https://assets.postman.com/postman-docs/monitor-dashboard1.jpg)
 
-A **Healthy** status indicates there were no failures in any of the runs during the specified timeframe. Failures will be noted here, as well changes in the average success rates and response times.
+A **Healthy** status indicates there were no failures in any of the runs during the specified timeframe. Failures will be noted here, as well as changes in the average success rates and response times.
 
 > Hovering over a monitor in the list allows you to run it outside of its predetermined schedule by clicking **▶**. To pause, resume, edit, and delete monitors, select the **...** icon.
 
@@ -67,19 +67,19 @@ You can view each monitor in more detail by selecting it from the Dashboard.
 
 You can use the **Monitor Summary** to see how your APIs have performed over time. Each monitor run is represented by a bar in the graph.
 
-The upper section charts your monitor's average response time for each run, while the lower section visualizes the percentage of failure for each run. To view the exact response time and failed percent, you can hover over each run individually.
+The upper section charts your monitor's average response time for each run, while the lower section visualizes the percentage of failed tests for each run across all regions. To view the exact response time and failed percent, you can hover over each run individually.
 
 [![monitor summary](https://assets.postman.com/postman-docs/individual-monitor.jpg)](https://assets.postman.com/postman-docs/individual-monitor.jpg)
 
 ### Request split
 
-You can use **Request Split** to see how the response time varies for all requests made in a given run. To break this down into individual requests, you'll want to utilize [Filters](#Filters).
+You can use **Request Split** to see how the response time varies for all requests made in a given run. To break this down into individual requests, you can utilize [Filters](#Filters).
 
 [![monitor summary](https://assets.postman.com/postman-docs/request-split.jpg)](https://assets.postman.com/postman-docs/request-split.jpg)
 
 ### Filters
 
-You can use filters to identify recurring patterns in your monitoring runs, by comparing requests, run types, results, and regions
+You can use filters to identify recurring patterns in your monitoring runs by selecting particular requests, run types, results, and regions.
 
 [![monitor filters](https://assets.postman.com/postman-docs/filter-example.gif)](https://assets.postman.com/postman-docs/filter-example.gif)
 
@@ -87,28 +87,28 @@ You can use filters to identify recurring patterns in your monitoring runs, by c
 
 #### Filtering by request
 
-You can filter by request to compare an individual request's response time in different runs. To do so, click to open the drop-down menu **All Requests** next to **Filter by**, then select your request.
+You can filter by request to compare an individual request's response time in different runs. Click to open the drop-down menu **All Requests** next to **Filter by**, then select your request.
 
 #### Filtering by type
 
-You can filter by run type to compare how the response time changes between manual runs, scheduled runs, and webhook runs. To do so, click to open the drop-down menu **Type: All**, then select the type of run you'd like to analyze further.
+You can filter by run type to compare how the response time changes between manual runs, scheduled runs, and webhook runs. Click to open the drop-down menu **Type: All**, then select the type of run you'd like to analyze further.
 
-> Manual runs are initiated in the Postman Dashboard. Scheduled runs are initiated by the schedule you set when creating or editing your monitor. Webhook runs are initiated by integrations you've created.
+> Manual runs are initiated in the Postman Dashboard or are triggered by the [Postman API](https://documenter.getpostman.com/view/631643/JsLs/?version=latest#5b277ca0-7114-e04e-f1f5-246fbbd6d973). Scheduled runs are initiated by the schedule you set when creating or editing your monitor. Webhook runs are initiated by integrations you've created.
 
 #### Filtering by run result
 
 Each run is labeled based on its result:
 
-* Successful: Your monitor completed the run with no issues and passed all tests.
-* Failure: Your monitor completed the run, however one or more tests failed.
-* Error: Your monitor was unable to complete its run due to an error. Errors are caused by Postman's network and are not a result of the monitor you've built. If you experience this, see [Postman's status page](https://status.postman.com/) or contact [Postman support](https://support.getpostman.com/).
-* Abort: Your monitor was unable to complete its run within the allotted five minutes, at which point it timed out.
+* **Successful**: Your monitor completed the run with no issues and passed all tests.
+* **Failure**: Your monitor completed the run, however one or more tests failed.
+* **Error**: Your monitor was unable to complete its run due to an error. An error can occur if there is a syntax error in the code you've written, a network error, or for various other reasons. If you encounter one, your [Console Log](#console-log) will help you identify what caused it.
+* **Abort**: Your monitor was unable to complete its run within the allotted five minutes, at which point it timed out.
 
-You can filter by run result to compare how your runs with the same result have differed. To do so, click to open the drop-down menu **Run result: All**, then select one or more types of run results to view.
+You can filter by run result to compare how your runs with the same result have differed. Click to open the drop-down menu **Run result: All**, then select one or more types of run results to view.
 
 #### Filtering by region
 
-You can filter by [region](/docs/postman/monitors/setting-up-monitor/#adding-regions) to compare how runs within different regions have varied. To do so, click to open the drop-down menu **All Regions**, then select a region to view.
+You can filter by [region](/docs/postman/monitors/setting-up-monitor/#adding-regions) to compare how runs within different regions have varied. Click to open the drop-down menu **All Regions**, then select a region to view.
 
 ### Test results
 
@@ -116,16 +116,20 @@ You can view **Test Results** below the monitor summary to find more detailed in
 
 [![test results](https://assets.postman.com/postman-docs/test-results-2.jpg)](https://assets.postman.com/postman-docs/test-results-2.jpg)
 
+> If your monitor is configured to run in multiple regions, you can view the test results for a particular region by selecting that region from the dropdown to the right of the **Test Results** tab.
+
 ### Console log
 
 You can view the **Console Log** below the monitor summary.
 
-This console logs in detail run events and 'console.log' statements that ran as part of your pre-request and test scripts. Run events include when Postman is preparing your run, running, rerunning ([if applicable](/docs/postman/monitors/setting-up-monitor/#using-retry-on-failure)), and the run result.
+This section logs monitor run details along with the [`console.log`](https://learning.postman.com/docs/postman/sending-api-requests/debugging-and-logs/) statements that run as part of your pre-request and test scripts. Run details specify the various stages of a monitor run such as preparing run, running, rerunning ([if applicable](/docs/postman/monitors/setting-up-monitor/#using-retry-on-failure)), and the run result, along with error and test failure information.
 
 [![console log](https://assets.postman.com/postman-docs/console-log-2.jpg)](https://assets.postman.com/postman-docs/console-log-2.jpg)
 
- You can use this console to both troubleshoot issues and learn more about an individual run's behavior.
+> If your monitor is configured to run in multiple regions, you can view the console logs for a particular region by selecting that region from the dropdown to the right of the **Console Log** tab.
+
+You can use this console to both troubleshoot issues and learn more about an individual run's behavior.
 
 ## Next steps
 
-Learn how to [troubleshoot your monitors](/docs/postman/monitors/troubleshooting-monitors/) and check out [Postman monitoring's FAQs](/docs/postman/monitors/faqs-monitors/).
+Learn how to [troubleshoot your monitors](/docs/postman/monitors/troubleshooting-monitors/) and check out [Postman monitoring FAQs](/docs/postman/monitors/faqs-monitors/).

--- a/src/pages/docs/postman/monitors/viewing-monitor-results.md
+++ b/src/pages/docs/postman/monitors/viewing-monitor-results.md
@@ -51,9 +51,9 @@ Your Postman Dashboard allows you to track the health and performance of your AP
         * [Filtering by request](#filtering-by-request)
 
         * [Filtering by type](#filtering-by-type)
-        
+
         * [Filtering by run result](#filtering-by-run-result)
-      
+
         * [Filtering by region](#filtering-by-region)
 
     * [Test results](#test-results)
@@ -80,7 +80,7 @@ You can view each monitor in more detail by selecting it from the Dashboard.
 
 ### Monitor summary
 
-You can use the **Monitor Summary** to see how your APIs have performed over time. Each monitor run is represented by a bar in the graph. 
+You can use the **Monitor Summary** to see how your APIs have performed over time. Each monitor run is represented by a bar in the graph.
 
 The upper section charts your monitor's average response time for each run, while the lower section visualizes the percentage of failure for each run. To view the exact response time and failed percent, you can hover over each run individually.
 
@@ -135,7 +135,7 @@ You can view **Test Results** below the monitor summary to find more detailed in
 
 You can view the **Console Log** below the monitor summary.
 
-This console logs in detail run events and 'console.log' statements that ran as part of your pre-request and test scripts. Run events include when Postman is preparing your run, running, rerunning ([if applicable](/docs/postman/monitors/setting-up-monitor/#using-retry-on-failure)), and the run result. 
+This console logs in detail run events and 'console.log' statements that ran as part of your pre-request and test scripts. Run events include when Postman is preparing your run, running, rerunning ([if applicable](/docs/postman/monitors/setting-up-monitor/#using-retry-on-failure)), and the run result.
 
 [![console log](https://assets.postman.com/postman-docs/console-log-2.jpg)](https://assets.postman.com/postman-docs/console-log-2.jpg)
 

--- a/src/pages/docs/postman/monitors/viewing-monitor-results.md
+++ b/src/pages/docs/postman/monitors/viewing-monitor-results.md
@@ -34,43 +34,113 @@ contextual_links:
 warning: false
 ---
 
-You can set up monitors to send daily or weekly emails with a summary for all your monitors. You can [turn off email notifications](/docs/postman/monitors/setting-up-monitor/) in the settings.
+Your Postman Dashboard allows you to track the health and performance of your APIs. With the Dashboard, you can stay up to date on what's happening across multiple monitors, as well as dive into an individual monitor's performance over time.
 
-In addition, you can receive important notifications (both [in-app](/docs/postman/notifications) and email) if a monitor fails.
+## Contents
 
-[![email summary of monitors](https://assets.postman.com/postman-docs/monitoring-email-results1.png)](https://assets.postman.com/postman-docs/monitoring-email-results1.png)
+* [Viewing monitors in the Dashboard](#viewing-monitors-in-the-dashboard)
 
-## Monitors page
+* [Viewing individual monitors](#viewing-individual-monitors)
 
-The [Monitors](https://monitor.getpostman.com/) page lists all your monitors (both team and private).
+    * [Monitor summary](#monitor-summary)
 
-[![monitors page](https://assets.postman.com/postman-docs/WS-monitoring-results-page-1.png)](https://assets.postman.com/postman-docs/WS-monitoring-results-page-1.png)
+    * [Request split](#request-split)
 
-You can click a monitor to view more details about its performance and troubleshooting, such as:
+    * [Filters](#filters)
 
-| **Status** | **Average success rate** | **Average response time** |
-| -----------| -------------------------| --------------------------|
-| The number of failed runs in the selected timeframe. A ‘Healthy’ status indicates there were no failures in any of the runs. | The percent of successful runs out of the total runs in the timeframe. A run is successful only when all the tests pass during that run. You can also see a change in this value compared to the previous time period. | The average response time of all the requests over all the runs in milliseconds. You can also see the percentage change from the previous time period. |
+        * [Filtering by request](#filtering-by-request)
 
-**Note:** All shared monitors are visible to team members, and shared monitors always inherit the permissions of the shared collection.
+        * [Filtering by type](#filtering-by-type)
+        
+        * [Filtering by run result](#filtering-by-run-result)
+      
+        * [Filtering by region](#filtering-by-region)
 
-## Monitor details page
+    * [Test results](#test-results)
 
-When you click a monitor, the Monitor Performance page appears. The main timeline shows all past runs of the monitor. Each bar signifies one run of the monitor.
+    * [Console log](#console-log)
 
-Red indicates failing tests. Blue indicates the total response time of all the requests over time.
+    * [Next steps](#next-steps)
 
-These visuals are a great way to measure performance improvements when you’ve made changes to your infrastructure.
+## Viewing monitors in the Dashboard
 
-[![monitor perf](https://assets.postman.com/postman-docs/WS-monitor-perf-page-1.png)](https://assets.postman.com/postman-docs/WS-monitor-perf-page-1.png)
+Each workspace has its own monitoring space within the Postman Dashboard, which you can navigate to by opening your [Dashboard](https://go.postman.co/) and selecting your workspace > **Monitors**. Monitors in team workspaces are visible to all members of the workspace.
 
-The results section shows request-level details: test results, response code, response time, and the response size. Additionally, you can filter by region if you set up [monitors in multiple regions](/docs/postman/monitors/intro-monitors/#monitoring-resources-in-multiple-regions).
+The Dashboard provides a high-level overview of the monitors you have available in your workspace, including status, average success rate, and average response time within the given timeframe.
 
-[![monitor perf](https://assets.postman.com/postman-docs/WS-monitor-results-1.png)](
-https://assets.postman.com/postman-docs/WS-monitor-results-1.png)
+[![monitoring dashboard](https://assets.postman.com/postman-docs/monitor-dashboard1.jpg)](https://assets.postman.com/postman-docs/monitor-dashboard.jpg)
 
-You can also view the log when you click the **Console Log** tab.
+A **Healthy** status indicates there were no failures in any of the runs during the specified timeframe. Failures will be noted here, as well changes in the average success rates and response times.
 
-[![view logs](https://assets.postman.com/postman-docs/59042622.png)](https://assets.postman.com/postman-docs/59042622.png)
+> Hovering over a monitor in the list allows you to run it outside of its predetermined schedule by clicking **▶**. To pause, resume, edit, and delete monitors, select the **...** icon.
 
-The console log prints a detailed log of run events and 'console.log' statements that ran as part of your pre-request and test scripts. You can use them to [diagnose failures](/docs/postman/monitors/troubleshooting-monitors).
+## Viewing individual monitors
+
+You can view each monitor in more detail by selecting it from the Dashboard.
+
+### Monitor summary
+
+You can use the **Monitor Summary** to see how your APIs have performed over time. Each monitor run is represented by a bar in the graph. 
+
+The upper section charts your monitor's average response time for each run, while the lower section visualizes the percentage of failure for each run. To view the exact response time and failed percent, you can hover over each run individually.
+
+[![monitor summary](https://assets.postman.com/postman-docs/individual-monitor.jpg)](https://assets.postman.com/postman-docs/individual-monitor.jpg)
+
+### Request split
+
+You can use **Request Split** to see how the response time varies for all requests made in a given run. To break this down into individual requests, you'll want to utilize [Filters](#Filters).
+
+[![monitor summary](https://assets.postman.com/postman-docs/request-split.jpg)](https://assets.postman.com/postman-docs/request-split.jpg)
+
+### Filters
+
+You can use filters to identify recurring patterns in your monitoring runs, by comparing requests, run types, results, and regions
+
+[![monitor filters](https://assets.postman.com/postman-docs/filter-example.gif)](https://assets.postman.com/postman-docs/filter-example.gif)
+
+> You can **Clear Filters** to return to your original dashboard view.
+
+#### Filtering by request
+
+You can filter by request to compare an individual request's response time in different runs. To do so, click to open the drop-down menu **All Requests** next to **Filter by**, then select your request.
+
+#### Filtering by type
+
+You can filter by run type to compare how the response time changes between manual runs, scheduled runs, and webhook runs. To do so, click to open the drop-down menu **Type: All**, then select the type of run you'd like to analyze further.
+
+> Manual runs are initiated in the Postman Dashboard. Scheduled runs are initiated by the schedule you set when creating or editing your monitor. Webhook runs are initiated by integrations you've created.
+
+#### Filtering by run result
+
+Each run is labeled based on its result:
+
+* Successful: Your monitor completed the run with no issues and passed all tests.
+* Failure: Your monitor completed the run, however one or more tests failed.
+* Error: Your monitor was unable to complete its run due to an error. Errors are caused by Postman's network and are not a result of the monitor you've built. If you experience this, see [Postman's status page](https://status.postman.com/) or contact [Postman support](https://support.getpostman.com/).
+* Abort: Your monitor was unable to complete its run within the allotted five minutes, at which point it timed out.
+
+You can filter by run result to compare how your runs with the same result have differed. To do so, click to open the drop-down menu **Run result: All**, then select one or more types of run results to view.
+
+#### Filtering by region
+
+You can filter by [region](/docs/postman/monitors/setting-up-monitor/#adding-regions) to compare how runs within different regions have varied. To do so, click to open the drop-down menu **All Regions**, then select a region to view.
+
+### Test results
+
+You can view **Test Results** below the monitor summary to find more detailed information on your tests, including which passed or failed, response codes, and response times.
+
+[![test results](https://assets.postman.com/postman-docs/test-results-2.jpg)](https://assets.postman.com/postman-docs/test-results-2.jpg)
+
+### Console log
+
+You can view the **Console Log** below the monitor summary.
+
+This console logs in detail run events and 'console.log' statements that ran as part of your pre-request and test scripts. Run events include when Postman is preparing your run, running, rerunning ([if applicable](/docs/postman/monitors/setting-up-monitor/#using-retry-on-failure)), and the run result. 
+
+[![console log](https://assets.postman.com/postman-docs/console-log-2.jpg)](https://assets.postman.com/postman-docs/console-log-2.jpg)
+
+ You can use this console to both troubleshoot issues and learn more about an individual run's behavior.
+
+## Next steps
+
+Learn how to [troubleshoot your monitors](/docs/postman/monitors/troubleshooting-monitors/) and check out [Postman monitoring's FAQs](/docs/postman/monitors/faqs-monitors/).

--- a/src/pages/docs/postman/monitors/viewing-monitor-results.md
+++ b/src/pages/docs/postman/monitors/viewing-monitor-results.md
@@ -69,7 +69,7 @@ You can view each monitor in more detail by selecting it from the Dashboard.
 
 You can use the **Monitor Summary** to see how your APIs have performed over time. Each monitor run is represented by a bar in the graph.
 
-The upper section charts your monitor's average response time for each run, while the lower section visualizes the percentage of failed tests for each run across all regions. To view the exact response time and failed percent, you can hover over each run individually.
+The upper section charts your monitor's average response time for each run, while the lower section visualizes the number of failed tests for each run across all regions. To view the exact response time and failed percent, you can hover over each run individually.
 
 [![monitor summary](https://assets.postman.com/postman-docs/individual-monitor.jpg)](https://assets.postman.com/postman-docs/individual-monitor.jpg)
 
@@ -81,7 +81,7 @@ You can use **Request Split** to see how the response time varies for all reques
 
 ### Filters
 
-You can use filters to identify recurring patterns in your monitoring runs by selecting particular requests, run types, results, and regions.
+You can use filters to identify recurring patterns in your monitoring runs by selecting particular requests, run types, results, and regions (if applicable).
 
 [![monitor filters](https://assets.postman.com/postman-docs/filter-example.gif)](https://assets.postman.com/postman-docs/filter-example.gif)
 
@@ -111,6 +111,8 @@ You can filter by run result to compare how your runs with the same result have 
 #### Filtering by region
 
 You can filter by [region](/docs/postman/monitors/setting-up-monitor/#adding-regions) to compare how runs within different regions have varied. Click to open the drop-down menu **All Regions**, then select a region to view.
+
+> This feature is only available if you selected multiple regions when you created or last edited your monitor. To learn more about regions, see [Adding regions](/docs/postman/monitors/setting-up-monitor/#adding-regions).
 
 #### Filtering by formula
 


### PR DESCRIPTION
This PR includes the revamped "Viewing monitor results" page (basically entirely rewritten). I moved the "Monitor dashboard" section to that page as I felt it made more sense to lead with that. I also updated for branded terms (see confluence). Lastly, noticed I had previously used "re-run" instead of "rerun" in "Setting up a monitor", so I fixed that.

Oh and my first gif! (let me know if it looks good, I couldn't get the 1px border to work @SueSmith)

@ArjunSingh-PM let me know if I'm missing anything or what pieces could be better worded, was working off of the notes from syncs we had a bit ago.