### PR TITLE
HOTFIX - revert gdpr cookies plugin down to 1.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gatsby-plugin-algolia": "^0.3.4",
     "gatsby-plugin-catch-links": "^3.8.0",
     "gatsby-plugin-env-variables": "^1.0.2",
-    "gatsby-plugin-gdpr-cookies": "^1.0.14",
+    "gatsby-plugin-gdpr-cookies": "1.0.7",
     "gatsby-plugin-google-analytics": "^2.3.4",
     "gatsby-plugin-google-tagmanager": "^2.1.15",
     "gatsby-plugin-manifest": "^2.4.17",


### PR DESCRIPTION
Revert the GDPR plugin back down to `1.0.7`

Branched out of MASTER to avoid getting any changes sitting in DEVELOP