### PR TITLE
adding new contextual Ping Identity links to right sidebar

### DIFF
--- a/src/pages/docs/postman/collection-runs/using-environments-in-collection-runs.md
+++ b/src/pages/docs/postman/collection-runs/using-environments-in-collection-runs.md
@@ -11,6 +11,14 @@ contextual_links:
   - type: section
     name: "Additional Resources"
   - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "Ping Identity"
+    url: "https://www.postman.com/resources/case-studies/pingidentity/"
+  - type: link
+    name: "AMC Theatres"
+    url: "https://www.postman.com/resources/case-studies/amc-theatres/"
+  - type: subtitle
     name: "Related Blog Posts"
   - type: link
     name: "Generate Spotify Playlists using a Postman Collection"

--- a/src/pages/docs/postman/collections/creating-collections.md
+++ b/src/pages/docs/postman/collections/creating-collections.md
@@ -13,6 +13,9 @@ contextual_links:
   - type: subtitle
     name: "Case Studies"
   - type: link
+    name: "Ping Identity"
+    url: "https://www.postman.com/resources/case-studies/pingidentity/"
+  - type: link
     name: "AMC Theatres"
     url: "https://www.postman.com/resources/case-studies/amc-theatres/"
   - type: link

--- a/src/pages/docs/postman/collections/intro-to-collections.md
+++ b/src/pages/docs/postman/collections/intro-to-collections.md
@@ -16,6 +16,9 @@ contextual_links:
     name: "AMC Theatres"
     url: "https://www.postman.com/resources/case-studies/amc-theatres/"
   - type: link
+    name: "Ping Identity"
+    url: "https://www.postman.com/resources/case-studies/pingidentity/"
+  - type: link
     name: "iQmetrix"
     url: "https://www.postman.com/resources/case-studies/iqmetrix/"
   - type: subtitle

--- a/src/pages/docs/postman/collections/managing-collections.md
+++ b/src/pages/docs/postman/collections/managing-collections.md
@@ -11,6 +11,14 @@ contextual_links:
   - type: section
     name: "Additional Resources"
   - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "AMC Theatres"
+    url: "https://www.postman.com/resources/case-studies/amc-theatres/"
+  - type: link
+    name: "Ping Identity"
+    url: "https://www.postman.com/resources/case-studies/pingidentity/"
+  - type: subtitle
     name: "Related Blog Posts"
   - type: link
     name: "Audit your AWS infrastructure with Postman"

--- a/src/pages/docs/postman/scripts/test-scripts.md
+++ b/src/pages/docs/postman/scripts/test-scripts.md
@@ -17,6 +17,9 @@ contextual_links:
   - type: subtitle
     name: "Case Studies"
   - type: link
+    name: "Ping Identity"
+    url: "https://www.postman.com/resources/case-studies/pingidentity/"
+  - type: link
     name: "iQmetrix"
     url: "https://www.postman.com/resources/case-studies/iqmetrix/"
   - type: subtitle


### PR DESCRIPTION
We have a new Ping Identity case study. I added it to the right sidebar on some pages that are relevant to the topics in case study.