### PR TITLE
Updated `go.postman` links

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -62,7 +62,7 @@ const LoginCheck = (props) => {
   }
   return (
     <a
-      href="https://go.postman.co/build"
+      href="https://go.postman.co/home"
       className="btn btn__primary"
       onClick={() => {
         // To stop the page reloading

--- a/src/pages/docs/getting-started/installation-and-updates.md
+++ b/src/pages/docs/getting-started/installation-and-updates.md
@@ -35,7 +35,7 @@ contextual_links:
 
 ---
 
-Postman is available as a native desktop app for Mac, Windows (32-bit / 64-bit), and Linux (32-bit / 64-bit) operating systems, and on the web at **[go.postman.co/build](https://go.postman.co/build)**.
+Postman is available as a native desktop app for Mac, Windows (32-bit / 64-bit), and Linux (32-bit / 64-bit) operating systems, and on the web at **[go.postman.co/home](https://go.postman.co/home)**.
 
 To get the latest version of the Postman desktop app, visit the [download page](https://www.postman.com/downloads/) and click **Download** for your platform.
 
@@ -115,7 +115,7 @@ Categories=Development;
 
 ## Using Postman on the web
 
-You can use Postman in your web browser to carry out your API development and testing tasks in conjunction with the Postman Agent. To access Postman on the web, visit [go.postman.co/build](https://go.postman.co/build) in your browser. If you are using the Postman web client, you will need to also download the Postman desktop agent. You will be prompted to download and install the agent so that you can make requests from the web. You can also download the agent directly from [this Downloads page](https://www.postman.com/downloads/).
+You can use Postman in your web browser to carry out your API development and testing tasks in conjunction with the Postman Agent. To access Postman on the web, visit [go.postman.co/home](https://go.postman.co/home) in your browser. If you are using the Postman web client, you will need to also download the Postman desktop agent. You will be prompted to download and install the agent so that you can make requests from the web. You can also download the agent directly from [this Downloads page](https://www.postman.com/downloads/).
 
 <img alt="Postman Agent" src="https://assets.postman.com/postman-docs/download-agent.jpg" width="500px"/>
 

--- a/src/pages/docs/getting-started/postman-account.md
+++ b/src/pages/docs/getting-started/postman-account.md
@@ -49,7 +49,7 @@ Signing up for an account is optional—you can use the desktop Postman app with
 
 To use Postman on the desktop, [download](https://www.postman.com/downloads/) the app and launch it.
 
-Alternatively, navigate to Postman on the web at [go.postman.co/build](https://go.postman.co/build).
+Alternatively, navigate to Postman on the web at [go.postman.co/home](https://go.postman.co/home).
 
 You will see a prompt to log in or sign up.
 

--- a/src/pages/docs/getting-started/syncing.md
+++ b/src/pages/docs/getting-started/syncing.md
@@ -54,7 +54,7 @@ These entities can sync with the server and be saved to the cloud:
 
 Install [Postman](https://www.postman.com/downloads/) and sign in with the same email address or username on all your devices.
 
-Alternatively, access Postman on the web by visiting [go.postman.co/build](https://go.postman.co/build) in your browser and signing into your account.
+Alternatively, access Postman on the web by visiting [go.postman.co/home](https://go.postman.co/home) in your browser and signing into your account.
 
 If you forget your username or password, you can recover them using the links in the sign-in prompt.
 


### PR DESCRIPTION
Fixes #3141

Updated the `go.postman.co/build` HREFs to `go.postman.co/home`