### PR TITLE
[MARKENG-156] Remove scrollTo function in gatsby-browser to fix double click anchor bug

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,12 +3,3 @@ exports.onClientEntry = () => {
     function OptanonWrapper() {} // eslint-disable-line no-unused-vars
   })();
 };
-
-// Always start at the top of the page on a route change.
-exports.onInitialClientRender = () => {
-  if (!window.location.hash) {
-    window.scrollTo(0, 0);
-  } else {
-    window.location = window.location.hash;
-  }
-};

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,12 +3,3 @@ exports.onClientEntry = () => {
     function OptanonWrapper() { } // eslint-disable-line no-unused-vars
   })();
 };
-
-// Always start at the top of the page on a route change.
-exports.onRouteUpdate = () => {
-  if (typeof window !== `undefined`) { window.scrollTo(0, 0)}
-}
-
-exports.shouldUpdateScroll = args => {
-   return false;
-};

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,14 @@
 exports.onClientEntry = () => {
   (() => {
-    function OptanonWrapper() { } // eslint-disable-line no-unused-vars
+    function OptanonWrapper() {} // eslint-disable-line no-unused-vars
   })();
+};
+
+// Always start at the top of the page on a route change.
+exports.onInitialClientRender = () => {
+  if (!window.location.hash) {
+    window.scrollTo(0, 0);
+  } else {
+    window.location = window.location.hash;
+  }
 };


### PR DESCRIPTION
This updates the double clicking anchor issues for links under /contents/