### PR TITLE
Style guide edits

### DIFF
--- a/src/pages/docs/getting-started/settings.md
+++ b/src/pages/docs/getting-started/settings.md
@@ -63,7 +63,7 @@ If you want Postman to persist your file paths, then you must save your files in
 Postman flags a warning for files that are not stored in this directory.
 
 However, delimiting the working directory can have some unintended security issues as follows:
-  
+
   1. It is against the general principle of security to give system-wide access to a program as it exposes a user's system to all types of threats.
   2. Restricting the working directory would prevent safety issues arising when files obtained from external/anonymous sources are used. For example, a collection that the user has obtained from the internet. The user may or may not have proper information about the collection and as such may not understand if the collection serves some other hidden function.
   3. Absolute file path can also be given to postman, but when sharing it may not work for the user it is shared to as absolute paths can vary between systems.
@@ -117,7 +117,7 @@ Import and export data in bulk inside Postman.  This will overwrite your existi
 
 ## Add-ons
 
-Download Newman, Postman's command line companion, to integrate Postman collections with your build system, or run automated tests for your API through a cron job. Learn more about [Newman](/docs/running-collections/using-newman-cli/command-line-integration-with-newman/).
+Download Newman, Postman's command-line companion, to integrate Postman collections with your build system or run automated tests for your API through a cron job. Learn more about [Newman](/docs/running-collections/using-newman-cli/command-line-integration-with-newman/).
 
 ## Sync
 

