### PR TITLE
Remove beta notice for web

### DIFF
--- a/src/pages/docs/getting-started/installation-and-updates.md
+++ b/src/pages/docs/getting-started/installation-and-updates.md
@@ -132,8 +132,6 @@ Postman on the web is under active development, but there are a few features you
 * **Certificates and Proxy**: These will take the browser defined value and cannot be overridden by Postman.
 * **Postman Interceptor**
 
-> [Postman for the Web](https://blog.postman.com/announcing-postman-for-the-web-now-in-open-beta/) is still under development. Please [try it out](https://blog.postman.com/introducing-the-postman-agent-send-api-requests-from-your-browser-without-limits/) and give the team feedback by joining in the discussion on the [community forum](https://community.postman.com/t/announcing-postman-for-the-web-now-in-open-beta/14192).
-
 ## Updating Postman
 
 The native Postman apps will notify you when a major update is available. For other updates you will see a dot on the settings icon. If the indicator is red instead of orange, it indicates a failed update.


### PR DESCRIPTION
We had an old notice that the web version was in beta, and it's not anymore.