### PR TITLE
New direct link for API key creation added on top of alternative dash…

### DIFF
--- a/src/pages/docs/developer/intro-api.md
+++ b/src/pages/docs/developer/intro-api.md
@@ -19,21 +19,23 @@ warning: false
 
 ---
 
-The [Postman API](https://docs.api.getpostman.com/) endpoints to help you integrate Postman within your development toolchain.
+The [Postman API](https://docs.api.getpostman.com/) endpoints to help you integrate Postman within your development toolchain.
 
-You can add new collections, update existing collections, update environments, and add and run monitors directly through the API. This enables you to programmatically access data stored in your Postman account.
+You can add new collections, update existing collections, update environments, and add and run monitors directly through the API. This enables you to programmatically access data stored in your Postman account.
 
-You can get started with the API via the **Run in Postman** button at the top of the [Postman API documentation](https://docs.api.getpostman.com/) and use the Postman app to send requests.
+You can get started with the API via the **Run in Postman** button at the top of the [Postman API documentation](https://docs.api.getpostman.com/) and use the Postman app to send requests.
 
 You will need an [API key](#generating-a-postman-api-key) to access the Postman API.
 
 > The Postman API is [rate limited](#rate-limits).
 
-## Generating a Postman API Key
+## Generating a Postman API key
 
-You need a valid API Key to send requests to the Postman API endpoints.
+You need a valid API Key to send requests to the Postman API endpoints.
 
-To generate a new API Key go to the [Postman API keys page](https://web.postman.co/settings/me/api-keys).
+Navigate to the [web dashboard](https://app.getpostman.com/). Select a workspace and open __Integrations__. Locate the Postman API and click __View Details__.
+
+![Workspace Integrations](https://assets.postman.com/postman-docs/workspace-integrations-api.jpg)
 
 If you do not have any keys yet you will be prompted to create one. Click __Generate API Key__.
 
@@ -47,12 +49,6 @@ Copy your key and click __Close__.
 
 <img src="https://assets.postman.com/postman-docs/copy-api-key.jpg" width="300px" alt="API Key Name"/>
 
-Alternatively you can navigate to the [web dashboard](https://app.getpostman.com/). Select a workspace and open __Integrations__. Locate the Postman API and click __View Details__.
-
-![Workspace Integrations](https://assets.postman.com/postman-docs/workspace-integrations-api.jpg)
-
-From now on you will be guided to the same API Key generation process described above.
-
 Once you have keys generated you can manage them within your workspace.
 
 ![Workspace Keys](https://assets.postman.com/postman-docs/api-keys-overview.jpg)
@@ -63,17 +59,17 @@ Use __API Key Settings__ to specify expiration periods for your keys.
 
 ### Authentication
 
-You will need to authenticate your requests to the Postman API by sending your API Key in the `X-Api-Key` header of every request you make.
+You will need to authenticate your requests to the Postman API by sending your API Key in the `X-Api-Key` header of every request you make.
 
 Your API Key provides access to any Postman data you have permissions for.
 
-You can store your API key in an [environment variable](/docs/sending-requests/managing-environments/)—if you name it `postman-api-key` the Postman API collection will use it automatically
+You can store your API key in an [environment variable](/docs/sending-requests/managing-environments/)—if you name it `postman-api-key` the Postman API collection will use it automatically
 
 ## Rate Limits
 
 API access rate limits are applied at a per-key basis in unit time.
 
-Access to the API using a key is limited to **60 requests per minute**. Every API response includes the following set of headers to identify the status of your consumption.
+Access to the API using a key is limited to **60 requests per minute**. Every API response includes the following set of headers to identify the status of your consumption.
 
 | Header                | Description   |
 | ---                   | ---           |

--- a/src/pages/docs/developer/intro-api.md
+++ b/src/pages/docs/developer/intro-api.md
@@ -33,6 +33,8 @@ You will need an [API key](#generating-a-postman-api-key) to access the Postman 
 
 You need a valid API Key to send requests to the Postman API endpoints.
 
+You can generate an API Key directly from your [Postman API Keys page](https://go.postman.co/settings/me/api-keys) or by navigating to the [web dashboard](https://app.getpostman.com/).
+
 Navigate to the [web dashboard](https://app.getpostman.com/). Select a workspace and open __Integrations__. Locate the Postman API and click __View Details__.
 
 ![Workspace Integrations](https://assets.postman.com/postman-docs/workspace-integrations-api.jpg)

--- a/src/pages/docs/developer/intro-api.md
+++ b/src/pages/docs/developer/intro-api.md
@@ -29,13 +29,11 @@ You will need an [API key](#generating-a-postman-api-key) to access the Postman 
 
 > The Postman API is [rate limited](#rate-limits).
 
-## Generating a Postman API key
+## Generating a Postman API Key
 
 You need a valid API Key to send requests to the Postman API endpoints.
 
-Navigate to the [web dashboard](https://app.getpostman.com/). Select a workspace and open __Integrations__. Locate the Postman API and click __View Details__.
-
-![Workspace Integrations](https://assets.postman.com/postman-docs/workspace-integrations-api.jpg)
+To generate a new API Key go to the [Postman API keys page](https://web.postman.co/settings/me/api-keys).
 
 If you do not have any keys yet you will be prompted to create one. Click __Generate API Key__.
 
@@ -48,6 +46,12 @@ Enter a name for your key and click __Generate API Key__.
 Copy your key and click __Close__.
 
 <img src="https://assets.postman.com/postman-docs/copy-api-key.jpg" width="300px" alt="API Key Name"/>
+
+Alternatively you can navigate to the [web dashboard](https://app.getpostman.com/). Select a workspace and open __Integrations__. Locate the Postman API and click __View Details__.
+
+![Workspace Integrations](https://assets.postman.com/postman-docs/workspace-integrations-api.jpg)
+
+From now on you will be guided to the same API Key generation process described above.
 
 Once you have keys generated you can manage them within your workspace.
 


### PR DESCRIPTION
I added the direct link to the API Key page on top of the section "Generating a Postman API Key". The procedure is the same as the dashboard's one, so the pictures previously used for the dashboard procedure are still valid also for the direct link. 

I moved the dashboard procedure at the end of the section, considering it as an alternative way to achieve the purpose of creating a new API Key.

@SueSmith please let me know what you think and if this approach works for you.
Thanks!