### PR TITLE
[2394] consent button label; Close

### DIFF
--- a/src/components/CookieAlert.jsx
+++ b/src/components/CookieAlert.jsx
@@ -6,7 +6,7 @@ const CookieAlert = () => (
   <div className="CookieWrapper">
     <CookieConsent
       location="bottom"
-      buttonText="Accept and Close"
+      buttonText="Close"
       cookieName="gatsby-gdpr-google-analytics"
       style={{
         display: 'block',


### PR DESCRIPTION
_Branched from `develop`_, this changes the label on the button for the cookie consent alert to "Close".

<img width="810" alt="consent-btn-Close" src="https://user-images.githubusercontent.com/56083362/82259974-49ceba00-9911-11ea-93c4-a7fd0f7e4940.png">
