### PR TITLE
Update request creation instructions in the Getting Started guide

### DIFF
--- a/src/pages/docs/getting-started/creating-the-first-collection.md
+++ b/src/pages/docs/getting-started/creating-the-first-collection.md
@@ -37,9 +37,9 @@ Let's review how to [send a basic request](/docs/getting-started/sending-the-fir
 
 ## Creating your first collection
 
-To create a new request from the Overview tab, use the Get Started section at the right of Postman and click **Create a request**.
+You can create a new request from the Postman launch screen, using __New__ &gt; __Request__.
 
-<img alt="Create new request" src="https://assets.postman.com/postman-docs/create-new-request-v8.jpg" width="300px"/>
+<img alt="Create new request" src="https://assets.postman.com/postman-docs/new-request-v8.jpg"/>
 
 Enter a request in the request builder and click the **Save** button to open the **SAVE REQUEST** modal.
 


### PR DESCRIPTION
The current steps from this section don't seem to be applicable anymore
in Postman v8. The file name is indicative of this, as the screenshot
used in other pages has a "-v8" suffix.

This is the only page still requiring this old screenshot.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>