### PR TITLE
[WEBSITES-1586] Update devDependencies to remove duplicated packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,17 +68,13 @@
   },
   "devDependencies": {
     "babel-jest": "^25.1.0",
-    "babel-preset-gatsby": "^0.2.14",
     "eslint": "^6.4.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.7.0",
-    "identity-obj-proxy": "^3.0.0",
-    "jest": "^25.1.0",
-    "prettier": "^1.18.2",
-    "react-test-renderer": "^16.9.0"
+    "jest": "^25.1.0"
   },
   "keywords": [
     "gatsby"


### PR DESCRIPTION
Removed babel-preset-gatsby, iddentity-obj-proxy, prettier and react-test-renderer from devDependencies in package.json. Ran develop and everything looks good. Warnings no longer show on CLI.

Anything listed under dependencies will always download regardless or production/develop and anything in devDependencies will install additionally specific to the develop environment.