### PR TITLE
Rename the Upcoming Livestreams section to Upcoming Events

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -157,10 +157,10 @@ class IndexPage extends React.Component {
             </div>
           </div>
         </section>
-        {/* Livestream Section */}
+        {/* Events Section */}
         <section className="row section">
           <div className="col-md-12 text-center mb-3">
-            <h2 id="upcoming-livestreams">Upcoming Postman Livestreams</h2>
+            <h2 id="upcoming-livestreams">Upcoming Postman Events</h2>
             <p>
               <a href="https://www.twitch.tv/getpostman" target="_blank" rel="noopener noreferrer">
                 Follow us


### PR DESCRIPTION
The events include live streams + webinars so changing it to upcoming events instead.

I haven't switched the id on purpose this time, because #upcoming-livestreams is used on the app release notes. I will switch that whenever a new build goes out for a new version or later in a separate PR.