### PR TITLE
Alter contribution flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,14 +8,16 @@ Please note we have a [code of conduct](https://www.postman.com/code-of-conduct)
 
 We follow [Git Flow](https://guides.github.com/introduction/flow/) for changes to this repository.
 
+_GitHub desktop is much easier if you're unfamiliar with using git / GitHub on the command line._
+
 * Fork this repo to create a copy hosted on your github account. The Fork button is in the top right of the page.
     * If you're a collaborator on the repo you can instead just create a branch.
 * Clone down your copy of this repo onto your local machine: `git clone <YOUR GITHUB REPO URL>`
 * Navigate to the new directory git created. `cd postman-docs`
 * Checkout the `develop` branch. `git checkout develop`
-* Create a new branch for your work based on develop `git checkout -b <YOUR BRANCH NAME>` Your branch name should be something descriptive of the changes you wish to make, and include the Issue number this change is associated with. Example: `1234-update-mock-api-docs`
 * Run `npm install` to add all dependencies
-* Make your changes. The Learning Center's documentation is built from the `.md` files in the `docs` folder of the repo
+* Create a new branch for your work based on develop `git checkout -b <YOUR BRANCH NAME>` Your branch name should be something descriptive of the changes you wish to make, and can include the issue number this change is associated with. Example: `feature/1234-update-mock-api-docs`
+* Make your changes. The Learning Center's documentation is built from the `.md` files in the `/src/pages/docs` folder of the repo
 * Check your files against our markdown guidelines by running `npm run test:mdlint` and resolve any errors
 * When you're ready to apply your changes, push your changed files to your forked repo
     * `git add <FILENAMES OF CHANGED FILES>`
@@ -31,7 +33,7 @@ We follow [Git Flow](https://guides.github.com/introduction/flow/) for changes t
     * Select `head branch: <YOUR BRANCH NAME>`
     * Click `Create pull request`
 
-Your pull request will be reviewed by administrators and will either be approved, denied, or sent back for changes.
+Your pull request will be reviewed and we'll get back to you!
 
 ## Pull Request Process
 


### PR DESCRIPTION
@ch264 made a couple of minor edits here to hopefully avoid people including `package-lock` file changes when they make content prs (mainly running `npm install` while they're still on `develop` branch, then creating their own branch - hopefully should allow people to run the site locally without editing / committing `package-lock` on their branch..)