### PR TITLE
Correct the documented range of randomInt and randomPrice

### DIFF
--- a/src/pages/docs/writing-scripts/script-references/variables-list.md
+++ b/src/pages/docs/writing-scripts/script-references/variables-list.md
@@ -43,7 +43,7 @@ The following is a list of dynamic variables whose values are randomly generated
 |:--------------------------|:----------------------------------------------|:-------------------------------------------|
 | **`$randomAlphaNumeric`** | A random alpha-numeric character              | `6`, `"y"`, `"z"`                          |
 | **`$randomBoolean`**      | A random boolean value (true/false)           | `true`, `false`, `false`, `true`           |
-| **`$randomInt`**          | A random integer between 1 and 1000           | `802`, `494`, `200`                        |
+| **`$randomInt`**          | A random integer between 0 and 1000           | `802`, `494`, `200`                        |
 | **`$randomColor`**        | A random color                                | `"red"`, `"fuchsia"`, `"grey"`             |
 | **`$randomHexColor`**     | A random hex value                            | `"#47594a"`, `"#431e48"`, `"#106f21"`      |
 | **`$randomAbbreviation`** | A random abbreviation                         | `SQL`, `PCI`, `JSON`                       |
@@ -228,7 +228,7 @@ The following is a list of dynamic variables whose values are randomly generated
 
 | **Variable Name**             | **Description**                           | **Examples**                                   |
 |:------------------------------|:-----------------------------------------|:-----------------------------------------------|
-| **`$randomPrice`**            | A random price between 100.00 and 999.00 | `531.55`, `488.76`, `511.56`                   |
+| **`$randomPrice`**            | A random price between 0.00 and 1000.00  | `531.55`, `488.76`, `511.56`                   |
 | **`$randomProduct`**          | A random product                         | `Towels`, `Pizza`, `Pants`                     |
 | **`$randomProductAdjective`** | A random product adjective               | `Unbranded`, `Incredible`, `Tasty`             |
 | **`$randomProductMaterial`**  | A random product material                | `Steel`, `Plastic`, `Frozen`                   |


### PR DESCRIPTION
Addresses the following customer-raised issue which was raised on GitHub:
https://github.com/postmanlabs/postman-app-support/issues/10168

Customer determined that the range of `$randomInt` is actually different to the listed range (0-1000 rather than 1-1000).

I also observed that `$randomPrice` is using a specified range, and by testing this I found that the range was also different to that listed.

Validated behaviour via the following pre-request script:

```
numbers = [];
for (i = 1; i < 10000; i++) {
    numbers.push(pm.variables.replaceIn('{{$randomInt}}'));
}
numbers.sort((function(a, b){return a-b}));
console.log("Numbers range from " + numbers[0] + " to " + numbers[numbers.length-1]);

prices = []
for (i = 1; i < 100000; i++) {
    prices.push(pm.variables.replaceIn('{{$randomPrice}}'));
}
prices.sort((function(a, b){return a-b}));
console.log("Prices range from " + prices[0] + " to " + prices[prices.length-1]);
```

![image](https://user-images.githubusercontent.com/7154703/127815403-122627b7-0db0-4ab2-8ef6-b6a538fe2131.png)
