### PR TITLE
updated monitor usage doc

### DIFF
--- a/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/intro-monitors.md
+++ b/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/intro-monitors.md
@@ -109,9 +109,9 @@ See more on [how Postman calculates usage](#how-postman-calculates-monitor-usage
 
 ## Viewing monitor usage
 
-Your [monitor usage dashboard](https://go.postman.co/usage/monitors), also available by navigating to your general [usage dashboard](https://go.postman.co/usage) > **View detailed monitoring usage**, provides a high-level overview of your team's monitoring usage.
+Your [monitor usage dashboard](https://go.postman.co/usage/monitors), also available by navigating to your general [usage dashboard](https://go.postman.co/usage) > **View detailed monitoring usage** under **Monitoring Usage**, provides a high-level overview of your team's monitoring usage.
 
-This page allows you to view your team's current billing period, how many requests have been made, and which monitors have run. It also identifies monitors by name, collection, environment, and creator, and provides a breakdown of requests made by each monitor.
+This page allows you to view your team's current billing period, how many requests have been made, and which monitors have run. It also identifies monitors by name, collection, environment, and creator.
 
 [![monitoring usage details](https://assets.postman.com/postman-docs/monitoring-usage-details.jpg)](https://assets.postman.com/postman-docs/monitoring-usage-details.jpg)
 

--- a/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/intro-monitors.md
+++ b/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/intro-monitors.md
@@ -109,7 +109,7 @@ See more on [how Postman calculates usage](#how-postman-calculates-monitor-usage
 
 ## Viewing monitor usage
 
-To view a high-level overview of your team's monitoring usage, you can access [monitor usage dashboard](https://go.postman.co/usage/monitors) by navigating to [your team usage dashboard](https://go.postman.co/usage) and selecting **View detailed monitoring usage** under **Monitoring Usage**.
+To view a high-level overview of your team's monitoring usage, you can access your [monitor usage dashboard](https://go.postman.co/usage/monitors) by navigating to your [team usage dashboard](https://go.postman.co/usage) and selecting **View detailed monitoring usage** under **Monitoring Usage**.
 
 This page allows you to view your team's current billing period, how many requests have been made, and which monitors have run. It also identifies monitors by name, collection, environment, and creator.
 

--- a/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/intro-monitors.md
+++ b/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/intro-monitors.md
@@ -109,7 +109,7 @@ See more on [how Postman calculates usage](#how-postman-calculates-monitor-usage
 
 ## Viewing monitor usage
 
-Your [monitor usage dashboard](https://go.postman.co/usage/monitors), also available by navigating to your general [usage dashboard](https://go.postman.co/usage) > **View detailed monitoring usage** under **Monitoring Usage**, provides a high-level overview of your team's monitoring usage.
+To view a high-level overview of your team's monitoring usage, you can access [monitor usage dashboard](https://go.postman.co/usage/monitors) by navigating to [your team usage dashboard](https://go.postman.co/usage) and selecting **View detailed monitoring usage** under **Monitoring Usage**.
 
 This page allows you to view your team's current billing period, how many requests have been made, and which monitors have run. It also identifies monitors by name, collection, environment, and creator.
 


### PR DESCRIPTION
Navigating to usage dashboard, it is quite hard to find "View detailed monitoring usage" so included additional information for more clarity. 

Also, monitoring usage page does not provide a breakdown of requests made by each monitor, so removed this part.