### PR TITLE
MARKENG-230 - Update case study url, fixes redirect

### DIFF
--- a/src/pages/docs/collaborating-in-postman/using-workspaces/creating-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/creating-workspaces.md
@@ -22,7 +22,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Movember Foundation"
-    url: "https://www.postman.com/resources/case-studies/movember-foundation/"
+    url: "https://www.postman.com/customers/movember-foundation/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/collaborating-in-postman/using-workspaces/managing-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/managing-workspaces.md
@@ -14,7 +14,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Giant Machines"
-    url: "https://www.postman.com/resources/case-studies/giant-machines/"
+    url: "https://www.postman.com/customers/giant-machines/"
   - type: section
     name: "Next Steps"
   - type: link

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/mock-with-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/mock-with-api.md
@@ -21,10 +21,10 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Gear4Music"
-    url: "https://www.postman.com/resources/case-studies/gear4music/"
+    url: "https://www.postman.com/customers/gear4music/"
   - type: link
     name: "Giant Machines"
-    url: "https://www.postman.com/resources/case-studies/giant-machines/"
+    url: "https://www.postman.com/customers/giant-machines/"
   - type: subtitle
     name: "Related Blog Posts"
   - type: link

--- a/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/intro-monitors.md
+++ b/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/intro-monitors.md
@@ -14,7 +14,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Monetary"
-    url: "https://www.postman.com/resources/case-studies/monetary/"
+    url: "https://www.postman.com/customers/monetary/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/viewing-monitor-results.md
+++ b/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/viewing-monitor-results.md
@@ -9,7 +9,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Monetary"
-    url: "https://www.postman.com/resources/case-studies/monetary/"
+    url: "https://www.postman.com/customers/monetary/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/publishing-your-api/authoring-your-documentation.md
+++ b/src/pages/docs/publishing-your-api/authoring-your-documentation.md
@@ -17,7 +17,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Imgur"
-    url: "https://www.postman.com/resources/case-studies/imgur/"
+    url: "https://www.postman.com/customers/imgur/"
   - type: section
     name: "Next Steps"
   - type: link

--- a/src/pages/docs/publishing-your-api/custom-doc-domains.md
+++ b/src/pages/docs/publishing-your-api/custom-doc-domains.md
@@ -9,7 +9,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Imgur"
-    url: "https://www.postman.com/resources/case-studies/imgur/"
+    url: "https://www.postman.com/customers/imgur/"
   - type: section
     name: "Next Steps"
   - type: link

--- a/src/pages/docs/publishing-your-api/documenting-your-api.md
+++ b/src/pages/docs/publishing-your-api/documenting-your-api.md
@@ -14,10 +14,10 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Cisco DevNet"
-    url: "https://www.postman.com/resources/case-studies/cisco-devnet/"
+    url: "https://www.postman.com/customers/cisco-devnet/"
   - type: link
     name: "Imgur"
-    url: "https://www.postman.com/resources/case-studies/imgur/"
+    url: "https://www.postman.com/customers/imgur/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/publishing-your-api/run-in-postman/creating-run-button.md
+++ b/src/pages/docs/publishing-your-api/run-in-postman/creating-run-button.md
@@ -15,7 +15,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Intuit"
-    url: "https://www.postman.com/resources/case-studies/intuit/"
+    url: "https://www.postman.com/customers/intuit/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/publishing-your-api/viewing-documentation.md
+++ b/src/pages/docs/publishing-your-api/viewing-documentation.md
@@ -14,10 +14,10 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Cisco DevNet"
-    url: "https://www.postman.com/resources/case-studies/cisco-devnet/"
+    url: "https://www.postman.com/customers/cisco-devnet/"
   - type: link
     name: "Imgur"
