### PR TITLE
[GH-3223] removed 'gatsby-plugin-catch-links' plugin; update package-lock

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -92,7 +92,6 @@ module.exports = {
         ],
       },
     },
-    'gatsby-plugin-catch-links',
     'gatsby-transformer-sharp',
     {
       resolve: 'gatsby-plugin-manifest',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9855,15 +9855,6 @@
         }
       }
     },
-    "gatsby-plugin-catch-links": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-3.9.0.tgz",
-      "integrity": "sha512-zugIqkQBn9I2fE50we+QHT6EsMQvmgsr1G7i4dRc87RRcFshYMG1UA1Lkj0BxPNI188wWEFzdwKh2R5UUnikQA==",
-      "requires": {
-        "@babel/runtime": "^7.14.0",
-        "escape-string-regexp": "^1.0.5"
-      }
-    },
     "gatsby-plugin-env-variables": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-env-variables/-/gatsby-plugin-env-variables-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "gatsby": "^2.32.8",
     "gatsby-cli": "^2.19.2",
     "gatsby-plugin-algolia": "^0.22.0",
-    "gatsby-plugin-catch-links": "^3.8.0",
     "gatsby-plugin-env-variables": "^1.0.2",
     "gatsby-plugin-gdpr-cookies": "1.0.7",
     "gatsby-plugin-google-analytics": "^2.3.4",


### PR DESCRIPTION
fixes #3223 

* removed from package.json
* removed from gatsby config file
* `npm i` to gen up new package-lock.json