### PR TITLE
Update configuring-scim.md

### DIFF
--- a/src/pages/docs/administration/managing-your-team/configuring-scim.md
+++ b/src/pages/docs/administration/managing-your-team/configuring-scim.md
@@ -95,7 +95,7 @@ Under **SCIM provisioning**, select **Generate SCIM API Key**.
 
 Name your key and click **Generate**. Copy your new API key for later use and click **Done**.
 
-> You can revisit this page to generate a new API key later on if needed. Your previous API key will stay active briefly while you switch over.
+> You can revisit this page to manage your SCIM API keys. If you regenerate an existing API key, you will have the option to keep the previous key active briefly while you switch over.
 
 <!-- -->
 


### PR DESCRIPTION
A user can generate multiple SCIM API keys. Creating a new SCIM API key does not make existing keys inactive. If a user regenerates an existing API ley, they have the option to delete the existing API key or to delete it after a period of 6 hours of key regeneration.