### PR TITLE
updated year in global footer

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -442,7 +442,7 @@ class FooterComponent extends React.Component {
               <li className="copyright-notice list-inline-item">
                 ©
                 <span id="current-year" />
-                2020 Postman, Inc. All rights reserved
+                2021 Postman, Inc. All rights reserved
               </li>
             </div>
           </div>


### PR DESCRIPTION
Changed 2020 --> 2021 in global footer.

<img width="710" alt="Screen Shot 2021-01-07 at 1 25 57 PM" src="https://user-images.githubusercontent.com/4358288/103946820-00271f80-50ec-11eb-8ded-2363f1ed2d15.png">
