### PR TITLE
update links to use new domain

### DIFF
--- a/legacy-documentation/v5/managing_collections/creating_documentation.md
+++ b/legacy-documentation/v5/managing_collections/creating_documentation.md
@@ -40,7 +40,7 @@ Note: Any confidential info (passwords/access tokens) in your environment might 
 * To unpublish, open the Docs link from your Postman app. Click the Published button near the top of the screen. For a collection that's already been published, you'll be able to view the public link or unpublish the collection.
 [![](https://www.postman.com/img/v1/docs/publishing_docs/Docs5.png)][4]
 
-* We've published documentation for this collection at [https://documenter.getpostman.com/view/583/coopers-meal-plan/4u2][5].
+<!-- * We've published documentation for this collection at [https://documenter.postman.com/view/583/coopers-meal-plan/4u2][5]. -->
 
 Oh, and in case you're wondering who Cooper is, why we're trying to feed him, or what his collection is all about, check out our blog post [here][6].
 
@@ -49,6 +49,6 @@ Oh, and in case you're wondering who Cooper is, why we're trying to feed him, or
 [2]: https://www.postman.com/img/v1/docs/publishing_docs/Docs3.png
 [3]: https://www.postman.com/img/v1/docs/publishing_docs/Docs4.png
 [4]: https://www.postman.com/img/v1/docs/publishing_docs/Docs5.png
-[5]: https://documenter.getpostman.com/view/583/coopers-meal-plan/4u2
+<!-- [5]: https://documenter.postman.com/view/583/coopers-meal-plan/4u2 -->
 [6]: https://blog.postman.com/conditional-workflows-in-postman/
 [7]: https://static.getpostman.com/postman-docs/40ce4cda-5788-4e18-9141-4391de078244.png

--- a/legacy-documentation/v5/postman/api_documentation/how_to_document_using_markdown.md
+++ b/legacy-documentation/v5/postman/api_documentation/how_to_document_using_markdown.md
@@ -5,7 +5,7 @@ warning: false
 
 ---
 
-Postman has created a collection to test [Markdown styling](https://documenter.getpostman.com/view/4630964/S1LsXVJy) inside Postman or in other services that render Markdown. The descriptions in the collection contain Markdown syntax and some of them have links to HTML pages of their rendered version.
+Postman has created a collection to test [Markdown styling](https://documenter.postman.com/view/4630964/S1LsXVJy) inside Postman or in other services that render Markdown. The descriptions in the collection contain Markdown syntax and some of them have links to HTML pages of their rendered version.
 
 [![markdown reference](https://assets.postman.com/postman-docs/59188697.png)](https://assets.postman.com/postman-docs/59188697.png)
 

--- a/legacy-documentation/v5/postman/api_documentation/publishing_public_docs.md
+++ b/legacy-documentation/v5/postman/api_documentation/publishing_public_docs.md
@@ -23,7 +23,7 @@ When signed in to Postman, you can select a [corresponding environment](https://
 
 The public URL field contains the URL to share with the outside world. For example, if you’re publishing your primary collection, you might want to select a “production” environment, so your documentation is immediately usable for new visitors.
 
-Here's an [example](https://documenter.getpostman.com/view/583/coopers-meal-plan/4u2) of a collection we've published.
+<!-- Here's an [example](https://documenter.postman.com/view/583/coopers-meal-plan/4u2) of a collection we've published. -->
 
 > **IMPORTANT:**  Any confidential information in your environment, such as **passwords and access tokens**, might be publicly visible. Remove all such information from the environment before you publish documentation with an environment.
 

--- a/legacy-documentation/v5/postman/collections/using_markdown_for_descriptions.md
+++ b/legacy-documentation/v5/postman/collections/using_markdown_for_descriptions.md
@@ -7,7 +7,7 @@ warning: false
 
 Postman supports [Markdown](https://learning.postman.com/docs/postman/api_documentation/how_to_document_using_markdown/) as a way to style text descriptions for [requests](https://learning.postman.com/docs/postman/sending_api_requests/requests/), [collections](https://learning.postman.com/docs/postman/collections/creating_collections/), and [folders](https://learning.postman.com/docs/postman/collections/managing_collections/) in collections. You can also embed screenshots and other images for more descriptive flair.
 
-For more information about Markdown, review the [reference for using Markdown](https://documenter.getpostman.com/view/33232/markdown-in-api-documentation/JsGc) for API documentation.
+For more information about Markdown, review the [reference for using Markdown](https://documenter.postman.com/view/33232/markdown-in-api-documentation/JsGc) for API documentation.
 
 Postman renders Markdown in your Workspace, and in public or internal API documentation.
 

--- a/legacy-documentation/v5/postman/mock_servers.md
+++ b/legacy-documentation/v5/postman/mock_servers.md
@@ -33,7 +33,7 @@ You can also use the Postman app to retrieve the `collectionId`. Find the Colle
 
 {% raw %} 
 ```
-https://documenter.getpostman.com/collection/view/{{collectionId}}
+https://documenter.postman.com/collection/view/{{collectionId}}
 ``` 
 {% endraw %}
 

--- a/legacy-documentation/v5/postman/mock_servers/mock_with_api.md
+++ b/legacy-documentation/v5/postman/mock_servers/mock_with_api.md
@@ -27,7 +27,7 @@ You can also use the Postman app to retrieve the `collectionId`. Find the Colle
 
 {% raw %} 
 ```
-https://documenter.getpostman.com/collection/view/{{collectionId}}
+https://documenter.postman.com/collection/view/{{collectionId}}
 ``` 
 {% endraw %}
 

--- a/legacy-documentation/v5/postman/monitors/intro_monitors.md
+++ b/legacy-documentation/v5/postman/monitors/intro_monitors.md
@@ -20,7 +20,7 @@ There are a few minor differences between running collections in a Postman monit
 ##### **Variables**
 
    *   Can't import existing global variables, but you can create new ones during a monitor run.
-   *   Global and environment variables are not persisted. If you require persisting environment variables, we recommend adding a call to update the environment variable using the [Postman API](https://learning.postman.com/docs/postman/postman_api/intro_api/). The following is an [example of how to update the environment variable](https://documenter.getpostman.com/view/218543/lunch-picker/6fWy4Ao#fe7e2416-4af9-fffc-02af-b8fc2c58a181) in this manner.
+   *   Global and environment variables are not persisted. If you require persisting environment variables, we recommend adding a call to update the environment variable using the [Postman API](https://learning.postman.com/docs/postman/postman_api/intro_api/). The following is an [example of how to update the environment variable](https://documenter.postman.com/view/218543/lunch-picker/6fWy4Ao#fe7e2416-4af9-fffc-02af-b8fc2c58a181) in this manner.
 
    [![persist env in monitor](https://assets.postman.com/postman-docs/monitorPersistEnv.png)](https://assets.postman.com/postman-docs/monitorPersistEnv.png)
 

--- a/legacy-documentation/v5/reference/index.md
+++ b/legacy-documentation/v5/reference/index.md
@@ -14,4 +14,4 @@ warning: false
 *   [Collection SDK (API Reference)](http://www.postmanlabs.com/postman-collection/)
 *   [Postman settings](/docs/postman/launching_postman/settings/)
 *   [Keyboard shortcuts](/docs/postman/launching_postman/settings/)
-*   [Markdown reference](https://documenter.getpostman.com/view/33232/markdown-in-api-documentation/JsGc)
+*   [Markdown reference](https://documenter.postman.com/view/33232/markdown-in-api-documentation/JsGc)

--- a/src/pages/docs/collaborating-in-postman/commenting-on-collections.md
+++ b/src/pages/docs/collaborating-in-postman/commenting-on-collections.md
@@ -145,4 +145,4 @@ Your teammate will be notified in the app or with an email that they've been tag
 
 ## Next steps
 
-Postman comments support Markdown. For more information on formatting using Markdown refer to [Markdown in API Documentation](https://documenter.getpostman.com/view/33232/markdown-in-api-documentation/JsGc?version=latest).
+Postman comments support Markdown. For more information on formatting using Markdown refer to [Markdown in API Documentation](https://documenter.postman.com/view/33232/markdown-in-api-documentation/JsGc?version=latest).

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/mock-with-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/mock-with-api.md
@@ -55,7 +55,7 @@ Let's retrieve the `collectionId` of `testAPI` using the [Postman API](http
 You can also use Postman to retrieve the `collectionId`. Find the Collection and hit `View Docs`. The `collectionId` is visible in the documentation url:
 
 ```text
-https://documenter.getpostman.com/collection/view/{{collectionId}}
+https://documenter.postman.com/collection/view/{{collectionId}}
 ```
 
 As an optional step, you can include an environment as a part of your simulation by retrieving the `environmentId` of `testAPIEnv` using the [Postman API](https://api.getpostman.com/). Get a list of all your environments using the [GET All Environments endpoint](https://docs.api.getpostman.com/#d26bd079-e3e1-aa08-7e21-66f55df99351). Search for the name of your environment and retrieve the `uid` from the results, which will be used as the `environmentId` in the next step.

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -66,7 +66,7 @@ To try out a mock server, carry out the following steps:
 * [Creating mock servers](#creating-mock-servers)
     * [Configuring mock details](#configuring-mock-details)
 * [Making requests to mocks](#making-requests-to-mocks)
-    * [Using HTTP access control](#using-http-access-control-for-a-mock)
+    * [Using HTTP access control for a mock](#using-http-access-control-for-a-mock)
 * [Viewing mock calls](#viewing-mock-calls)
     * [Troubleshooting mock calls](#troubleshooting-mock-calls)
 
@@ -174,7 +174,7 @@ The mock URL includes the ID for the mock and the path for the request with a sa
 
 If you save your mock URL to a variable, you can reference it across requests—for example if you have a production server and a mock server, you could have an [environment](/docs/sending-requests/managing-environments/) for each one with the same variable name in each for the mock URL. With your requests using the variable, you can then switch between the two environments.
 
-> You can also retrieve your mock ID from the [Postman API](https://documenter.getpostman.com/view/631643/JsLs/?version=latest#018b5d62-f6fc-f752-597e-c1eb4bb98d24)
+> You can also retrieve your mock ID from the [Postman API](https://documenter.postman.com/view/631643/JsLs/?version=latest#018b5d62-f6fc-f752-597e-c1eb4bb98d24)
 
 When you **Send** a request to your mock server URL it will send back one of the examples you added to the request with the same path and method. ([You can provide multiple examples](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/) and Postman will return the one that matches your request configuration most closely).
 

--- a/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/viewing-monitor-results.md
+++ b/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/viewing-monitor-results.md
@@ -93,7 +93,7 @@ You can filter by request to compare an individual request's response time in di
 
 You can filter by run type to compare how the response time changes between manual runs, scheduled runs, and webhook runs. Click to open the drop-down menu **Type: All**, then select the type of run you'd like to analyze further.
 
-> Manual runs are initiated in Postman or are triggered by the [Postman API](https://documenter.getpostman.com/view/631643/JsLs/?version=latest#5b277ca0-7114-e04e-f1f5-246fbbd6d973). Scheduled runs are initiated by the schedule you set when creating or editing your monitor. Webhook runs are initiated by integrations you've created.
+> Manual runs are initiated in Postman or are triggered by the [Postman API](https://documenter.postman.com/view/631643/JsLs/?version=latest#5b277ca0-7114-e04e-f1f5-246fbbd6d973). Scheduled runs are initiated by the schedule you set when creating or editing your monitor. Webhook runs are initiated by integrations you've created.
 
 #### Filtering by run result
 

--- a/src/pages/docs/getting-started/creating-the-first-collection.md
+++ b/src/pages/docs/getting-started/creating-the-first-collection.md
@@ -50,7 +50,7 @@ Enter a request in the request builder and click **Save** to open the **SAVE REQ
 <img alt="Save request modal" src="https://assets.postman.com/postman-docs/save-request-modal-v8.jpg"/>
 
 * As an optional step, enter a new request name. Otherwise, the default name will be the request URL.
-* As an optional step, enter a request description in plain text or using [Markdown](https://documenter.getpostman.com/view/33232/markdown-in-api-documentation/JsGc?version=latest).
+* As an optional step, enter a request description in plain text or using [Markdown](https://documenter.postman.com/view/33232/markdown-in-api-documentation/JsGc?version=latest).
 
 Save this request to an existing collection, or create a new collection by entering a collection name, and then click the **Save** button.
 

--- a/src/pages/docs/publishing-your-api/authoring-your-documentation.md
+++ b/src/pages/docs/publishing-your-api/authoring-your-documentation.md
@@ -166,7 +166,7 @@ You can include any image you have hosted online in your documentation. Use the 
 
 ## Markdown demo collection
 
-You can use the Postman [Markdown collection](https://documenter.getpostman.com/view/4630964/S1LsXVJy) to see how Markdown is rendered in documentation and the Postman app.
+You can use the Postman [Markdown collection](https://documenter.postman.com/view/4630964/S1LsXVJy) to see how Markdown is rendered in documentation and the Postman app.
 
 ![markdown reference](https://assets.postman.com/postman-docs/Updated+Markdown+image+for+Authoring+your+docs.jpg)
 

--- a/src/pages/docs/publishing-your-api/publishing-your-docs.md
+++ b/src/pages/docs/publishing-your-api/publishing-your-docs.md
@@ -35,7 +35,7 @@ You can publish your API documentation to make it available for public viewing b
 
 Your public documentation will always display up-to-date content representing the current state of your collection. You don’t need to repeat the publication flow each time you want to update your documentation.
 
-Your documentation will include the **Run in Postman** button so users can interact with your API directly in Postman. For example, check out the [Postman API documentation](https://documenter.getpostman.com/view/631643/JsLs/)—generated from a Postman Collection. You can publish your documentation to the API Network or as a template to make your collections publicly available in Postman, aiding developer onboarding and adoption.
+Your documentation will include the **Run in Postman** button so users can interact with your API directly in Postman. For example, check out the [Postman API documentation](https://documenter.postman.com/view/631643/JsLs/)—generated from a Postman Collection. You can publish your documentation to the API Network or as a template to make your collections publicly available in Postman, aiding developer onboarding and adoption.
 
 > You can publish documentation for collections that you created or have permission to edit.
 

--- a/src/pages/docs/sending-requests/intro-to-collections.md
+++ b/src/pages/docs/sending-requests/intro-to-collections.md
@@ -63,7 +63,7 @@ To see an overview of a collection, open it from the sidebar. You can edit your 
 
 [![Collection description](https://assets.postman.com/postman-docs/collection-description-v8.jpg)](https://assets.postman.com/postman-docs/collection-description-v8.jpg)
 
-> You can use [markdown in your collection descriptions](https://documenter.getpostman.com/view/33232/markdown-in-api-documentation/JsGc?version=latest).
+> You can use [markdown in your collection descriptions](https://documenter.postman.com/view/33232/markdown-in-api-documentation/JsGc?version=latest).
 
 You can edit details for your collections at any time by clicking the collection to open it in a tab.
 

--- a/src/pages/docs/sending-requests/visualizer.md
+++ b/src/pages/docs/sending-requests/visualizer.md
@@ -151,11 +151,11 @@ The `pm.getData(callback)` method takes a callback function as its parameter. Th
 
 See more visualizer code working by importing any of the following collections. Use the __Run in Postman__ buttons to import from the documentation for each one. Import the collection > open a request from __Collections__ on the left sidebar in Postman > click __Send__ to run it—you'll see the rendered data in __Visualize__.
 
-* [DIY collection that renders a bar chart using ChartJS](https://documenter.getpostman.com/view/4946945/SVzz4KxB?version=latest)
+* [DIY collection that renders a bar chart using ChartJS](https://documenter.postman.com/view/4946945/SVzz4KxB?version=latest)
 ![Bar Chart](https://assets.postman.com/postman-docs/visualizer-example-v8.jpg)
-* [Heat map visualization](https://documenter.getpostman.com/view/4946945/SVzw6MYM?version=latest)
+* [Heat map visualization](https://documenter.postman.com/view/4946945/SVzw6MYM?version=latest)
 ![Heat Map](https://assets.postman.com/postman-docs/visualizer-temp-v8.jpg)
-* [Various chart and graph examples](https://documenter.getpostman.com/view/2897506/SW7Z2Tkd?version=latest)
+* [Various chart and graph examples](https://documenter.postman.com/view/2897506/SW7Z2Tkd?version=latest)
 ![Map Visualizer](https://assets.postman.com/postman-docs/visualizer-map-v8.jpg)
 
 ## Visualizer API

--- a/src/pages/docs/writing-scripts/test-scripts.md
+++ b/src/pages/docs/writing-scripts/test-scripts.md
@@ -110,7 +110,7 @@ Using the `pm.expect` syntax gives your test result messages a different formatâ
 
 <img src="https://assets.postman.com/postman-docs/expect-test-syntax-v8.jpg" alt="Failed Test Results" width="500px"/>
 
-> Use the __Run in Postman__ button in the [Intro to writing tests collection](https://documenter.getpostman.com/view/1559645/RzZFCGFR?version=latest) to import templates containing some example test scripts into Postman and experiment with the code.
+> Use the __Run in Postman__ button in the [Intro to writing tests collection](https://documenter.postman.com/view/1559645/RzZFCGFR?version=latest) to import templates containing some example test scripts into Postman and experiment with the code.
 
 Your code can test the request [environment](/docs/sending-requests/managing-environments/), as in the following example:
 


### PR DESCRIPTION
Greetings team,

as requested by @tristandenyer on issue #3023 Kindly find the proposed changes to the docs

The second commit seeks to get some clarification on how to edit (remove) the links returning a 404

Issue #3023: Update all documenter.getpostman.com links to use new domain