### PR TITLE
remove URL and use root for manifest file

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -97,7 +97,7 @@ module.exports = {
       options: {
         name: 'Postman Learning Center',
         short_name: 'Postman Learning Center',
-        start_url: 'https://learning.postman.com/',
+        start_url: '/',
         background_color: '#FF6C37',
         theme_color: '#FF6C37',
         display: 'minimal-ui',


### PR DESCRIPTION
This reverts the start)url change back to using the root. See Chrome console WARN:

<img width="547" alt="Screen Shot 2021-04-30 at 2 38 13 PM" src="https://user-images.githubusercontent.com/4358288/116946213-694c1900-ac2e-11eb-9dce-069689a23dd6.png">
