### PR TITLE
removed redirect chaining and updated anchor links

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "googleapis": "^55.0.0",
     "identity-obj-proxy": "^3.0.0",
     "markdownlint-cli": "^0.19.0",
-    "node": "^12.11.1",
+    "node": "^12.13.0",
     "node-sass": "^4.13.1",
     "prettier": "^1.18.2",
     "prismjs": "^1.20.0",

--- a/redirects.json
+++ b/redirects.json
@@ -217,7 +217,7 @@
 	},
 	{
 		"from": "/docs/postman-for-publishers/api-network/add-api-network/",
-		"to": "/docs/publishing-your-api/add-api-network/"
+		"to": "/docs/publishing-your-api/authoring-your-documentation/"
 	},
 	{
 		"from": "/docs/postman-for-publishers/api-network/api-submission-guidelines/",
@@ -1489,7 +1489,7 @@
 	},
 	{
 		"from": "/docs/postman_for_publishers/api_network/add_api_network/",
-		"to": "/docs/publishing-your-api/add-api-network/"
+		"to": "/docs/publishing-your-api/authoring-your-documentation/"
 	},
 	{
 		"from": "/docs/postman_for_publishers/api_network/api_submission_guidelines/",
@@ -1800,7 +1800,7 @@
 		"to": "/docs/administration/managing-your-team/managing-your-team/"},
 {
 		"from": "/docs/publishing-your-api/add-api-network/",
-		"to": "/docs/publishing-your-api/publish-public-api/"
+		"to": "/docs/publishing-your-api/authoring-your-documentation/"
 },
 {
 		"from": "/docs/integrations/available-integrations/microsoft-flow/",

--- a/src/pages/docs/administration/managing-your-team/managing-your-team.md
+++ b/src/pages/docs/administration/managing-your-team/managing-your-team.md
@@ -49,7 +49,7 @@ Each team member must have a minimum of one role assigned to them. Note that onl
 
 Teams may have two support accounts at no additional cost. Support accounts are defined as members with only admin and/or billing roles.
 
-> Roles can also be assigned via [groups](/docs/administration/managing-your-team/user-groups/#editing-team-roles-for-a-user-group).
+> Roles can also be assigned via [groups](/docs/administration/managing-your-team/user-groups/).
 
 ## Invites
 

--- a/src/pages/docs/administration/sso/saml-okta.md
+++ b/src/pages/docs/administration/sso/saml-okta.md
@@ -18,7 +18,7 @@ You can set up your custom SAML application by using the available Postman app i
 ## Contents
 
 * [Setting up a custom SAML application in Okta](#setting-up-a-custom-saml-application-in-okta)
-* [Setting up a custom SAML application in Okta by using the Postman app](#setting-up-a-custom-saml-application-in-okta-using-the-postman-app)
+* [Setting up a custom SAML application in Okta by using the Postman app](#setting-up-a-custom-saml-application-in-okta-by-using-the-postman-app)
 
 ## Setting up a custom SAML application in Okta
 

--- a/src/pages/docs/administration/team-merge.md
+++ b/src/pages/docs/administration/team-merge.md
@@ -49,7 +49,7 @@ Team migration can occur in different ways depending on your needs and preferred
 
 ## Migrating your data
 
-You can choose either [centralized](#centralized-migration) or [distributed](#distributed-migration) migration to export your team data.
+You can choose either [centralized](#choosing-centralized-migration) or [distributed](#choosing-distributed-migration) migration to export your team data.
 
 > As a precautionary measure prior to migrating data, admins and team members are strongly encouraged to perform a [JSON data dump backup through a bulk export](/docs/getting-started/importing-and-exporting-data/#exporting-data-dumps).
 
@@ -103,7 +103,7 @@ See [performing distributed migration](#performing-distributed-migration) to cho
 * The appointed admin on the old team should inherit ownership of all shared collections. To do this they can [join the existing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#joining-workspaces).
     * Data from team workspaces you have not joined will not be present in the export.
     * By default, the person who imports a collection or environment is automatically assigned the Editor role (see more about [roles](/docs/collaborating-in-postman/roles-and-permissions/)). Everyone else on the team will be assigned as Viewer.
-* [Export all data](#what-data-is-exported-in-a-large-JSON-file-data-dump?) at once via a [JSON data dump](/docs/getting-started/importing-and-exporting-data/#exporting-data-dumps).
+* [Export all data](/docs/getting-started/importing-and-exporting-data/#exporting-postman-data) at once via a [JSON data dump](/docs/getting-started/importing-and-exporting-data/#exporting-data-dumps).
 * The appointed admin can then [re-import into the new team](/docs/getting-started/importing-and-exporting-data/#importing-data-into-postman).
     * All collections included in the data dump will be imported into your currently selected workspace.
 * When your new team is ready for team members to join, the admin on the new team can send invitations to all other team members. The invite link will prompt them to leave their current team to join the new team.

--- a/src/pages/docs/administration/team-settings.md
+++ b/src/pages/docs/administration/team-settings.md
@@ -40,7 +40,7 @@ When you select **Team Settings**, you will be automatically directed to **Edit 
 
 <img alt="Edit team profile" src="https://assets.postman.com/postman-docs/edit-team-profile-settings.jpg"/>
 
-You can also opt to enable your team's public profile. If you enable this feature, your team's profile will show up on Postman's [API Network](/docs/publishing-your-api/add-api-network/), along with any [APIs](/docs/publishing-your-api/add-api-network/#adding-your-api), [collections](/docs/publishing-your-api/publishing-your-docs/), and [workspaces](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/#creating-a-public-workspace) your team has published. You can also add an **About your team** section, a link to your website, and links to social media accounts to your team's public profile.
+You can also opt to enable your team's public profile. If you enable this feature, your team's profile will show up on Postman's [API Network](/docs/collaborating-in-postman/adding-private-network/), along with any [APIs](/docs/collaborating-in-postman/adding-private-network/#adding-your-apis), [collections](/docs/publishing-your-api/publishing-your-docs/), and [workspaces](/docs/collaborating-in-postman/public-workspaces/) your team has published. You can also add an **About your team** section, a link to your website, and links to social media accounts to your team's public profile.
 
 ## Making your team discoverable
 

--- a/src/pages/docs/administration/upgrading-to-v8.md
+++ b/src/pages/docs/administration/upgrading-to-v8.md
@@ -21,9 +21,9 @@ This section describes the steps to migrate your team to Postman v8.
     * [Upgrading to v8 as an individual](#upgrading-to-v8-as-an-individual)
     * [Upgrading to v8 as a team](#upgrading-to-v8-as-a-team)
 * [Migrating from v6 to Postman v8](#migrating-from-v6-to-postman-v8)
-    * [Migrating from v6 as an individual](#Migrating-from-v6-as-an-individual)
-    * [Migrating from v6 as a team](#Migrating-from-v6-as-a-team)
-* [Installing earlier versions of Postman](#installing-earlier-versions-of-Postman)
+    * [Migrating from v6 as an individual](#migrating-from-v6-as-an-individual)
+    * [Migrating from v6 as a team](#migrating-from-v6-as-a-team)
+* [Installing earlier versions of Postman](#installing-earlier-versions-of-postman)
     * [Downloading Postman v7](#downloading-postman-v7)
     * [Downloading Postman v6](#downloading-postman-v6)
 
@@ -77,7 +77,7 @@ First, you need to update your Postman app from v6 to v7.36.5.
 
 <img alt="Migrate v6 to v7.35.6" src="https://assets.postman.com/postman-docs/migrate-v6-to-v7.36.5.jpg"/>
 
-Once the update is complete, you will be on Postman v7.36.5. This is the gateway version to update to v8. See [upgrading to v8](#upgrading-from-v7-to-v8) to update your app to Postman v8.
+Once the update is complete, you will be on Postman v7.36.5. This is the gateway version to update to v8. See [upgrading to v8](#upgrading-to-postman-v8) to update your app to Postman v8.
 
 ### Migrating from v6 as a team
 
@@ -87,7 +87,7 @@ If you are an admin, it is recommended you upgrade your team to v8 at your earli
 
 Once your team has migrated to Postman v8, all users in the team would be notified, via email and banners within the app, that they need to update their app to Postman v8.
 
-> If you are on a team and download Postman v7 or above while the rest of your team is using an older version of Postman v6 or below, you will not be able to use Postman v7 or above. [Download Postman v7](#downloading-postman-v7-app) or [download Postman v6](#downloading-postman-v6-app) to continue working with your team in the interim.
+> If you are on a team and download Postman v7 or above while the rest of your team is using an older version of Postman v6 or below, you will not be able to use Postman v7 or above. [Download Postman v7](#downloading-postman-v7) or [download Postman v6](#downloading-postman-v6) to continue working with your team in the interim.
 
 ## Installing earlier versions of Postman
 

--- a/src/pages/docs/collaborating-in-postman/public-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/public-workspaces.md
@@ -24,7 +24,7 @@ contextual_links:
     url: "https://youtu.be/4ulU2FZMPjQ"	  
 ---
 
-[Public workspaces](https://blog.postman.com/public-workspaces-why-we-created-them-what-you-can-do/) enable you to collaborate on entities with anyone across the world. Before you create a public workspace, navigate to your [team profile settings](https://postman.postman.co/settings/team/general) and enable your public team profile. This will ensure your team's profile will show up on the [Public API Network](/docs/publishing-your-api/add-api-network/).
+[Public workspaces](https://blog.postman.com/public-workspaces-why-we-created-them-what-you-can-do/) enable you to collaborate on entities with anyone across the world. Before you create a public workspace, navigate to your [team profile settings](https://postman.postman.co/settings/team/general) and enable your public team profile. This will ensure your team's profile will show up on the [Public API Network](/docs/collaborating-in-postman/public-workspaces/).
 
 <img alt="Enable team profile" src="https://assets.postman.com/postman-docs/enable-public-profile-url.jpg"/>
 
@@ -175,4 +175,4 @@ Click **X** next to the team member you want to remove from the public workspace
 
 ## Next steps
 
-To add an API to the network, see [Adding your API](/docs/publishing-your-api/add-api-network/#adding-your-api). For more details on how to add categories to a public workspace, visit [Providing API detail](/docs/publishing-your-api/add-api-network/#providing-api-detail).
+To add an API to the network, see [Adding your API](docs/collaborating-in-postman/adding-private-network/#adding-your-apis). For more details on how to add categories to a public workspace, visit [Providing API detail](/docs/publishing-your-api/authoring-your-documentation/#documenting-request-detail).

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -32,7 +32,7 @@ You can use version control with your Postman Collections by forking and merging
 * [Forking an environment](#forking-an-environment)
 * [Creating pull requests](#creating-pull-requests)
     * [Pull request settings](#pull-request-settings)
-    * [Creating public PRs](#creating-public-PRs)
+    * [Creating public PRs](#creating-public-prs)
     * [Watching a pull request](#watching-a-pull-request)
 * [Approving changes](#approving-changes)
 * [Merging changes](#merging-changes)

--- a/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/setting-up-monitor.md
+++ b/src/pages/docs/designing-and-developing-your-api/monitoring-your-api/setting-up-monitor.md
@@ -39,7 +39,7 @@ Postman Monitoring offers a number of configuration options when creating a moni
 
     * [Creating a monitor via a collection](#creating-a-monitor-via-a-collection)
 
-    * [Creating a monitor with the + New button](#creating-a-monitor-with-the--new-button)
+    * [Creating a monitor with the + New button](#creating-a-monitor-with-the-new-button)
 
     * [Creating a monitor from history](#creating-a-monitor-from-history)
 

--- a/src/pages/docs/designing-and-developing-your-api/the-api-workflow.md
+++ b/src/pages/docs/designing-and-developing-your-api/the-api-workflow.md
@@ -177,7 +177,7 @@ You can edit existing mock servers from an **API** by opening the **Develop** ta
 
 <img alt="Edit Mock from Schema" src="https://assets.postman.com/postman-docs/edit-mock-schema.jpg" width="200px"/>
 
-Your [mock will open for editing](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/#editing-and-deleting-mock-servers) in Postman.
+Your [mock will open for editing](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/) in Postman.
 
 [![api edit mock web](https://assets.postman.com/postman-docs/editmockserver.png)](https://assets.postman.com/postman-docs/editmockserver.png)
 

--- a/src/pages/docs/designing-and-developing-your-api/view-and-analyze-api-reports.md
+++ b/src/pages/docs/designing-and-developing-your-api/view-and-analyze-api-reports.md
@@ -52,10 +52,10 @@ Your API reports will include different information if you're on an [Enterprise]
 You can access the following reports from the left navigation bar of your dashboard:
 
 * [Team Activity](#team-activity-reports)
-* [All APIs](#all-apis-reports)
-* [Private Network APIs](#private-network-apis-reports)
-* [Security Audit](#security-audit-reports)
-* [Individual API View](#individual-api-view-reports)
+* [All API reports](#all-api-reports)
+* [Private Network API reports](#private-network-api-reports)
+* [Security Audit reports](#security-audit-reports)
+* [Individual API view reports](#individual-api-view-reports)
 
 ## Team activity reports
 

--- a/src/pages/docs/getting-started/importing-and-exporting-data.md
+++ b/src/pages/docs/getting-started/importing-and-exporting-data.md
@@ -69,7 +69,7 @@ You can import your data from files, folders, links, raw text, or GitHub reposit
 
 You can import Postman data you previously exported, including collections, environments, data dumps, and globals.
 
-To import Postman data, click **Import**. Select your file or folder, input your link, paste your raw text, or [import from GitHub](#importing-github-repositories). Postman will automatically recognize Postman data, confirming the name, format, and what the file will import as. Click **Import** to bring your data into Postman.
+To import Postman data, click **Import**. Select your file or folder, input your link, paste your raw text, or [import from GitHub](#importing-via-github-repositories). Postman will automatically recognize Postman data, confirming the name, format, and what the file will import as. Click **Import** to bring your data into Postman.
 
 ![Import collection and environment](https://assets.postman.com/postman-docs/import-coll-env-2.jpg)
 

--- a/src/pages/docs/getting-started/using-scratch-pad.md
+++ b/src/pages/docs/getting-started/using-scratch-pad.md
@@ -52,7 +52,7 @@ To export all Scratch Pad data:
 1. Select **Collections**, **Environments**, or both, and select **Request Data Export**.
 1. You'll get an email with a link to download the data dump, which is a single JSON file containing your data.
 
-You can also export a single collection or an environment. For more information, see [Exporting Postman data](/docs/getting-started/importing-and-exporting-data/#exporting-postman-data/)
+You can also export a single collection or an environment. For more information, see [Exporting Postman data](/docs/getting-started/importing-and-exporting-data/#exporting-postman-data)
 
 To import Scratch Pad data:
 
@@ -60,4 +60,4 @@ To import Scratch Pad data:
 1. Click **Import** in the upper-left corner.
 1. Drag and drop your exported data dump, collection, or environment and click **Import**.
 
-For more information on importing, see [Importing data into Postman](/docs/getting-started/importing-and-exporting-data/#importing-data-into-postman/).
+For more information on importing, see [Importing data into Postman](/docs/getting-started/importing-and-exporting-data/#importing-data-into-postman).

--- a/src/pages/docs/integrations/available-integrations/statuspage.md
+++ b/src/pages/docs/integrations/available-integrations/statuspage.md
@@ -41,7 +41,7 @@ Make sure to create your Statuspage account and create a page and components bef
 1. Select a workspace from the list which contains the monitor you would like to use.
 1. Select the monitor you wish to use from the list.
 1. Select a Statuspage page where the monitor updates will be sent. This list will be populated with the pages you have created in Statuspage.
-1. Select one or both Statuspage actions. See [Link monitor to component](/docs/integrations/available-integrations/statuspage/#link-monitor-to-component/) and [Create incident when monitoring run fails](/docs/integrations/available-integrations/statuspage/#create-incident-when-monitoring-run-fails) for information on how to fill in these sections.
+1. Select one or both Statuspage actions. See [Link monitor to component](#link-monitor-to-component) and [Create incident when monitoring run fails](#create-incident-when-monitoring-run-fails) for information on how to fill in these sections.
 ![Configure Statuspage](https://assets.postman.com/postman-docs/configure-statuspage.jpg)
 1. Click the **Add Integration** button.
 

--- a/src/pages/docs/publishing-your-api/publishing-your-docs.md
+++ b/src/pages/docs/publishing-your-api/publishing-your-docs.md
@@ -99,7 +99,7 @@ To share your API documentation with your users and the wider Postman community,
 
 > When you publish public documentation, anyone with the URL can access it. By sharing your documentation with the API Network or as a template, you increase the visibility of your API to a wider range of consumers by leveraging the Postman community. Users can then access both the API Network and community templates via the __New__ button within the Postman app or [on the web](https://explore.postman.com).
 
-* Choose __Add to API Network__ to [feature your team docs in the Postman publisher network](/docs/publishing-your-api/add-api-network/).
+* Choose __Add to API Network__ to [feature your team docs in the Postman publisher network](/docs/publishing-your-api/publishing-your-docs/).
 
 You can only add to API Network when publishing from a team. You can configure your team profile by clicking __Public Profile Settings__, enabling your profile, and filling out your team details for display.
 

--- a/src/pages/docs/sending-requests/capturing-request-data/proxy.md
+++ b/src/pages/docs/sending-requests/capturing-request-data/proxy.md
@@ -164,4 +164,4 @@ If your proxy has basic auth, take the following steps:
 
     * Create this file and save it in a convenient location. When you open this file, the set environment variables will only apply to the Postman process.
 
-For troubleshooting configuration or request issues, see [Troubleshooting using console](/docs/sending-requests/troubleshooting-api-requests).
+For troubleshooting configuration or request issues, see [Troubleshooting using console](/docs/sending-requests/troubleshooting-api-requests/).

--- a/src/pages/docs/writing-scripts/script-references/postman-sandbox-api-reference.md
+++ b/src/pages/docs/writing-scripts/script-references/postman-sandbox-api-reference.md
@@ -121,7 +121,7 @@ console.log(pm.variables.get('score'));//outputs 2
 
 > See the [Postman Collection SDK Variables reference](https://www.postmanlabs.com/postman-collection/Variable.html) for more detail.
 
-You can also access variables defined in the individual scopes via [pm.environment](#scripting-with-environment-variables), [pm.collectionVariables](#scripting-with-collection-variables), and [pm.globals](#scripting-with-global-variables).
+You can also access variables defined in the individual scopes via [pm.environment](#using-environment-variables-in-scripts), [pm.collectionVariables](#using-collection-variables-in-scripts), and [pm.globals](#using-global-variables-in-scripts).
 
 #### Using environment variables in scripts
 
@@ -688,7 +688,7 @@ The callback function accepts two parameters:
 * `error`
     * Any error detail
 * `data`
-    * Data [passed to the template](#pmvisualizerset) by `pm.visualizer.set`
+    * Data [passed to the template](#scripting-visualizations) by `pm.visualizer.set`
 
 Example usage:
 


### PR DESCRIPTION
* i (temporarily) installed the https://www.gatsbyjs.com/plugins/gatsby-remark-check-links/ plugin to find broken links.
* it came back with a redirect chain and anchor links that have rotted away.
* I fixed the LONG redirect chain
* I updated all anchor links (some required reassigning to other / new page topics for them)