### PR TITLE
Fixed NTLM spelling and anchor link.

### DIFF
--- a/src/pages/docs/postman/sending-api-requests/authorization.md
+++ b/src/pages/docs/postman/sending-api-requests/authorization.md
@@ -71,7 +71,7 @@ You can pass auth details along with any request you send in Postman. Auth data 
         * [Requesting a token](#requesting-an-oauth-20-token)
     * [Hawk authentication](#hawk-authentication)
     * [AWS Signature](#aws-signature)
-    * [NLTM authentication](#nltm-authentication)
+    * [NTLM authentication](#ntlm-authentication)
     * [Akamai EdgeGrid](#akamai-edgegrid)
 * [Syncing cookies](#syncing-cookies)
 * [Next steps](#next-steps)


### PR DESCRIPTION
NTLM was spelled wrong and so was the anchor link, this caused the page not to jump to the section when clicking the link in the content list.