### PR TITLE
updated left nav styles to fix seceond level highlight

### DIFF
--- a/src/components/LeftNav/LeftNav.scss
+++ b/src/components/LeftNav/LeftNav.scss
@@ -26,7 +26,6 @@
     margin-left: -10px;
     .caret {
       position: relative;
-      // top: 14px; // needed for old caret
       left: -8px;
       transition: transform .2s ease;
       -webkit-transform: rotate(-90deg);
@@ -34,6 +33,10 @@
       -o-transform: rotate(-90deg);
       -ms-transform: rotate(-90deg);
       transform: rotate(-90deg);
+      @media screen and (min-width: 768px) {
+        width: 10%;
+        height: 24px;
+      }
       
       &.active-caret {
         transition: transform .2s ease;
@@ -55,16 +58,21 @@
       cursor: pointer;
       outline: inherit;
       text-transform: capitalize;
+
+      @media screen and (min-width: 768px) {
+        width: 90%;
+      text-align: left;
+      }
       &:hover{
         color: $grey_60;
       }
     }
 
     &.currentUrl {
-      background-color: $grey_60;
-      color: $white;
-      margin: 0 -8px 16px -80px;
-      padding: 8px 0 8px 70px;
+      // background-color: $grey_60;
+      // color: $white;
+      margin: 0 -8px 0 -80px;
+      padding: 0 0 8px 70px;
       & button {
         &:hover {
           color: $white;


### PR DESCRIPTION
Removing the dark highlight from left nav second levels
<img width="727" alt="Screen Shot 2021-09-16 at 11 27 46 AM" src="https://user-images.githubusercontent.com/4358288/133669803-fd3b65fc-2659-4d46-8dc7-8378b3a9457f.png">

- fixed up the padding between parents of open drawers in left nav
