### PR TITLE
Add language to every fenced code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We would love for you to contribute to the Learning Center! To contribute to thi
 
 ## Build the Learning Center locally
 
-```
+```shell
 
    $ git clone https://github.com/postmanlabs/postman-docs.git
    $ cd postman-docs
@@ -40,7 +40,7 @@ You can build the Learning Center and run it in a Docker container using the fol
 
 2. Create a file and name it "dockerfile" with the following contents:
 
-    ```
+    ```shell
 
     FROM node:12
 
@@ -60,7 +60,7 @@ You can build the Learning Center and run it in a Docker container using the fol
 
     The dockerfile should be in the same directory as the postman-docs directory
 
-    ```
+    ```shell
 
     # example directory structure
     |--[current folder]
@@ -81,7 +81,7 @@ You can build the Learning Center and run it in a Docker container using the fol
 
 You can also build with the `docker-compose` command using the dockerfile above and this docker-compose.yaml
 
-```
+```yaml
 
 version: '3'
 services:
@@ -95,7 +95,7 @@ services:
 
 The docker-compose.yaml should be in the same directory as the postman-docs directory and dockerfile.
 
-```
+```shell
 
 # example directory structure
 |--[current folder]
@@ -121,7 +121,7 @@ The built site will only host the most up-to-date docs. All legacy documentation
 
 * Links in the docs should be relative. Example:
 
-```
+```shell
 
    [Newman](/docs/postman/collection-runs/command-line-integration-with-newman/)
 

--- a/src/pages/docs/administration/sso/microsoft-adfs.md
+++ b/src/pages/docs/administration/sso/microsoft-adfs.md
@@ -147,19 +147,19 @@ Collect the Identity Provider Single Sign-On URL, Identity Provider Issuer, and 
 
 * For ADFS 2.0, open the following file in a text editor:
 
-```
+```shell
 %systemroot%\inetpub\adfs\ls\web.config
 ```
 
 * For ADFS 3.0, open the following file in a text editor:
 
-```
+```shell
 %systemroot%\ADFS\Microsoft.IdentityServer.Servicehost.exe.config
 ```
 
 In the `<microsoft.identityServer.web>` section, add a line for __useRelyStateForIdpInitiatedSignOn__ as follows, and save the change:
 
-```
+```shell
 <microsoft.identityServer.web>    ... <useRelayStateForIdpInitiatedSignOn enabled="true" />    ...</microsoft.identityServer.web>
 ```
 

--- a/src/pages/docs/administration/upgrading-to-v8.md
+++ b/src/pages/docs/administration/upgrading-to-v8.md
@@ -104,7 +104,7 @@ Please use the following links to download the latest Postman v7 version for you
 
 **Note:** If you are using Postman for Linux, and had installed the app via 'Ubuntu Software Center' or 'Snap Store', please use the following commands to switch to Postman v7.
 
-```
+```shell
 sudo snap switch --channel=v7/stable postman
 sudo snap refresh postman
 ```
@@ -121,7 +121,7 @@ Please use the following links to download the latest Postman v6 version for you
 
 **Note:** If you are using Postman for Linux, and had installed the app via 'Ubuntu Software Center' or 'Snap Store', please use the following commands to switch to Postman v6.
 
-```
+```shell
 sudo snap switch --channel=v6/stable postman
 sudo snap refresh postman
 ```

--- a/src/pages/docs/api-security/security-warnings.md
+++ b/src/pages/docs/api-security/security-warnings.md
@@ -69,7 +69,7 @@ The following list describes possible warning messages and potential ways to res
 
 **Resolution:**
 
-```
+```json
 openapi: 3.0.0
 info:
 paths:
@@ -87,7 +87,7 @@ security:
 
 **Resolution:**
 
-```
+```json
 openapi: 3.0.0
 info:
 paths:
@@ -105,7 +105,7 @@ security:
 
 **Resolution:**
 
-```
+```json
 openapi: 3.0.0
 info:
 paths:
@@ -123,7 +123,7 @@ security:
 
 **Resolution:**
 
-```
+```json
 security:
   - OAuth2:
     - read
@@ -151,7 +151,7 @@ components:
 
 **Resolution:**
 
-```
+```json
 components:
   securitySchemes:
     testAuth:
@@ -171,7 +171,7 @@ components:
 
 **Resolution:**
 
-```
+```json
 paths:
   /user:
     get:
@@ -189,7 +189,7 @@ paths:
 
 **Resolution:**
 
-```
+```json
 paths:
   /user:
     get:
@@ -207,7 +207,7 @@ paths:
 
 **Resolution:**
 
-```
+```json
   /user:
     get:
       tags:
@@ -226,7 +226,7 @@ paths:
 
 **Resolution:**
 
-```
+```json
 paths:
   "/user":
     get:
@@ -259,7 +259,7 @@ components:
 
 **Resolution:**
 
-```
+```json
 servers:
   - url: https://my.api.example.com/
     description: API server
@@ -285,7 +285,7 @@ security:
 
 **Resolution:**
 
-```
+```json
 servers:
   - url: https://my.api.example.com/
     description: API server
@@ -310,7 +310,7 @@ security:
 
 **Resolution:**
 
-```
+```json
 servers:
   - url: https://my.api.example.com/
     description: API server
@@ -336,7 +336,7 @@ security:
 
 **Resolution**:
 
-```
+```json
 servers:
   - url: https://my.api.example.com/
     description: API server
@@ -364,7 +364,7 @@ security:
 
 **Resolution:**
 
-```
+```json
 components:
   securitySchemes:
     OAuth2:
@@ -388,7 +388,7 @@ paths:
 
 **Resolution:**
 
-```
+```json
 components:
   securitySchemes:
     ApikeyAuth:
@@ -412,7 +412,7 @@ paths:
 
 **Resolution:**
 
-```
+```json
 get:
   operationId: getPetsById
   servers:
@@ -429,7 +429,7 @@ get:
 
 **Resolution**:
 
-```
+```json
 components:
   securitySchemes:
     OpenIdScheme:
@@ -456,7 +456,7 @@ paths:
 
 **Resolution:**
 
-```
+```json
 components:
   securitySchemes:
      OauthScheme:
@@ -476,7 +476,7 @@ components:
 
 **Resolution:**
 
-```
+```json
 components:
   securitySchemes:
      OauthScheme:

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -158,13 +158,13 @@ With your mock URL, you can start making requests right away. Make sure the requ
 
 Open a tab (or edit the address in an existing tab) and add the mock URL:
 
-```
+```shell
 https://<mock-id>.mock.pstmn.io/<request-path>
 ```
 
 For example:
 
