### PR TITLE
updated start URL for manifest file

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -108,7 +108,7 @@ module.exports = {
       options: {
         name: 'Postman Learning Center',
         short_name: 'Postman Learning Center',
-        start_url: '/',
+        start_url: 'https://learning.postman.com/',
         background_color: '#FF6C37',
         theme_color: '#FF6C37',
         display: 'minimal-ui',


### PR DESCRIPTION
This updates the starting URL for the manifest file to be absolute instead of relative. (This is the URL people's homescreen app icons are set to—should they add LC to their homepscreen.)