### PR TITLE
Video embed nocookies

### DIFF
--- a/src/pages/docs/integrations/webhooks.md
+++ b/src/pages/docs/integrations/webhooks.md
@@ -5,7 +5,7 @@ page_id: "custom_webhooks"
 warning: false
 contextual_links:
   - type: section
-    name: "Prerequisites"
+    name: "Prerequisite"
   - type: link
     name: "Grouping requests in collections"
     url: "/docs/sending-requests/intro-to-collections/"

--- a/src/pages/docs/publishing-your-api/publishing-your-docs.md
+++ b/src/pages/docs/publishing-your-api/publishing-your-docs.md
@@ -120,7 +120,7 @@ Add listing details for your public documentation, including name, summary, desc
 
 If you do not want to make your docs discoverable at this time, you can go ahead and publish then add them to the API Network or Postman Templates later.
 
-<iframe class="mb-4" width="560" height="315" src="https://www.youtube.com/embed/w-EgqQ8Anvw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe loading="lazy" class="mb-4" width="560" height="315" src="https://www.youtube-nocookie.com/embed/w-EgqQ8Anvw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Publishing and unpublishing
 

--- a/src/pages/docs/sending-requests/supported-api-frameworks/graphql.md
+++ b/src/pages/docs/sending-requests/supported-api-frameworks/graphql.md
@@ -48,7 +48,7 @@ Try it out in Postman with this [example template](https://explore.postman.com/t
 
 ## Sending a GraphQL query
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/7pUbezVADQs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube-nocookie.com/embed/7pUbezVADQs" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br/>
 

--- a/src/pages/docs/sending-requests/visualizer.md
+++ b/src/pages/docs/sending-requests/visualizer.md
@@ -61,7 +61,7 @@ Visualizers let you present your response data in ways that help to make sense o
 
 ## Visualizing response data
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/i1jU-kivApg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube-nocookie.com/embed/i1jU-kivApg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br/>
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -153,9 +153,11 @@ class IndexPage extends React.Component {
           <div className="col-lg-8 order-lg-13">
             <div className="embed-responsive embed-responsive-16by9">
               <iframe
+                loading="lazy"
                 className="embed-responsive-item"
-                src="https://www.youtube.com/embed/7E60ZttwIpY?rel=0"
+                src="https://www.youtube-nocookie.com/embed/7E60ZttwIpY?rel=0"
                 title="Intro to Postman"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                 allowFullScreen
               />
             </div>


### PR DESCRIPTION
* added updated `allow` attributes to youtube embeds
* added `-nocookie` to embed URLs to fix white screen of death in youtube iframes. (YouTube embeds were not showing videos and request was being "stalled" in Network tab.)