### PR TITLE
[MARKENG][c] npm run build:nvmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ auth.json
 
 # Ignore temporary bff data used for build
 bff-data/
+
+# Generated
+.nvmrc

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "bff": "NODE_ENV=development node bff.js",
     "build": "npm run bff && GATSBY_ACTIVE_ENV=development gatsby build",
     "build:dev": "npm run build",
+    "build:nvmrc": "echo $(node -p -e 'require(\"./package\").engines.node.split(\">=\").join(\"\")') > .nvmrc",
     "build:prod": "NODE_ENV=production node bff.js && GATSBY_NEWRELIC_ENV=production GATSBY_ACTIVE_ENV=production gatsby build",
     "clean": "gatsby clean",
     "dev": "npm run bff && gatsby develop",


### PR DESCRIPTION
**Root Cause**
If you are using the wrong version of node, when you run the app or install dependencies, errors may occur.

**Solution Description**
_Branched from `develop`_, this adds an npm script to easily install & run the correct version of NodeJS w/ `npm run build:nvmrc; nvm install`; similar to postman-marketing-website-www

![demo-npm-run-build-nvmrc](https://user-images.githubusercontent.com/56083362/126824743-7a29a145-6dcd-461b-ae81-605f93149a93.gif)
