### PR TITLE
Feature/time traverse and failure notifications

### DIFF
--- a/src/pages/docs/postman/monitors/setting-up-monitor.md
+++ b/src/pages/docs/postman/monitors/setting-up-monitor.md
@@ -105,7 +105,7 @@ You can create a monitor with a POST request to the Postman API. Visit the [API 
 
 You will need to give your new monitor a name and designate the collection you would like it to run, as well as the version. You can also add an environment here if you would like your monitor to use one.
 
-[![create monitor](https://assets.postman.com/postman-docs/setting-up-a-monitor.jpg)](https://assets.postman.com/postman-docs/setting-up-a-monitor.jpg)
+![Create monitor page](https://assets.postman.com/postman-docs/create-monitor.jpg)
 
 > Postman maintains ceiling limits on various team and user actions, including monitor creation. For more information, see [Usage limits](/docs/postman/monitors/intro-monitors/#usage-limits).
 
@@ -139,9 +139,9 @@ You will receive daily and weekly summaries of your active monitors in the app a
 
 You can opt out of daily and/or weekly summaries by navigating to your [web dashboard](https://app.getpostman.com/), selecting your avatar in the upper-right corner, and clicking **Notification Preferences**.
 
-When creating a monitor, you can choose to receive email notifications for run failures and errors and define up to five recipients under **Show Additional Preferences**.
+When creating or editing a monitor, you can choose to receive email notifications for run failures and errors under **Show Additional Preferences**. You can define up to five recipients and the number of times you'd like to be notified of consecutive failures.
 
-> You'll be notified of run failures up to three consecutive times. After three, Postman will wait until your run succeeds to notify you.
+> Once the number of consecutive failures exceeds your defined notification limit, Postman will wait until your run succeeds to notify you.
 
 You can find detailed information on your monitor results by navigating to your [web dashboard](https://go.postman.co/), selecting a workspace > **Monitors**.
 

--- a/src/pages/docs/postman/monitors/setting-up-monitor.md
+++ b/src/pages/docs/postman/monitors/setting-up-monitor.md
@@ -105,7 +105,7 @@ You can create a monitor with a POST request to the Postman API. Visit the [API 
 
 You will need to give your new monitor a name and designate the collection you would like it to run, as well as the version. You can also add an environment here if you would like your monitor to use one.
 
-![Create monitor page](https://assets.postman.com/postman-docs/create-monitor.jpg)
+![Create monitor page](https://assets.postman.com/postman-docs/create-monitor-1.jpg)
 
 > Postman maintains ceiling limits on various team and user actions, including monitor creation. For more information, see [Usage limits](/docs/postman/monitors/intro-monitors/#usage-limits).
 
@@ -139,9 +139,9 @@ You will receive daily and weekly summaries of your active monitors in the app a
 
 You can opt out of daily and/or weekly summaries by navigating to your [web dashboard](https://app.getpostman.com/), selecting your avatar in the upper-right corner, and clicking **Notification Preferences**.
 
-When creating or editing a monitor, you can choose to receive email notifications for run failures and errors under **Show Additional Preferences**. You can define up to five recipients and the number of times you'd like to be notified of consecutive failures.
+When creating or editing a monitor, you can choose to receive email notifications for run failures and errors under **Show Additional Preferences**. You can define up to five recipients and configure when you would like to stop failure notifications for consecutive run failures.
 
-> Once the number of consecutive failures exceeds your defined notification limit, Postman will wait until your run succeeds to notify you.
+> Once the number of consecutive failures exceeds your defined notification limit, Postman will wait until your run succeeds to notify you. By default this limit is three.
 
 You can find detailed information on your monitor results by navigating to your [web dashboard](https://go.postman.co/), selecting a workspace > **Monitors**.
 

--- a/src/pages/docs/postman/monitors/viewing-monitor-results.md
+++ b/src/pages/docs/postman/monitors/viewing-monitor-results.md
@@ -43,6 +43,8 @@ Your Postman Dashboard allows you to track the health and performance of your AP
 
         * [Filtering by formula](#filtering-by-formula)
 
+    * [Time traverse](#time-traverse)
+    
     * [Test results](#test-results)
 
     * [Console log](#console-log)
@@ -71,13 +73,13 @@ You can use the **Monitor Summary** to see how your APIs have performed over tim
 
 The upper section charts your monitor's average response time for each run, while the lower section visualizes the number of failed tests for each run across all regions. To view the exact response time and failed percent, you can hover over each run individually.
 
-[![monitor summary](https://assets.postman.com/postman-docs/individual-monitor.jpg)](https://assets.postman.com/postman-docs/individual-monitor.jpg)
+![Monitor summary](https://assets.postman.com/postman-docs/monitor-summary-view.jpg)
 
 ### Request split
 
 You can use **Request Split** to see how the response time varies for all requests made in a given run. To break this down into individual requests, you can utilize [Filters](#Filters).
 
-[![monitor summary](https://assets.postman.com/postman-docs/request-split.jpg)](https://assets.postman.com/postman-docs/request-split.jpg)
+![Request split](https://assets.postman.com/postman-docs/request-split-view.jpg)
 
 ### Filters
 
@@ -124,6 +126,14 @@ You can filter by mathematical formula to view the average, sum, minimum, and ma
 * **Maximum**: The maximum total response time for a run across all regions.
 
 Click to open the drop-down menu **Average**, then select an option. To view the newly calculated response time value, you can hover over each run individually.
+
+### Time traverse
+
+You can navigate through past run results to review what happened at a particular point in time. To do so, click **Go to** in the upper-left corner of the monitor summary or request split graph. Select the time and date, then click **Apply** to be taken to a specific run.
+
+![Time traverse](https://assets.postman.com/postman-docs/time-traverse.jpg)
+
+> To revert the view to your most recent runs, select the time and date you defined in the upper-left corner of the graph, then click **Reset**.
 
 ### Test results
 

--- a/src/pages/docs/postman/monitors/viewing-monitor-results.md
+++ b/src/pages/docs/postman/monitors/viewing-monitor-results.md
@@ -129,7 +129,7 @@ Click to open the drop-down menu **Average**, then select an option. To view the
 
 ### Time traverse
 
-You can navigate through past run results to review what happened at a particular point in time. To do so, click **Go to** in the upper-left corner of the monitor summary or request split graph. Select the time and date, then click **Apply** to be taken to a specific run.
+You can navigate through past run results to review what happened at a particular point in time. To do so, click **Go to** in the upper-left corner of the monitor summary or request split graph. Select the time and date, then click **Apply** to view a specific run.
 
 ![Time traverse](https://assets.postman.com/postman-docs/time-traverse.jpg)
 

--- a/src/pages/docs/postman/monitors/viewing-monitor-results.md
+++ b/src/pages/docs/postman/monitors/viewing-monitor-results.md
@@ -44,7 +44,7 @@ Your Postman Dashboard allows you to track the health and performance of your AP
         * [Filtering by formula](#filtering-by-formula)
 
     * [Time traverse](#time-traverse)
-    
+
     * [Test results](#test-results)
 
     * [Console log](#console-log)


### PR DESCRIPTION
Docs for monitoring 1.4 release. Includes updated screenshots on setting up a monitor and viewing monitor results, as well as blurbs about configuring failure notifications and time traverse (assuming we're still calling it that @ArjunSingh-PM ?).

Note: I'd like to wait until this hits production to update the gif in viewing, due to beta's region limitations