### PR TITLE
[MARKENG-155] fixed console WARN by declaring language w/ prism

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,33 @@ If you would like to add, edit or replace images you are welcome to do so. There
 * You can upload the image to your GitHub Pull-Request and link the image
 * You can host the image and link to your own hosted image
 
+## Adding/Editing Codeblocks
+
+If you would like to add, edit or replace Markdown code blocks you are welcome to do so. There are two things in which you need to know:
+
+* We use Prism.js via a Gatsby plugin [gatsby-remark-prismjs](https://www.gatsbyjs.com/plugins/gatsby-remark-prismjs/#usage-in-markdown "See usage in markdown documentation")
+* Imediately following the opening 3 backticks ` ``` ` should be the language declaration. See Markdown example:
+
+```markdown
+    ```json
+    {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {},
+    "id": "http://example.com/example.json",
+    "properties": {
+        "collection": {
+        "id": "/properties/collection",
+        "properties": {},
+        "type": "object"
+        }
+    },
+    "type": "object"
+    }
+    ```
+```
+
+For a list of supported languages by Prism syntax highlighter, [read more](https://lucidar.me/en/web-dev/list-of-supported-languages-by-prism/). When in doubt, use `text`, `bash` or `shell` to keep the code block from interfering.
+
 **Note**:
 
 Images hosted by Postman should always be referenced as follows:

--- a/legacy-documentation/v5/postman/scripts/postman_sandbox_api_reference.md
+++ b/legacy-documentation/v5/postman/scripts/postman_sandbox_api_reference.md
@@ -42,7 +42,7 @@ A number of NodeJS modules are also available:
 
 In order to use a library, simply call the `require` function and pass the module name as a parameter and assign the return of the function to a variable.
 
-```
+```js
 var atob = require('atob'),
     _ = require('lodash'), 
   
@@ -92,7 +92,7 @@ Some things to know about `pm.sendRequest()`:
 * The method accepts a collection SDK compliant request and a callback. The callback receives 2 arguments, an error (if any) and SDK compliant response.
 * It can be used in the pre-request or the test script.
 
-```
+```js
 // example with a plain string URL
 pm.sendRequest('https://postman-echo.com/get', function (err, res) {
     if (err) {
@@ -219,7 +219,7 @@ The `cookies` object contains a list of cookies that are associated with the dom
 
    In the following sample test, we are checking that everything about a response is valid for us to proceed.
 
-    ```
+    ```js
     pm.test("response should be okay to process", function () {
         pm.response.to.not.be.error;
         pm.response.to.have.jsonBody('');
@@ -233,7 +233,7 @@ The `cookies` object contains a list of cookies that are associated with the dom
   
   This function is useful to deal with assertions of data from a response or variables.
       
-  ```
+  ```js
     pm.test('environment to be production', function () {
         pm.expect(pm.environment.get('env')).to.equal('production');
     });

--- a/legacy-documentation/v5/pro/integrations/microsoft_flow.md
+++ b/legacy-documentation/v5/pro/integrations/microsoft_flow.md
@@ -90,7 +90,7 @@ For different types of integrations, the JSON schema varies. The following shows
 
 ##### **Monitor Run Results**
 
-```
+```json
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {},
@@ -165,7 +165,7 @@ For different types of integrations, the JSON schema varies. The following shows
 
 ##### **Collection and Team Activity Feed**
 
-```
+```json
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {},
@@ -214,7 +214,7 @@ For different types of integrations, the JSON schema varies. The following shows
 
 ##### **Backup Collections**
 
-```
+```json
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {},

--- a/src/pages/docs/sending-requests/capturing-request-data/proxy.md
+++ b/src/pages/docs/sending-requests/capturing-request-data/proxy.md
@@ -157,6 +157,7 @@ If your proxy has basic auth, take the following steps:
       Double-clicking this bat file should open Postman without any of the proxy environment variables set.
 
     * **Mac/Linux** - create the .sh file with the following contents:
+    
     ```shell
     `HTTP_PROXY`=`http://USER:PASS@host:port`
     `HTTPS_PROXY`=`https://USER:PASS@host:port` /path/to/postman

--- a/src/pages/docs/sending-requests/capturing-request-data/proxy.md
+++ b/src/pages/docs/sending-requests/capturing-request-data/proxy.md
@@ -131,7 +131,8 @@ If you are unable to send any requests through Postman and your network does not
 
         * **Windows** –  create a postman.bat file with the following contents:
 
-        ```set HTTP_PROXY=''
+        ```shell
+        set HTTP_PROXY=''
         set HTTPS_PROXY=''
         set http_proxy=''
         set https_proxy=''
@@ -147,7 +148,8 @@ If your proxy has basic auth, take the following steps:
 * Start Postman with the appropriate environment variables:
     * **Windows** — create a postman.bat file with the following contents:
 
-      ```set HTTP_PROXY=http://USER:PASS@host:port
+      ```shell
+      set HTTP_PROXY=http://USER:PASS@host:port
       set HTTPS_PROXY=https://USER:PASS@host:port
       start C:\path\to\Postman.exe
       ```
@@ -155,7 +157,9 @@ If your proxy has basic auth, take the following steps:
       Double-clicking this bat file should open Postman without any of the proxy environment variables set.
 
     * **Mac/Linux** - create the .sh file with the following contents:
+    ```shell
     `HTTP_PROXY`=`http://USER:PASS@host:port`
     `HTTPS_PROXY`=`https://USER:PASS@host:port` /path/to/postman
+    ```
 
     * Create this file and save it in a convenient location. When you open this file, the set environment variables will only apply to the Postman process.

--- a/src/pages/docs/sending-requests/capturing-request-data/proxy.md
+++ b/src/pages/docs/sending-requests/capturing-request-data/proxy.md
@@ -157,7 +157,7 @@ If your proxy has basic auth, take the following steps:
       Double-clicking this bat file should open Postman without any of the proxy environment variables set.
 
     * **Mac/Linux** - create the .sh file with the following contents:
-    
+
     ```shell
     `HTTP_PROXY`=`http://USER:PASS@host:port`
     `HTTPS_PROXY`=`https://USER:PASS@host:port` /path/to/postman


### PR DESCRIPTION
* fixed console WARN by declaring language w/ prism on /docs/sending-requests/capturing-request-data/proxy/ (bottom code block)
* ...which corrected the first code block (below) that was truncating the first line (thinking it was language)
* updated other code blocks missing language
* updated CONTRIBUTING.md to explain usage of code blocks and Prism

Before:
<img width="828" alt="Screen Shot 2021-05-04 at 10 59 58 PM" src="https://user-images.githubusercontent.com/4358288/117102632-92070800-ad2d-11eb-985f-388a4ee86873.png">

After:
<img width="800" alt="Screen Shot 2021-05-04 at 11 04 10 PM" src="https://user-images.githubusercontent.com/4358288/117102644-96332580-ad2d-11eb-9f15-a28164e264b2.png">
