### PR TITLE
[MARKENG-686] [c] Added in Firefox backdrop-blur workaround

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -640,7 +640,7 @@ class Header extends React.Component {
             </div>
           </div>
         </nav>
-        <nav className="navbar-v6 navbar navbar-expand-lg navbar-light bg-light nav-secondary">
+        <nav className="navbar-v6 navbar navbar-expand-lg navbar-light bg-light nav-secondary blurred-container">
           <a className="navbar-brand" href="/">
             <span id="learning-center-home-link" className="nav-link uber-nav">
               Learning Center

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -34,6 +34,21 @@
       top: 0;
       z-index: 1020;
     }
+
+    @supports ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
+      &.blurred-container {
+        -webkit-backdrop-filter: blur(10px);
+        backdrop-filter: blur(10px);
+      }
+    }
+    
+    /* slightly transparent fallback for Firefox (not supporting backdrop-filter) */
+    @supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
+      &.blurred-container {
+        background-color: rgba(255, 255, 255, .9) !important;
+      }
+    }
+ 
   }
 
   .navbar-nav .nav-link,


### PR DESCRIPTION
Added a work around for `backdrop-blur` incompatibility with firefox.

![Screen Shot 2021-09-16 at 10 03 58 AM](https://user-images.githubusercontent.com/14118422/133662072-e006c6cc-7a4a-4c8d-b022-de4727c75dde.png)
![Screen Shot 2021-09-16 at 10 34 39 AM](https://user-images.githubusercontent.com/14118422/133662076-f38d44b1-97c4-42a0-8998-3f9f4d22f926.png)
  