### PR TITLE
[MARKENG-263] home events, css-based event expiration; avoid link offset issue

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -46,13 +46,7 @@ class IndexPage extends React.Component {
       'Nov',
       'Dec',
     ];
-    // If, upcomingEvents is an array, sort the events array by date, and filter out past events.
-    // Else, leave as is.. which is an object with upcomingEvents.development = true
-    const sortedUpcomingEvents = Array.isArray(upcomingEvents)
-      ? upcomingEvents
-        .sort((a, b) => new Date(a.date) - new Date(b.date))
-        .filter((event) => new Date(event.expiration) > new Date())
-      : upcomingEvents;
+    const sortedUpcomingEvents = upcomingEvents;
 
     return (
       <Layout>
@@ -198,8 +192,9 @@ class IndexPage extends React.Component {
                 // Combine platform, date and time of the event
                 // Example: Livestream - 01/01/2000 4PM PST
                 const eventInformation = `${event.location} - ${date} ${event.time}`;
+                const isStale = new Date(event.expirationDate) < (new Date()) && ' d-none' || '';
                 return (
-                  <div className="col-12 col-xl-10 offset-xl-1 mb-4" key={uuidv4()}>
+                  <div className={`col-12 col-xl-10 offset-xl-1 mb-4${isStale}`} key={uuidv4()}>
                     <OutboundLink
                       className="event-link-wrapper"
                       href={event.link}


### PR DESCRIPTION
**Ticket/Issue:**
MARKENG-263

**What are the changes?**
_Branched from `develop`_, this implements a CSS-based (JS minimal) solution to suppress expired events.

Why make these changes?
RE: the reported “link offset issue”, the culprit is runtime date logic (expiration). By eliminating runtime date evaluation logic & using CSS to suppress expired events, we can avoid the link offset suppression issue.

link offset suppression issue (JS-based)
*It’s a private video; use your postman email address to log-in to Youtube, to see it:
https://youtu.be/XQsHt9aU2ls

![demo-LC-css-event-exp](https://user-images.githubusercontent.com/56083362/123712315-efe43780-d826-11eb-8404-718b1bf290d3.gif)
