### PR TITLE
added gatsby-plugin-catch-links plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -91,6 +91,7 @@ module.exports = {
         ],
       },
     },
+    'gatsby-plugin-catch-links',
     'gatsby-transformer-sharp',
     {
       resolve: 'gatsby-plugin-manifest',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10822,6 +10822,25 @@
         }
       }
     },
+    "gatsby-plugin-catch-links": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-3.8.0.tgz",
+      "integrity": "sha512-SjgNG27IJ6mU/TkMVrvkuZtCS5NJql/rDJ4JN0WGX3eN4n+vwR3YDLeeIFpfVouSYUFfoqIdhcbHI4QBDk9rvw==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "gatsby-plugin-env-variables": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-env-variables/-/gatsby-plugin-env-variables-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gatsby": "^2.32.8",
     "gatsby-cli": "^2.19.2",
     "gatsby-plugin-algolia": "^0.3.4",
+    "gatsby-plugin-catch-links": "^3.8.0",
     "gatsby-plugin-env-variables": "^1.0.2",
     "gatsby-plugin-gdpr-cookies": "^1.0.14",
     "gatsby-plugin-google-analytics": "^2.3.4",


### PR DESCRIPTION
added gatsby-plugin-catch-links to keep page from reloading to top when cookie notice is closed.

When you click on the cookie notice, the page jumps to the top.

With this plugin, it appears to keep that from happening by treating it as a React / SPA type link.

**Reproduce issue:**
* open https://learning.postman.com/
* ensure the cookie notice is visible (otherwise clear Application data in Inspect toolbar)
* scroll down page
* close cookie notice
* note that the page scrolls to top

**Acceptance criteria with this plugin:**
* build app as production (gatsby clean, gatsby build, gatsby serve)
* ensure the cookie notice is visible (otherwise clear Application data in Inspect toolbar)
* scroll down page
* close cookie notice
* note that the page does NOT scroll to top

I also noticed that this may remove the left nav bar flickering / repainting I am seeing when paginating.