### PR TITLE
Small Spelling Fix

### DIFF
--- a/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/integrations-for-alerts.md
+++ b/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/integrations-for-alerts.md
@@ -38,4 +38,4 @@ Note: only JSON data is currently supported as the request body in the webhook.
 
 ### Sending output to another API
 
-The data that is sent to the webhook can be used to trigger another API and define a logic based on the incoming data. For example, you could set up a monitoring webhook on your Github repository, so that based on the updates happening in your repository, you can trigger custom build pipelines and perform CI tests.
+The data that is sent to the webhook can be used to trigger another API and define a logic based on the incoming data. For example, you could set up a monitoring webhook on your GitHub repository, so that based on the updates happening in your repository, you can trigger custom build pipelines and perform CI tests.

--- a/src/pages/docs/integrations/available-integrations/keen.md
+++ b/src/pages/docs/integrations/available-integrations/keen.md
@@ -28,7 +28,7 @@ Setting up a Keen integration requires you to get a project ID and API key befor
 
 ## Configuring Postman monitors
 
-In the **[Integrations](https://go.postman.co/workspaces)** tab for your worksapce, select Keen IO from the list of third party integrations.
+In the **[Integrations](https://go.postman.co/workspaces)** tab for your workspace, select Keen IO from the list of third party integrations.
 
 [![keen dashboard](https://assets.postman.com/postman-docs/integrations_keen1.png)](https://assets.postman.com/postman-docs/integrations_keen1.png)
 


### PR DESCRIPTION
- adjusted the spelling of "worksapce" to read as "workspace"
- adjusted "Github" to read as "GitHub"

Resolves: fix/small-spelling-fix