### PR TITLE
[MARKENG-719] updated LI bullets to accept p tag inside li

### DIFF
--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -22,7 +22,7 @@
   // WIP - need to get ul li markers to move away from text
   ///////////////////////////////////////////////////////////////////
   ul {
-    margin-left: 32px;
+    margin-left: 16px;
     margin-bottom: 24px;
 
     li::marker {
@@ -40,9 +40,9 @@
       } 
     
     li {
-      // padding: 10px !important;
       margin-bottom: 8px;
       line-height: 1.625;
+      padding: 0 0 0 16px;
 
       li::before {
         direction: rtl !important;
@@ -52,15 +52,19 @@
       }
     }
     li::before {
-      content: "✦";
-      color: $orange_30 !important;
+      // content: "✦";
+      // color: $orange_30 !important;
       direction: rtl !important;
       margin-left: -28px !important;
       padding-right: 16px !important;
       width: 28px !important;
     }
 
-    list-style-type: none;
+    list-style-type: '✦';
+
+    li::marker {
+      color: $orange_30 !important;
+    }
   }
 
   ol {


### PR DESCRIPTION
Markdown applies a <p> to contents in an LI that has an indented UL below it. Targeting the li > p left an odd space to the left, so had to revert how we do bullets for these.

BEFORE
<img width="742" alt="Screen Shot 2021-09-22 at 10 07 21 AM" src="https://user-images.githubusercontent.com/4358288/134389740-3f313412-ece2-4538-a655-7c80b479b949.png">

AFTE
<img width="802" alt="Screen Shot 2021-09-22 at 10 07 03 AM" src="https://user-images.githubusercontent.com/4358288/134389829-2cfad485-7d11-480f-b630-7de2f0bc6124.png">
R
