### PR TITLE
escape '|' character

### DIFF
--- a/src/pages/docs/running-collections/using-newman-cli/command-line-integration-with-newman.md
+++ b/src/pages/docs/running-collections/using-newman-cli/command-line-integration-with-newman.md
@@ -113,7 +113,7 @@ $ newman run -h
 |:--|:--|
 | `--bail` | Stops the runner when a test case fails |
 | `--silent` | Disable terminal output |
-| `--color off` | Disable colored output (auto|on|off) (default: "auto")|
+| `--color off` | Disable colored output (auto\|on\|off) (default: "auto")|
 | `-k`, `--insecure` | Disable strict ssl |
 | `-x`, `--suppress-exit-code` | Continue running tests even after a failure, but exit with `code=0` |
 | `--ignore-redirects` | Disable automatic following of `3XX` responses |


### PR DESCRIPTION
escape '|' character otherwise the text will be influenced incorrectly

if '|' character occurs in a markdown table, (I guess) it will make the text display incorrectly

Let me show the text before and after this change
# Before change
![image](https://user-images.githubusercontent.com/3983683/130742777-01b37a65-f1e0-489f-8082-e4f0f6034f29.png)

# After change
![image](https://user-images.githubusercontent.com/3983683/130742917-930b63ba-8967-4c8f-a4f4-9b0b7dca9f33.png)
