### PR TITLE
Cookie consent rerender issue

### DIFF
--- a/src/components/CookieAlert.jsx
+++ b/src/components/CookieAlert.jsx
@@ -2,46 +2,74 @@
 import React from 'react';
 import CookieConsent from 'react-cookie-consent';
 
-const CookieAlert = () => (
-  <div id="CookieDiv" className="CookieWrapper">
-    <CookieConsent
-      location="bottom"
-      buttonText="Close"
-      cookieName="gatsby-gdpr-google-analytics"
-      style={{
-        display: 'block',
-        background: 'white',
-        // width: '100%',
-        // height: '100%',
-        // left: 0,
-        position: 'static',
-        color: '#282828',
-        padding: '20px 50px',
-        textAlign: 'center',
-        fontSize: '16px',
-        lineHeight: '24px',
-        boxShadow: '0px 4px 26.91px rgba(0, 0, 0, 0.15)',
-      }}
-      buttonStyle={{
-        display: 'block',
-        textAlign: 'center',
-        margin: '0 auto',
-        background: '#1C272B',
-        boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.15)',
-        borderRadius: '3px',
-        color: '#fff',
-        padding: '13px 24px',
-        fontWeight: '500',
-      }}
-      onAccept={() => {
-        document.getElementById('CookieDiv').remove();
-      }}
-    >
-      This website uses cookies to ensure you get the best experience on our website.
-      {' '}
-      <strong><a href="https://www.postman.com/licenses/privacy/#Automatic" rel="noopener noreferrer" target="_blank" style={{ color: 'black', textDecoration: 'underline' }}>Learn more</a></strong>
-    </CookieConsent>
-  </div>
-);
+class CookieAlert extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      displayCookieAlert: true,
+    };
+  }
+
+  componentDidMount() {
+    if (document.cookie.includes('gatsby-gdpr-google-analytics')) {
+      this.setState({
+        displayCookieAlert: false,
+      });
+    }
+  }
+
+  render() {
+    const { displayCookieAlert } = this.state;
+    const cookieMarkup = (
+      <div className="CookieWrapper">
+        <CookieConsent
+          location="bottom"
+          buttonText="Close"
+          cookieName="gatsby-gdpr-google-analytics"
+          style={{
+            display: 'block',
+            background: 'white',
+            position: 'static',
+            color: '#282828',
+            padding: '20px 50px',
+            textAlign: 'center',
+            fontSize: '16px',
+            lineHeight: '24px',
+            boxShadow: '0px 4px 26.91px rgba(0, 0, 0, 0.15)',
+          }}
+          buttonStyle={{
+            display: 'block',
+            textAlign: 'center',
+            margin: '0 auto',
+            background: '#1C272B',
+            boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.15)',
+            borderRadius: '3px',
+            color: '#fff',
+            padding: '13px 24px',
+            fontWeight: '500',
+          }}
+          onAccept={() => {
+            document.getElementById('CookieDiv').remove();
+          }}
+        >
+          This website uses cookies to ensure you get the best experience on our website.
+          {' '}
+          <strong><a href="/licenses/privacy/#Automatic" style={{ color: 'black', textDecoration: 'underline' }}>Learn more</a></strong>
+        </CookieConsent>
+      </div>
+    );
+    return (
+      <>
+        { displayCookieAlert ? (
+          <div id="CookieDiv">
+            {cookieMarkup}
+          </div>
+        ) : (
+          <></>
+        )}
+      </>
+    );
+  }
+}
 
 export default CookieAlert;


### PR DESCRIPTION
This fixes a cookie alert bug.

To recreate:
If you open the site in an incognito window, the CookieAlert will pop up. Inspect the Alert box and you can see the CookieDiv in the dom. When you click 'Close' this will remove the CookieDiv from the page.

The issue is when you refresh / continue to browse. The CookieDiv gets rendered and then the CookieConsent component checks for cookies, detects the cookie and doesn't render itself. However, the CookieDiv still gets rendered, preventing interaction with certain elements on the page.

This fix checks document.cookie and conditional renders the correct markup accordingly