-    url: "https://www.postman.com/resources/case-studies/imgur/"
+    url: "https://www.postman.com/customers/imgur/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/running-collections/using-newman-cli/continuous-integration.md
+++ b/src/pages/docs/running-collections/using-newman-cli/continuous-integration.md
@@ -17,7 +17,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Sikka"
-    url: "https://www.postman.com/resources/case-studies/sikka/"
+    url: "https://www.postman.com/customers/sikka/"
   - type: subtitle
     name: "Related Blog Posts"
   - type: link

--- a/src/pages/docs/running-collections/using-newman-cli/integration-with-jenkins.md
+++ b/src/pages/docs/running-collections/using-newman-cli/integration-with-jenkins.md
@@ -14,7 +14,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Sikka"
-    url: "https://www.postman.com/resources/case-studies/sikka/"
+    url: "https://www.postman.com/customers/sikka/"
   - type: subtitle
     name: "Related Blog Posts"
   - type: link

--- a/src/pages/docs/running-collections/using-newman-cli/integration-with-travis.md
+++ b/src/pages/docs/running-collections/using-newman-cli/integration-with-travis.md
@@ -14,7 +14,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Sikka"
-    url: "https://www.postman.com/resources/case-studies/sikka/"
+    url: "https://www.postman.com/customers/sikka/"
   - type: subtitle
     name: "Related Blog Posts"
   - type: link

--- a/src/pages/docs/sending-requests/authorization.md
+++ b/src/pages/docs/sending-requests/authorization.md
@@ -18,7 +18,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Intuit"
-    url: "https://www.postman.com/resources/case-studies/intuit/"
+    url: "https://www.postman.com/customers/intuit/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/sending-requests/examples.md
+++ b/src/pages/docs/sending-requests/examples.md
@@ -19,7 +19,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Imgur"
-    url: "https://www.postman.com/resources/case-studies/imgur/"
+    url: "https://www.postman.com/customers/imgur/"
   - type: section
     name: "Next Steps"
   - type: link

--- a/src/pages/docs/sending-requests/generate-code-snippets.md
+++ b/src/pages/docs/sending-requests/generate-code-snippets.md
@@ -19,10 +19,10 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Intuit"
-    url: "https://www.postman.com/resources/case-studies/intuit/"
+    url: "https://www.postman.com/customers/intuit/"
   - type: link
     name: "BigCommerce"
-    url: "https://www.postman.com/resources/case-studies/bigcommerce/"
+    url: "https://www.postman.com/customers/bigcommerce/"
   - type: subtitle
     name: "Blog Posts"
   - type: link

--- a/src/pages/docs/sending-requests/intro-to-collections.md
+++ b/src/pages/docs/sending-requests/intro-to-collections.md
@@ -14,7 +14,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Ping Identity"
-    url: "https://www.postman.com/resources/case-studies/pingidentity/"
+    url: "https://www.postman.com/customers/pingidentity/"
   - type: subtitle
     name: "Videos"
   - type: link

--- a/src/pages/docs/writing-scripts/intro-to-scripts.md
+++ b/src/pages/docs/writing-scripts/intro-to-scripts.md
@@ -18,7 +18,7 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Giant Machines"
-    url: "https://www.postman.com/resources/case-studies/giant-machines/"
+    url: "https://www.postman.com/customers/giant-machines/"
   - type: subtitle
     name: "Related Blog Posts"
   - type: link

--- a/src/pages/docs/writing-scripts/test-scripts.md
+++ b/src/pages/docs/writing-scripts/test-scripts.md
@@ -18,10 +18,10 @@ contextual_links:
     name: "Case Studies"
   - type: link
     name: "Ping Identity"
-    url: "https://www.postman.com/resources/case-studies/pingidentity/"
+    url: "https://www.postman.com/customers/pingidentity/"
   - type: link
     name: "iQmetrix"
-    url: "https://www.postman.com/resources/case-studies/iqmetrix/"
+    url: "https://www.postman.com/customers/iqmetrix/"
   - type: subtitle
     name: "Videos"
   - type: link


### PR DESCRIPTION
Updated URLs to case studies.  Current URLs cause a redirect on our marketing page.  These new urls avoid redirects.