-```
+```shell
 https://3589dfde-f398-45cd-88eb-b0fa0192fc3f.mock.pstmn.io/matches
 ```
 

--- a/src/pages/docs/sending-requests/cookies.md
+++ b/src/pages/docs/sending-requests/cookies.md
@@ -60,7 +60,7 @@ This opens the **MANAGE COOKIES** modal, and displays a list of domains and the 
 
 To add a new cookie for the domain, click **Add Cookie**. A pre-generated cookie string compliant with [HTTP State Management standards](https://tools.ietf.org/html/rfc6265#section-4.1) will be created.
 
-```
+```js
 <cookieName>=<cookieValue>; path=/; domain=.domain.com; HttpOnly; Secure; Expires=Tue, 19 Jan 2038 03:14:07 GMT;
 ```
 

--- a/src/pages/docs/sending-requests/managing-environments.md
+++ b/src/pages/docs/sending-requests/managing-environments.md
@@ -2,7 +2,7 @@
 title: "Managing environments"
 order: 25
 page_id: "managing-environments"
-search_keyword: "pm.globals.set, globals.set, pm.environment.set, environment.set, pm.variables.get, variables.get, pm.globals.get, globals.get, pm.environment.get, environment.get" 
+search_keyword: "pm.globals.set, globals.set, pm.environment.set, environment.set, pm.variables.get, variables.get, pm.globals.get, globals.get, pm.environment.get, environment.get"
 contextual_links:
   - type: section
     name: "Prerequisites"
@@ -139,7 +139,7 @@ When you have an environment selected in the drop-down, Postman will treat it as
 
 To use an environment variable value in a request, reference it by name, surrounded with [double curly braces](/docs/sending-requests/variables/):
 
-```
+```js
 {{base_url}}
 ```
 
@@ -154,7 +154,7 @@ Hover over a variable reference to see its current value.
 
 You can access current environment variable values in your __Pre-request__ and __Tests__ code.
 
-```
+```js
 pm.environment.get("variable_key");
 ```
 

--- a/src/pages/docs/sending-requests/supported-api-frameworks/making-soap-requests.md
+++ b/src/pages/docs/sending-requests/supported-api-frameworks/making-soap-requests.md
@@ -31,7 +31,7 @@ The following steps outline how to make a SOAP request in Postman.
 
 Open a new request tab in Postman and enter your SOAP endpoint URL in the address field. Try out the following example if you do not have a specific service you want to call:
 
-```
+```xml
 https://www.dataaccess.com/webservicesserver/NumberConversion.wso
 ```
 

--- a/src/pages/docs/sending-requests/variables.md
+++ b/src/pages/docs/sending-requests/variables.md
@@ -243,19 +243,19 @@ When you run a request, Postman will resolve the variable and replace it with it
 
 For example, you could have a request URL referencing a variable as follows:
 
-```
+```js
 http://pricey-trilby.glitch.me/customer?id={{cust_id}}
 ```
 
 Postman will send whatever value you currently have stored for the `cust_id` variable when the request runs. If `cust_id` is currently `3`, the request will be sent to the following URL including query parameter:
 
-```
+```js
 http://pricey-trilby.glitch.me/customer?id=3
 ```
 
 Alternatively, you could have a request body that accesses a variable by wrapping its reference in double-quotes:
 
-```
+```js
 { "customer_id" : "{{cust_id}}" }
 ```
 


### PR DESCRIPTION
Every fenced code block should have a language after the three backticks. It causes a warning on build otherwise.