### PR TITLE
[MARKENG-88] Forces window to top of page, when switching between routes.

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,3 +3,12 @@ exports.onClientEntry = () => {
     function OptanonWrapper() { } // eslint-disable-line no-unused-vars
   })();
 };
+
+// Always start at the top of the page on a route change.
+exports.onRouteUpdate = () => {
+  if (typeof window !== `undefined`) { window.scrollTo(0, 0)}
+}
+
+exports.shouldUpdateScroll = args => {
+   return false;
+};


### PR DESCRIPTION
This forces the window to the top of page on load, resolving the bug described in MARKENG-88.  (Was able to recreate).

I spent some time researching.. This appeared as a bug in Gatsby issue in 2018 and was resolved, but people still encounter from time to time, which has led people to suspect that it is the way Gatsby interacts with page CSS, specifically on the body tag. Only thing is the CSS fix wouldn't apply to our app? Thinking the bug isn't necessarily on our side, or on Gatsby's side, but with the way the two are interacting. Will need a little more investigation but this fixes the immediate problem.

Useful links:
https://stackoverflow.com/questions/55336831/how-to-fix-gatsby-js-link-component-retaining-scroll-position-and-not-resetting
https://github.com/gatsbyjs/gatsby/issues/3249
https://github.com/gatsbyjs/gatsby/issues/12997
https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/#shouldUpdateScroll
https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/#onRouteUpdate