### PR TITLE
updated grid layout for smaller breakpoints; fixed navbar styling

### DIFF
--- a/src/components/ContextualLinks/ContextualLinks.scss
+++ b/src/components/ContextualLinks/ContextualLinks.scss
@@ -1,10 +1,7 @@
 @import '../Shared/_variables.scss';
 
 .contextual-links {
-  margin: 12px 16px;
 
-  
-  
   .contextual-links__section {
     margin-top: 24px;
     margin-bottom: 8px;
@@ -17,7 +14,6 @@
     padding: 4px 0;
     display: block;
     
-
     a {
       color: $grey_50;
       font-size: 14px;
@@ -53,7 +49,6 @@
   // tablet view
   @media (min-width: 767px) and (max-width: 990px) {
       padding-bottom: 80px;
-      margin-left: 32px;
   }
 
 

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -6,7 +6,7 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', Helvetica, Arial, sans-serif;
 
   &.nav-primary {
-    backdrop-filter: blur(32px);
+    background-color: #ffffff !important;
     z-index: 2147483647;
     padding: 6px 16px;
     border-bottom: 1px solid #e6e6e6;
@@ -22,6 +22,7 @@
     padding: 4px 16px;
     top: 0;
     z-index: 1020;
+    border-bottom: 1px solid #e6e6e6;
 
     &.activeMenu {
       background-color: #ffffff !important;

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -73,10 +73,11 @@ p {
     margin-left: 0;
   }
 }
-// .container-fluid {
-//   padding-right: 24px;
-// }
 
+.container-fluid, .container-lg, .container-md, .container-sm, .container-xl {
+  padding-right: 12px;
+  padding-left: 12px;
+}
 
 div.col-sm-7.doc-page {
   padding: 64px 72px;

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -27,17 +27,18 @@ export default ({ data }) => {
           </nav>
           <div className="col">
             <div className="row row-eq-height">
-              <main className="col-sm-12 col-md-12 col-lg-7 offset-lg-1 doc-page">
+              <main className="col-sm-12 col-md-12 col-lg-9 offset-lg-0 col-xl-7 offset-xl-1 doc-page">
                 <h1>{post.frontmatter.title}</h1>
                 <span dangerouslySetInnerHTML={{ __html: post.html }} />
               </main>
-              <aside className="col-sm-12 col-md-12 col-lg-3 offset-lg-1 right-column">
+              <aside className="col-sm-12 col-md-12 col-lg-3 offset-lg-0 col-xl-3 offset-xl-1 right-column">
+                <hr className="d-block d-lg-none"/>
                 <div className="edit-button">
                   <EditDoc className="btn btn__small btn__secondary-light edit-button-styles" />
                 </div>
                 {contextualLinks}
                 <figure className="sticky w-75">
-                  <img src={pose} alt="pose" />
+                  <img src={pose} alt="pose" className="img-fluid"/>
                 </figure>
               </aside>
             </div>

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -1,9 +1,23 @@
 @import '../components/Shared/variables';
 
 .doc-page {
-  padding-left: 49px !important;
-  padding-top: 64px;
+  padding-left: 40px !important;
+  padding-top: 40px;
   padding-bottom: 40px;
+  padding-right: 40px;
+
+  @media (min-width:992px) and (max-width: 1199px) {
+    padding-right: 32px;
+  }
+
+  @media (min-width:992px) {
+    padding-top: 64px;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
 
   // WIP - need to get ul li markers to move away from text
   ///////////////////////////////////////////////////////////////////
@@ -42,7 +56,6 @@
     }
 
     list-style-type: '✦';
-    // list-style-type: '/2726';
 
     li::marker {
       color: $orange_30 !important;
@@ -103,16 +116,15 @@ blockquote {
 }
 
 .edit-button {
-  margin-top: 64px;
-  margin-left: 12px;
+  padding-top: 40px;
+
+  @media (min-width:992px) {
+    padding-top: 0;
+  }
   svg {
     overflow: hidden;
     vertical-align: middle;
     margin-bottom: 4px;
-  }
-
-  @media (min-width:767px) and (max-width: 990px) {
-    padding-left: 16px;
   }
 }
 
@@ -127,8 +139,14 @@ blockquote {
 }
 
 .right-column {
-  margin-top: 64px;
-  padding-left: 0px !important;
+  margin-top: 0px;
+  padding-left: 40px !important;
+
+  @media (min-width:992px) {
+    margin-top: 136px;
+    padding-right: 24px;
+    padding-left: 0px !important;
+  }
 }
 
 .sticky {
@@ -139,13 +157,6 @@ blockquote {
   // top: 0;
 
 }
-
-// @media (max-width: 990px) {
-//   .right-column {
-//     padding-bottom: 80px;
-//     padding-left: 16px;
-//   }
-// }
 
 tr:hover {
   background-color: #FAE1D4;


### PR DESCRIPTION
* removed blur from primary navbar
* added border to second navbar
* removed thin white space on far left (.container-fluid needed overrides)
* refactored how we do spacing around docs and right sidebar
* added HR on sm breakpoint between docs and right sidebar
* adjusted padding for all breakpoints to allow for better content viewing.