### PR TITLE
Search subheadings

### DIFF
--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -15,6 +15,9 @@ const pageQuery = `{
   ) {
     edges {
       node {
+        headings(depth: h3) {
+          value
+        }
         frontmatter {
           title
           search_keyword


### PR DESCRIPTION
Re #2509 this adds headings as a searchable attribute in Algolia

I have just tested this out very briefly in the demo site I had used for the restructure but here's what I've got set up in my own test Algolia index:

* increased typo tolerance to five chars (fixes "fork" query issue)
* selected searchable attributes as follows - to rank title, headings among other detail

![attributes](https://user-images.githubusercontent.com/6666370/88382041-8bf7fa00-cd9f-11ea-9eb2-6e61fd50d42f.png)
![ranking](https://user-images.githubusercontent.com/6666370/88382167-cd88a500-cd9f-11ea-9945-2a83c04b3be0.png)

When I search in the **Browse** tab in Algolia I get better results (e.g. "console" returns troubleshooting page first and top five are all more relevant, "variables" returns dynamic and using variables / environments pages etc), however:

* I'm not seeing the same results in my live demo site which may be on account of me missing some part of the build process (ran out of time to continue investigating this 🙃), but am wondering if there is an issue connecting the updated Algolia site to our live site - @ch264 if you could try a couple of queries in the Algloia **Browse** view and in the live site and see if you get different results that would confirm this..
* Although I'm finding these tweaks addresss most of the problematic queries we've been talking about, there are still some serious limitations to Algolia's algorithm that I think may mean we need to explore other options:
    * @loopDelicious you mentioned "switch account" doesn't return page with "switching accounts" in it, this is because Algolia does not do "stemming" i.e. treating "switch" and "switching" as equivalent.
    * The fact that Algoia does not offer any way to factor frequency of search term occurrence in page is imo always going to return less relevant results first.
    * _It looks like Elasticsearch does both of these so we might want to look into that at some point._

Re including more search results, am seeing `hitsPerPage` in `header.jsx` but held off on changing it in case there are layout implications..

In the meantime if we could try the above tweaks and check that nothing is broken in terms of linking the updated index to the live site that should hopefully be a significant improvement.