--- a/src/pages/docs/running-collections/intro-to-collection-runs.md
+++ b/src/pages/docs/running-collections/intro-to-collection-runs.md
@@ -109,7 +109,7 @@ To export a collection run, open it in the __Runner__ (using __History__ on the 
 
 In addition to using the Collection Runner in Postman, you can use collection runs in conjunction with other utilities in order to build automation into your API projects.
 
-* The Postman command line interface [Newman](/docs/running-collections/using-newman-cli/command-line-integration-with-newman/) allows you to run collections and build them into your development pipeline, responding to test outcomes to maintain your API performance.
+* The Postman command-line interface [Newman](/docs/running-collections/using-newman-cli/command-line-integration-with-newman/) enables you to run collections and build them into your development pipeline, responding to test outcomes to maintain your API performance.
 * Adding a [monitor](/docs/designing-and-developing-your-api/monitoring-your-api/intro-monitors/) to your collection lets you schedule collection runs and stay informed of any issues.
 
 ## Next steps

--- a/src/pages/docs/running-collections/using-newman-cli/command-line-integration-with-newman.md
+++ b/src/pages/docs/running-collections/using-newman-cli/command-line-integration-with-newman.md
@@ -28,15 +28,13 @@ tags:
 
 ---
 
-Newman is a command line Collection Runner for Postman. It allows you to run and test a Postman Collection directly from the command line. It is built with extensibility in mind so that you can easily integrate it with your continuous integration servers and build systems.
+Newman is a command-line Collection Runner for Postman. It enables you to run and test a Postman Collection directly from the command line. It is built with extensibility in mind so that you can easily integrate it with your continuous integration servers and build systems.
 
 Newman maintains feature parity with Postman and allows you to run collections the way they are executed inside the collection runner in Postman.
 
 Newman resides in the [NPM registry](https://www.npmjs.com/package/newman) and on [GitHub](https://github.com/postmanlabs/newman).
 
 [![newman gif](https://assets.postman.com/postman-docs/newman-running-in-terminal.gif)](https://assets.postman.com/postman-docs/newman-running-in-terminal.gif)
-
-We'll cover these topics to learn command line integration with Newman:
 
 * [Getting Started](#getting-started)
 * [Options](#options)
@@ -50,7 +48,7 @@ We'll cover these topics to learn command line integration with Newman:
 
 Newman is built on Node.js. To run Newman, make sure you have Node.js installed.
 
-You can [download and install](https://nodejs.org/en/download/current/) Node.js on Linux, Windows, and Mac OSX.
+You can [download and install](https://nodejs.org/en/download/current/) Node.js on Linux, Windows, and macOS.
 
 After you install Node.js, Newman is just a command away. Install Newman from npm globally on your system, which allows you to run it from anywhere.
 

--- a/src/pages/docs/running-collections/using-newman-cli/continuous-integration.md
+++ b/src/pages/docs/running-collections/using-newman-cli/continuous-integration.md
@@ -9,7 +9,7 @@ contextual_links:
     name: "Grouping requests in collections"
     url: "/docs/sending-requests/intro-to-collections/"
   - type: link
-    name: "Command line integration with Newman"
+    name: "Command-line integration with Newman"
     url: "/docs/running-collections/using-newman-cli/command-line-integration-with-newman/"
   - type: section
     name: "Additional Resources"

--- a/src/pages/docs/running-collections/using-newman-cli/integration-with-jenkins.md
+++ b/src/pages/docs/running-collections/using-newman-cli/integration-with-jenkins.md
@@ -6,7 +6,7 @@ contextual_links:
   - type: section
     name: "Prerequisites"
   - type: link
-    name: "Command line integration with Newman"
+    name: "Command-line integration with Newman"
     url: "/docs/running-collections/using-newman-cli/command-line-integration-with-newman/"
   - type: section
     name: "Additional Resources"
@@ -30,7 +30,7 @@ tags:
 
 ---
 
-Postman contains a full-featured [testing sandbox](/docs/writing-scripts/script-references/postman-sandbox-api-reference/) that lets you write and execute JavaScript based tests for your API. You can then hook up Postman with your build system using [Newman](/docs/running-collections/using-newman-cli/command-line-integration-with-newman/), the command line collection runner for Postman.
+Postman contains a full-featured [testing sandbox](/docs/writing-scripts/script-references/postman-sandbox-api-reference/) that lets you write and execute JavaScript based tests for your API. You can then hook up Postman with your build system using [Newman](/docs/running-collections/using-newman-cli/command-line-integration-with-newman/), the command-line collection runner for Postman.
 
 Newman allows you to run and test a Postman Collection. Newman and Jenkins are a perfect match. Let's review these topics to set up this operation.
 
@@ -49,7 +49,7 @@ Newman allows you to run and test a Postman Collection. Newman and Jenkins are a
 
 1. Install NodeJS and npm. Newman is written in NodeJS and the official copy is available through npm. Install [nodejs and npm for Linux](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 
-1. Install Newman globally, to set up Newman as a command line tool in Ubuntu.
+1. Install Newman globally, to set up Newman as a command-line tool in Ubuntu.
 
     ```bash
     $ npm install -g newman

--- a/src/pages/docs/running-collections/using-newman-cli/integration-with-travis.md
+++ b/src/pages/docs/running-collections/using-newman-cli/integration-with-travis.md
@@ -6,7 +6,7 @@ contextual_links:
   - type: section
     name: "Prerequisites"
   - type: link
-    name: "Command line integration with Newman"
+    name: "Command-line integration with Newman"
     url: "/docs/running-collections/using-newman-cli/command-line-integration-with-newman/"
   - type: section
     name: "Additional Resources"
@@ -72,7 +72,7 @@ Let's learn more about integration with Travis:
     Remember to add and commit these two files to your repo.
 
     [![tree view tests directory](https://assets.postman.com/postman-docs/travis_tree.png)](https://assets.postman.com/postman-docs/travis_tree.png)
-  
+
 1. Create a new file called `.travis.yml` and move it to the root of your project repository.
 
     Remember to add and commit it to your repo. This file tells Travis CI the programming language for your project and how to  build it.
@@ -82,7 +82,7 @@ Let's learn more about integration with Travis:
     [![tree view yml](https://assets.postman.com/postman-docs/travis_tree_yml.png)](https://assets.postman.com/postman-docs/travis_tree_yml.png)
 
 1. In the `.travis.yml` file, add a command to `install` Newman in the CI environment, and then add a `script` telling Newman to run the Postman tests (which we've placed in the `tests` directory).
-  
+
     Since Travis CI doesn’t know where Newman is located, let's update the `PATH`. In this node.js example, the `newman` tool is located in my `.bin` directory which is located in my `node_modules` directory.
 
     Now, the `.travis.yml` file looks like this for this `node.js` example:
@@ -107,7 +107,7 @@ Let's learn more about integration with Travis:
 Travis CI is now set up to run your Postman tests every time you trigger a build, for example, by pushing a commit to your repo.
 
 Let’s try it out. The Travis CI [build status page](https://travis-ci.org/) will show if the build passes or fails:
-  
+
 [![travis fail](https://assets.postman.com/postman-docs/travis_fail.png)](https://assets.postman.com/postman-docs/travis_fail.png)
 
    Travis CI is running the Newman command, but you see a failed exit code (1). Boo.
@@ -120,7 +120,7 @@ Let’s try it out. The Travis CI [build status page](https://travis-ci.org/) 
 
 [![PM test script](https://assets.postman.com/postman-docs/WS-get-information95.png)](https://assets.postman.com/postman-docs/WS-get-information95.png)
 
-   Once you fix the mistake in the test, let’s save the changes, update the repo with the latest collection file, and then trigger a Travis CI build once again by committing and pushing the change.  
+   Once you fix the mistake in the test, let’s save the changes, update the repo with the latest collection file, and then trigger a Travis CI build once again by committing and pushing the change.
 
 [![travis log success](https://assets.postman.com/postman-docs/travis_log_success.png)](https://assets.postman.com/postman-docs/travis_log_success.png)
 

--- a/src/pages/docs/running-collections/using-newman-cli/newman-with-docker.md
+++ b/src/pages/docs/running-collections/using-newman-cli/newman-with-docker.md
@@ -6,7 +6,7 @@ contextual_links:
   - type: section
     name: "Prerequisites"
   - type: link
-    name: "Command line integration with Newman"
+    name: "Command-line integration with Newman"
     url: "/docs/running-collections/using-newman-cli/command-line-integration-with-newman/"
   - type: section
     name: "Additional Resources"
@@ -65,7 +65,7 @@ The URL is a shareable public link to your collection. You can get this by click
 
 At this stage, you should see the [Collection](/docs/sending-requests/intro-to-collections/) running in Newman and the output displayed in the terminal.
 
-The entry point to the Docker image is Newman. So you can use all Newman command line parameters. You can also run locally stored collection files. The README of the image outlines how to mount shared data volumes.
+The entry point to the Docker image is Newman. So you can use all Newman command-line parameters. You can also run locally stored collection files. The README of the image outlines how to mount shared data volumes.
 
 ## Windows
 

--- a/src/pages/docs/running-collections/working-with-data-files.md
+++ b/src/pages/docs/running-collections/working-with-data-files.md
@@ -81,4 +81,4 @@ If the errors persist, [contact the Postman support team](https://support.getpos
 To continue learning to leverage collection runs, check out the following resources:
 
 * [Building workflows](/docs/running-collections/building-workflows/)
-* [Command line integration with Newman](/docs/running-collections/using-newman-cli/command-line-integration-with-newman/)
+* [Command-line integration with Newman](/docs/running-collections/using-newman-cli/command-line-integration-with-newman/)

--- a/src/pages/docs/writing-scripts/script-references/test-examples.md
+++ b/src/pages/docs/writing-scripts/script-references/test-examples.md
@@ -27,7 +27,7 @@ contextual_links:
   - type: section
     name: "Next Steps"
   - type: link
-    name: "Command line integration with Newman"
+    name: "Command-line integration with Newman"
     url: "/docs/running-collections/using-newman-cli/command-line-integration-with-newman/"
 
 warning: false


### PR DESCRIPTION
* macOS
* command-line hyphenated when used as an adjective
* some other minor edits