### PR TITLE
[TW-143] Remove postman.postman.com links and use go.postman.co

### DIFF
--- a/src/pages/docs/collaborating-in-postman/public-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/public-workspaces.md
@@ -24,7 +24,7 @@ contextual_links:
     url: "https://youtu.be/4ulU2FZMPjQ"
 ---
 
-[Public workspaces](https://blog.postman.com/public-workspaces-why-we-created-them-what-you-can-do/) enable you to collaborate on entities with anyone across the world. Before you create a public workspace, navigate to your [team profile settings](https://postman.postman.co/settings/team/general) and enable your public team profile. This will ensure your team's profile will show up on the [Public API Network](https://www.postman.com/explore).
+[Public workspaces](https://blog.postman.com/public-workspaces-why-we-created-them-what-you-can-do/) enable you to collaborate on entities with anyone across the world. Before you create a public workspace, navigate to your [team profile settings](https://go.postman.co/settings/team/general) and enable your public team profile. This will ensure your team's profile will show up on the [Public API Network](https://www.postman.com/explore).
 
 <img alt="Enable team profile" src="https://assets.postman.com/postman-docs/enable-public-profile-url.jpg"/>
 

--- a/src/pages/docs/integrations/available-integrations/aws-api-gateway.md
+++ b/src/pages/docs/integrations/available-integrations/aws-api-gateway.md
@@ -43,7 +43,7 @@ You can directly upload your API schemas from Postman to AWS API Gateway. Once t
 
     ![postman home](https://assets.postman.com/postman-docs/awsgateway-home.jpg)
 
-1. Select [**Integrations**](https://postman.postman.co/integrations/browse?category=all).
+1. Select [**Integrations**](https://go.postman.co/integrations/browse?category=all).
 
     ![postman integrations](https://assets.postman.com/postman-docs/awsgateway-integrations.jpg)
 

--- a/src/pages/docs/integrations/available-integrations/slack.md
+++ b/src/pages/docs/integrations/available-integrations/slack.md
@@ -77,7 +77,7 @@ The team activity appears in the **Configured Integrations** page.
 
 ## Send your Monitor Run Results to Slack
 
-From the [Slack integration details](https://postman.postman.co/integrations/service/slack) page select **Add Integration** for **Post monitoring results** option.
+From the [Slack integration details](https://go.postman.co/integrations/service/slack) page select **Add Integration** for **Post monitoring results** option.
 
 On the **Permission request** page, select the Slack channel your want to post to and select **Allow**.
 

--- a/src/pages/docs/integrations/intro-integrations.md
+++ b/src/pages/docs/integrations/intro-integrations.md
@@ -35,7 +35,7 @@ Integrations allow you to automate sharing data and functionality between Postma
 
 ## Accessing integrations
 
-You can access integrations by navigating to [Browse Integrations](https://postman.postman.co/integrations/browse) from your [Home page](http://go.postman.co/) and selecting "Integrations" from the menu on the left. Search and select the integration you wish to add to your workspace.
+You can access integrations by navigating to [Browse Integrations](https://go.postman.co/integrations/browse) from your [Home page](http://go.postman.co/) and selecting "Integrations" from the menu on the left. Search and select the integration you wish to add to your workspace.
 
 ![Workspace Integrations](https://assets.postman.com/postman-docs/browse-integrations.jpg)
 

--- a/src/pages/docs/integrations/webhooks.md
+++ b/src/pages/docs/integrations/webhooks.md
@@ -41,16 +41,16 @@ Once you whitelist this IP address, calls for the custom webhook will be able to
 
 ## Configuring custom webhook URL
 
-1. On the [Integrations](https://postman.postman.co/integrations/browse) page, search and select Webhooks from the list of integrations.
+1. On the [Integrations](https://go.postman.co/integrations/browse) page, search and select Webhooks from the list of integrations.
 
-[![custom_webhook](https://assets.postman.com/postman-docs/custom-webhooks.jpg)](https://assets.postman.com/postman-docs/custom-webhooks.jpg)  
+[![custom_webhook](https://assets.postman.com/postman-docs/custom-webhooks.jpg)](https://assets.postman.com/postman-docs/custom-webhooks.jpg)
 
 Each integration's page explains how to use the integration and what it can do. If available, you can view previously configured integrations for the selected integration.
 
 ![Workspace Integrations](https://assets.postman.com/postman-docs/webhooks-teammates.jpg)
 2. Select __Add Integration__ to configure your integration. Enter the required information for account and access authorization. Select the workspace you need to add the integration to and proceed with the integration setup.
 
-[![webhooks_view2](https://assets.postman.com/postman-docs/custom-webhooks-setup.jpg)](https://assets.postman.com/postman-docs/custom-webhooks-setup.jpg)  
+[![webhooks_view2](https://assets.postman.com/postman-docs/custom-webhooks-setup.jpg)](https://assets.postman.com/postman-docs/custom-webhooks-setup.jpg)
 
 ## Back up your Postman Collections
 


### PR DESCRIPTION
There shouldn't be links to postman.postman.com - use go.postman.com instead.