### PR TITLE
fixes #2694 correct link to shared responsibility

### DIFF
--- a/src/pages/docs/administration/onboarding-checklist.md
+++ b/src/pages/docs/administration/onboarding-checklist.md
@@ -8,7 +8,7 @@ contextual_links:
     name: "Additional Resources"
   - type: link
     name: "Security and Compliance: A Shared Responsibility Model"
-    url: "https://www.postman.com/shared-responsibility/"
+    url: "https://www.postman.com/security/shared-responsibility/"
   - type: link
     name: "Managing your team"
     url: "/docs/administration/managing-your-team/"


### PR DESCRIPTION
correct link for 'Security and Compliance: A Shared Responsibility Model' is https://www.postman.com/security/shared-responsibility/ 

fixes #2694 