### PR TITLE
Specify data parameter used while scripting in visualizations is a JSON object

### DIFF
--- a/src/pages/docs/writing-scripts/script-references/postman-sandbox-api-reference.md
+++ b/src/pages/docs/writing-scripts/script-references/postman-sandbox-api-reference.md
@@ -662,7 +662,7 @@ pm.visualizer.set(layout:String, data:Object, options:Object):Function
 * `layout` **required**
     * [Handlebars](https://handlebarsjs.com/) HTML template string
 * `data` _optional_
-    * JSON object that binds to the template and you can access it inside the template string 
+    * JSON object that binds to the template and you can access it inside the template string
 * `options` _optional_
     * [Options object](https://handlebarsjs.com/api-reference/compilation.html) for `Handlebars.compile()`
 

--- a/src/pages/docs/writing-scripts/script-references/postman-sandbox-api-reference.md
+++ b/src/pages/docs/writing-scripts/script-references/postman-sandbox-api-reference.md
@@ -662,7 +662,7 @@ pm.visualizer.set(layout:String, data:Object, options:Object):Function
 * `layout` **required**
     * [Handlebars](https://handlebarsjs.com/) HTML template string
 * `data` _optional_
-    * Data to bind to the template and that you can access inside the template string
+    * JSON object that binds to the template and you can access it inside the template string 
 * `options` _optional_
     * [Options object](https://handlebarsjs.com/api-reference/compilation.html) for `Handlebars.compile()`
 


### PR DESCRIPTION
The data parameter used in pm.visualizer.set is a JSON object. Since the documentation mentions object, it could make the user feel that it is a Javascript object and they would try to pass other types of Javascript objects to it eg. functions which a JSON object does not accept. Hence the change.