### PR TITLE
Fixed typo in URL for chrome interceptor extension

### DIFF
--- a/src/pages/docs/sending-requests/capturing-request-data/interceptor.md
+++ b/src/pages/docs/sending-requests/capturing-request-data/interceptor.md
@@ -241,7 +241,7 @@ You can use Interceptor to create a Postman collection for a web app or to debug
 To use Interceptor with Postman Chrome, you can take the following steps:
 
 1. [Install Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?) from the Chrome Web Store.
-2. Install [Interceptor](https://chrome.google.com/webstore/detail/postman-interceptor/aicmkgpgakddgnaphhhpliifpcfhicfo/support?hl=en) from the Chrome Web Store.
+2. Install [Interceptor](https://chrome.google.com/webstore/detail/postman-interceptor/aicmkgpgakddgnaphhhpliifpcfhicfo/) from the Chrome Web Store.
 3. Open Postman, click on the Interceptor icon in the toolbar, and toggle to **On**.
 
 You can then browse your app or website and monitor requests as they stream in to your Postman history.


### PR DESCRIPTION
I was downloading the postman interceptor addon and the current link sends you to the third "support" tab in Chrome webstore. I feel it should send you to the main "overview" tab instead.

![image](https://user-images.githubusercontent.com/49397642/104094204-a5c6c400-528f-11eb-81d8-5a378d1b836b.png)
