### PR TITLE
[MARKENG-378][c] bump node version in package to 12.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "url": "https://github.com/postmanlabs/postman-docs/issues"
   },
   "engines": {
-    "node": "12.11.0"
+    "node": "12.13.0"
   },
   "homepage": "https://github.com/postmanlabs/postman-docs#readme",
   "main": ".eslintrc.js",


### PR DESCRIPTION
**Ticket/Issue:**
MARKENG-378

**Root Cause**
We use the engines:node entry in the package directory to denote the version of NodeJS to use when running the app. The version specified in `postman-docs` (_12.11.0_) is behind compared to the version in `postman-marketing-website-www` (_12.13.0_).

**Solution Description**
_Branched from `develop`_, this bumps the node version in the package file.

*no visuals