### PR TITLE
[GH-3073] fixed broken image link

### DIFF
--- a/src/pages/docs/integrations/available-integrations/new-relic.md
+++ b/src/pages/docs/integrations/available-integrations/new-relic.md
@@ -79,7 +79,7 @@ The following metrics and their values are pushed from Postman to New Relic. Run
 
 There are several attributes can be used as dimensions when viewing metrics in New Relic. For example, you could add `monitor.name` or `user.name` to show separate lines for the monitor or user shown in the graph. The following example pivots latency data with regions:
 
-[![New Relic filters](https://assets.postman.com/postman-docs/new-relic-query.jpg)](/new-relic-query.jpg)
+[![New Relic filters](https://assets.postman.com/postman-docs/new-relic-query.jpg)](https://assets.postman.com/postman-docs/new-relic-query.jpg)
 
 The following attributes can be used as dimensions:
 


### PR DESCRIPTION
<img width="932" alt="Screen Shot 2021-05-18 at 4 16 54 PM" src="https://user-images.githubusercontent.com/4358288/118735039-781cf900-b7f4-11eb-8823-6a916593313c.png">
Fixes #3073 