### PR TITLE
feat: add contributor over time graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ We would love for you to contribute to the Learning Center! To contribute to thi
 
 > To say thank you for your contribution, we’d love to send you exclusive Contributor swag. Fill out the [Contributor Submission form](https://docs.google.com/forms/d/e/1FAIpQLSfbLAcxl-IOiv3NmgEaWw7FleOaXnIyIoIrY_zn6U4JvjQBGA/viewform?usp=send_form) and we’ll send you a token of our gratitude.
 
+## Contributor over time
+
+[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=postmanlabs/postman-docs)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=postmanlabs/postman-docs)
+
 ## Build the Learning Center locally
 
 ```


### PR DESCRIPTION
Hi, community!

To better present how our community grows, we develop a tool to show contributors growing history on [https://github.com/api7/contributor-graph](https://github.com/api7/contributor-graph). Since we found it helpful, we think maybe if it could help some other community.

## WHAT IT IS

Basically, it just shows the contributors growth over time, just like the stargazers over time on the README. It would be the same with stars that we would update the graph each day, so the link would always present the real-time data. There is some other stuff to play around with if you would like to give it a try~

![image](https://user-images.githubusercontent.com/72343596/119218729-72852300-bb14-11eb-837b-0cd1e33d19f1.png)

## HOW IT WORKS 

We use Github API to get all commits, try to find the “Github way” to filter commits so the result data would be similar to Github, and then get the first commit time of each user.

Don't hesitate to tell us if there is a better place to present this graph other than this, or there are some other worries or other features you would like to have~🍻

