### PR TITLE
[Fix #2575] Start search at 3 characters

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -136,9 +136,13 @@ class HeaderComponent extends React.Component {
                     placeholder: 'Search Postman Docs',
                   }}
                   onKeyUp={(event) => {
-                    this.setState({
-                      hasInput: event.currentTarget.value !== '',
-                    });
+                    event.currentTarget.value.length>=3?
+                      this.setState({
+                      hasInput: event.currentTarget.value,
+                    })
+                      :this.setState({
+                        hasInput: false,
+                      })
                   }}
                 />
 


### PR DESCRIPTION
Fix #2575 
Used a ternary expression to change the state accordingly after event.currentTarget.value.length>3 in the onKeyUp event.