### PR TITLE
[TW-131] Move API versioning page

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -765,7 +765,7 @@
 	},
 	{
 		"from": "/docs/postman/design-and-develop-apis/versioning-an-api/",
-		"to": "/docs/collaborating-in-postman/versioning-an-api/"
+		"to": "/docs/designing-and-developing-your-api/versioning-an-api/"
 	},
 	{
 		"from": "/docs/postman/design-and-develop-apis/view-and-analyze-api-reports/",
@@ -797,7 +797,11 @@
 	},
 	{
 		"from": "/docs/postman/design_and_develop_apis/versioning_an_api/",
-		"to": "/docs/collaborating-in-postman/versioning-an-api/"
+		"to": "/docs/designing-and-developing-your-api/versioning-an-api/"
+	},
+	{
+		"from": "/docs/collaborating-in-postman/versioning-an-api/",
+		"to": "/docs/designing-and-developing-your-api/versioning-an-api/"
 	},
 	{
 		"from": "/docs/postman/design_and_develop_apis/view_and_analyze_api_reports/",

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -20,7 +20,7 @@ contextual_links:
     name: "Next Steps"
   - type: link
     name: "Versioning APIs"
-    url: "/docs/collaborating-in-postman/versioning-an-api/"
+    url: "/docs/designing-and-developing-your-api/versioning-an-api/"
 ---
 
 You can use version control with your Postman Collections by forking and merging and utilizing a standard pull request process. Version control allows you to collaborate with teammates by working on different forks of the same collection, updating forks from the parent collection, and merging changes when you're ready. You can tag collaborators to review pull requests and resolve conflicts to manage collection versions.
@@ -295,4 +295,4 @@ The __Source__ will indicate the changes on your fork, with the __Destination__ 
 
 ## Next steps
 
-You can also use [version control on APIs](/docs/collaborating-in-postman/versioning-an-api/) you design and build in Postman.
+You can also use [version control on APIs](/docs/designing-and-developing-your-api/versioning-an-api/) you design and build in Postman.

--- a/src/pages/docs/designing-and-developing-your-api/creating-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/creating-an-api.md
@@ -42,5 +42,3 @@ You can rename, delete, or remove the API from the workspace using the __View mo
 > When you delete an API or remove it from a workspace, the collections, monitors, mocks, and environments linked to it will not be deleted / removed.
 
 <img alt="Edit API" src="https://assets.postman.com/postman-docs/v8-more-actions2.jpg"/>
-
-You can also [version your APIs](/docs/collaborating-in-postman/versioning-an-api/).

--- a/src/pages/docs/designing-and-developing-your-api/defining-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/defining-an-api.md
@@ -1,6 +1,6 @@
 ---
 title: 'Defining an API Specification'
-order: 81.2
+order: 81.3
 page_id: 'defining_api_specification'
 warning: false
 contextual_links:

--- a/src/pages/docs/designing-and-developing-your-api/developing-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/developing-an-api.md
@@ -1,6 +1,6 @@
 ---
 title: 'Developing an API'
-order: 81.4
+order: 81.5
 page_id: 'developing_an_api'
 warning: false
 contextual_links:
@@ -64,7 +64,7 @@ Select a mock server from your workspace and click **Add Mock Server**. You will
 
 ![Mock Added](https://assets.postman.com/postman-docs/mock-added-schema.jpg)
 
-You can add mocks to specific [versions of your API](/docs/collaborating-in-postman/versioning-an-api/) or [collection](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/).
+You can add mocks to specific [versions of your API](/docs/designing-and-developing-your-api/versioning-an-api/) or [collection](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/).
 
 ### Editing a mock server
 
@@ -100,7 +100,7 @@ In the **API** &gt; **Develop** tab, click **Add Documentation** &gt; **Add Exis
 
 Select the collection with the documentation you want to link and click **Add Documentation**. You will only see available collections in the list.
 
-You can add documentation to specific [versions of your API](/docs/collaborating-in-postman/versioning-an-api/). To learn more about versioning and documentation, check out [versioning your docs](/docs/publishing-your-api/documenting-your-api/#versioning-your-docs).
+You can add documentation to specific [versions of your API](/docs/designing-and-developing-your-api/versioning-an-api/). To learn more about versioning and documentation, check out [versioning your docs](/docs/publishing-your-api/documenting-your-api/#versioning-your-docs).
 
 ## Adding an environment
 

--- a/src/pages/docs/designing-and-developing-your-api/managing-apis.md
+++ b/src/pages/docs/designing-and-developing-your-api/managing-apis.md
@@ -20,7 +20,7 @@ contextual_links:
     name: "Next Steps"
   - type: link
     name: "Versioning APIs"
-    url: "/docs/collaborating-in-postman/versioning-an-api/"
+    url: "/docs/designing-and-developing-your-api/versioning-an-api/"
   - type: link
     name: "Viewing and analyzing APIs"
     url: "/docs/designing-and-developing-your-api/view-and-analyze-api-reports/"
@@ -92,5 +92,5 @@ You can use the __Restore__ link to revert the schema to a previous state.
 
 For more info on working with the API Builder in Postman, check out the following resources:
 
-- [Versioning APIs](/docs/collaborating-in-postman/versioning-an-api/)
+- [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/)
 - [Viewing and analyzing APIs](/docs/designing-and-developing-your-api/view-and-analyze-api-reports/)

--- a/src/pages/docs/designing-and-developing-your-api/observing-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/observing-an-api.md
@@ -1,6 +1,6 @@
 ---
 title: 'Observing an API'
-order: 81.6
+order: 81.7
 page_id: 'observing_an_api'
 warning: false
 contextual_links:

--- a/src/pages/docs/designing-and-developing-your-api/testing-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/testing-an-api.md
@@ -1,6 +1,6 @@
 ---
 title: 'Testing an API'
-order: 81.5
+order: 81.6
 page_id: 'testing_an_api'
 warning: false
 contextual_links:

--- a/src/pages/docs/designing-and-developing-your-api/the-api-workflow.md
+++ b/src/pages/docs/designing-and-developing-your-api/the-api-workflow.md
@@ -34,7 +34,8 @@ You can connect various components of your API development and testing process t
 The following are the high-level steps involved when creating and using APIs:
 
 * [Creating an API](/docs/designing-and-developing-your-api/creating-an-api/) - Start a new API in Postman.
-* [Defining an API](/docs/designing-and-developing-your-api/defining-an-api/) - Define your API by [editing your schema](/docs/designing-and-developing-your-api/defining-an-api/#editing-your-schema) and [generating a collection](/docs/designing-and-developing-your-api/defining-an-api/#generating-a-collection).
+* [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/) - Manage different versions of your APIs.
+* [Defining an API](/docs/designing-and-developing-your-api/defining-an-api/) - Define your API by [editing your schema](/docs/designing-and-developing-your-api/defining-an-api/#editing-your-schema), [validating the schema and elements](/docs/designing-and-developing-your-api/validating-elements-against-schema/), and [generating a collection](/docs/designing-and-developing-your-api/defining-an-api/#generating-a-collection).
 * [Watching an API](/docs/designing-and-developing-your-api/watching-an-api/) - Get notifications when an API changes.
 * [Developing an API](/docs/designing-and-developing-your-api/developing-an-api/) - Add [a mock server](/docs/designing-and-developing-your-api/developing-an-api/#adding-a-mock-server) and [documentation](/docs/designing-and-developing-your-api/developing-an-api/#adding-documentation) to your API.
 * [Testing an API](/docs/designing-and-developing-your-api/testing-an-api/) - Add [a test suite](/docs/designing-and-developing-your-api/testing-an-api/#adding-a-test-suite), [integration tests](/docs/designing-and-developing-your-api/testing-an-api/#adding-integration-tests), and [contract tests](/docs/designing-and-developing-your-api/testing-an-api/#adding-contract-tests) to your API.
@@ -44,7 +45,5 @@ The following are the high-level steps involved when creating and using APIs:
 
 For more information on building your APIs in Postman, check out the following resources:
 
-* [Versioning APIs](/docs/collaborating-in-postman/versioning-an-api/)
 * [Managing and sharing APIs](/docs/designing-and-developing-your-api/managing-apis/)
 * [Viewing and analyzing APIs](/docs/designing-and-developing-your-api/view-and-analyze-api-reports/)
-* [Validating schema and elements](/docs/designing-and-developing-your-api/validating-elements-against-schema/)

--- a/src/pages/docs/designing-and-developing-your-api/versioning-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/versioning-an-api.md
@@ -1,6 +1,6 @@
 ---
 title: 'Versioning APIs'
-order: 74
+order: 81.2
 page_id: 'versioning_an_api'
 warning: false
 contextual_links:

--- a/src/pages/docs/designing-and-developing-your-api/watching-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/watching-an-api.md
@@ -1,6 +1,6 @@
 ---
 title: 'Watching an API'
-order: 81.3
+order: 81.4
 page_id: 'watching_an_api'
 warning: false
 contextual_links:

--- a/src/pages/docs/integrations/available-integrations/github.md
+++ b/src/pages/docs/integrations/available-integrations/github.md
@@ -151,7 +151,7 @@ Once the integration is complete, return to the Postman app and navigate to your
 
 The sync of API schemas is two-way; after your first schema sync, each change to the schema in Postman will appear in the repository as a new commit. Similarly, if you or someone else updates the file on the GitHub repository, the API schema on Postman will be updated.
 
-To ensure that changes made in GitHub work properly in your  collection, use the Validate option as described [here](https://learning.postman.com/docs/collaborating-in-postman/versioning-an-api/#validating-apis).
+To ensure that changes made in GitHub work properly in your  collection, use the Validate option as described [here](/docs/designing-and-developing-your-api/versioning-an-api/#validating-apis).
 
 > If changes take place on the repository while you are editing the file on Postman, a **Conflict** state will be displayed. Saving the changes on Postman will override the file on GitHub.
 

--- a/src/pages/docs/integrations/available-integrations/github.md
+++ b/src/pages/docs/integrations/available-integrations/github.md
@@ -151,7 +151,7 @@ Once the integration is complete, return to the Postman app and navigate to your
 
 The sync of API schemas is two-way; after your first schema sync, each change to the schema in Postman will appear in the repository as a new commit. Similarly, if you or someone else updates the file on the GitHub repository, the API schema on Postman will be updated.
 
-To ensure that changes made in GitHub work properly in your  collection, use the Validate option as described [here](/docs/designing-and-developing-your-api/versioning-an-api/#validating-apis).
+To ensure that changes made in GitHub work properly in your collection, use the Validate option as described in [validating APIs](/docs/designing-and-developing-your-api/versioning-an-api/#validating-apis).
 
 > If changes take place on the repository while you are editing the file on Postman, a **Conflict** state will be displayed. Saving the changes on Postman will override the file on GitHub.
 

--- a/src/pages/docs/publishing-your-api/documenting-your-api.md
+++ b/src/pages/docs/publishing-your-api/documenting-your-api.md
@@ -166,7 +166,7 @@ If someone imports the collection using the __Run in Postman__ button from your 
 
 ## Versioning your docs
 
-Any version tags you add to your collections will be published along with your docs. You can add versions to an [API](/docs/collaborating-in-postman/versioning-an-api/) or collection.
+Any version tags you add to your collections will be published along with your docs. You can add versions to an [API](/docs/designing-and-developing-your-api/versioning-an-api/) or collection.
 
 ![Add Version](https://assets.postman.com/postman-docs/docs-version-options.jpg)
 


### PR DESCRIPTION
* Move https://learning.postman.com/docs/collaborating-in-postman/versioning-an-api/ to be under /docs/designing-and-developing-your-api
* Adjust order so it's after Creating APIs
* Edit https://learning.postman-beta.com/docs/designing-and-developing-your-api/the-api-workflow/ to refer to this task and link correctly. (Move the link out of the next steps list)
* Fix all other internal links
* Add a redirect