### PR TITLE
LC Bug: Update conditional for onClickOut function for mobile browsers

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -130,12 +130,19 @@ class HeaderComponent extends React.Component {
   }
 
   // click out search results box
-  onClickOut = () => {
-    document.getElementsByClassName('ais-SearchBox-input')[0].value = '';
-    this.setState(() => ({
-      hasInput: false,
-    }));
-  }
+  onClickOut = (e) => {
+    const searchInput = document.getElementsByClassName('ais-SearchBox-input')[0].value;
+    if (searchInput !== '') {
+      this.setState(() => ({
+        hasInput: true,
+      }));
+    } else {
+      this.setState(() => ({
+        hasInput: false,
+      }));
+    }
+  };
+
 
 
   render() {


### PR DESCRIPTION
This fixes the on click bug we are coming across for mobile browsers. I added a conditional to check the search box output and to update state only if theres input.

 We are using the react-onclickout package so that when a user clicks outside of the search box, the menu will disappear. The bug only appears on mobile browsers and doesn't appear on web.