### PR TITLE
Fixed build error for GATSBY_NEWRELIC_ENV env variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
   "license": "MIT",
   "scripts": {
     "bff": "NODE_ENV=development node bff.js",
-    "build": "npm run bff && GATSBY_NEWRELIC_ENV=production GATSBY_NEWRELIC_ENV=production GATSBY_ACTIVE_ENV=development gatsby build",
-    "build:dev": "GATSBY_NEWRELIC_ENV=production npm run build",
+    "build": "npm run bff && GATSBY_ACTIVE_ENV=development gatsby build",
+    "build:dev": "npm run build",
     "build:prod": "NODE_ENV=production node bff.js && GATSBY_NEWRELIC_ENV=production GATSBY_ACTIVE_ENV=production gatsby build",
     "clean": "gatsby clean",
     "dev": "npm run bff && gatsby develop",


### PR DESCRIPTION
We only want to use NR in production so I've updated the build and build:beta commands in our scripts. This also removes the log for a missing GATSBY_NEWRELIC_ENV environment during build.