### PR TITLE
[MARKENG-449] installed typescript package to clear dep WARN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23082,6 +23082,11 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg=="
+    },
     "typography": {
       "version": "0.16.21",
       "resolved": "https://registry.npmjs.org/typography/-/typography-0.16.21.tgz",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "s3-deploy": "^1.4.0",
     "sendmail": "^1.6.1",
     "shelljs": "^0.8.4",
+    "typescript": "2.8.1",
     "typography": "^0.16.19",
     "uuid": "^3.3.3"
   },


### PR DESCRIPTION
<img width="891" alt="Screen Shot 2021-08-03 at 11 51 07 AM" src="https://user-images.githubusercontent.com/4358288/128074295-cfc05e89-2cd1-4350-a216-db4c3ecf7dcc.png">

* running `npm i` then `npm run build` no longer shows dep WARN in terminal
* * web app builds and runs as expected—no changes should be noticeable on front-end