### PR TITLE
#3115 replaced three bit.ly urls in introduction.md with full urls

### DIFF
--- a/src/pages/docs/getting-started/introduction.md
+++ b/src/pages/docs/getting-started/introduction.md
@@ -40,8 +40,8 @@ If you're just starting to learn about APIs and Postman, you can use a variety o
 * Use the __Bootcamp__ to work through lessons inside Postman—open it at the bottom right of the app.
 * Explore [workspaces, collections, and more](https://www.postman.com/explore) that you can try out inside Postman, like the following:
     * [**Learn by API**](https://www.postman.com/postman/workspace/published-postman-templates/collection/9065401-ff29b3be-af69-4442-91e0-c1158b620fc2?ctx=documentation)–walk through beginner API concepts.
-    * [**Postman Training**](https://bit.ly/postman-training)–Learn APIs 101, Testing and Automation, API Adoption, and API First, earning [Postman badges](https://bit.ly/postman-api-badges).
-    * [**Student Program**](https://bit.ly/student-workspace)–Take the Student Expert training, covering request configurations and test scripting.
+    * [**Postman Training**](https://www.postman.com/postman/workspace/postman-galaxy-training/overview)–Learn APIs 101, Testing and Automation, API Adoption, and API First, earning [Postman badges](https://badgr.com/public/issuers/BC0x4AQaQPC7lFilsBP_tQ/badges).
+    * [**Student Program**](https://www.postman.com/postman/workspace/postman-student-program/overview)–Take the Student Expert training, covering request configurations and test scripting.
 
 ## What are you here to learn about?
 


### PR DESCRIPTION


**Remove shortened URLs #3115** 

In src/pages/docs/getting-started/introduction.md there are two links to bit.ly URLs. Change those to the actual URLs.

Replace three bit.ly links in src/pages/docs/getting-started/introduction.md with urls

<img width="925" alt="Screen Shot 2021-06-10 at 1 19 48 PM" src="https://user-images.githubusercontent.com/51421669/121569278-9e4a4900-c9ee-11eb-919f-126d86e79405.png">


