### PR TITLE
Fix #2374 , Fix 'no of items' display in cards.

### DIFF
--- a/src/pages/concepts.jsx
+++ b/src/pages/concepts.jsx
@@ -22,7 +22,7 @@ const ConceptPage = () => (
     <Hero title=" Postman Concepts" text="Get easy, API-First solutions with the industry’s only Complete API Development Environment." />
     <IconCard
       icon={newToPostman}
-      items="3 items"
+      items="2 items"
       title="New to Postman"
       description="Postman is the only complete API development environment used by 10 million developers."
       heading1="Blog"
@@ -61,7 +61,7 @@ const ConceptPage = () => (
 
     <IconCard
       icon={environmentsIcon}
-      items="3 items"
+      items="2 items"
       title="Postman Environments"
       description="Make assertions about the correctness of your API responses, pass data between requests, and add dynamic behavior to requests and collections."
       heading1="Blog"
@@ -103,7 +103,7 @@ const ConceptPage = () => (
 
     <IconCard
       icon={runIcon}
-      items="3 items"
+      items="2 items"
       title="Running a Collection"
       description="Run a collection as a series of requests against a corresponding environment."
       heading1="docs"


### PR DESCRIPTION
Fix #2374 
Fix some card components which display wrong 'no of items' in subheading .
1 . 
![1](https://user-images.githubusercontent.com/16597292/81281972-318cae80-9078-11ea-8971-2a53e16d1821.PNG)
![4](https://user-images.githubusercontent.com/16597292/81281980-35203580-9078-11ea-9bfe-190b60f54fe9.PNG)

2. 
![2](https://user-images.githubusercontent.com/16597292/81282177-71539600-9078-11ea-866c-fbc2de6e4913.PNG)
![5](https://user-images.githubusercontent.com/16597292/81282191-74e71d00-9078-11ea-908d-c0089658f984.PNG)

3.
![3](https://user-images.githubusercontent.com/16597292/81282234-82040c00-9078-11ea-82f9-3d4be6f948fe.PNG)
![6](https://user-images.githubusercontent.com/16597292/81282243-84fefc80-9078-11ea-92f8-29f55e57c6ce.PNG)





