### PR TITLE
[MARKENG-625] Updated caniuse-lite to synchronize version across different tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5306,9 +5306,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001257",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-      "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA=="
+      "version": "1.0.30001259",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
+      "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
Ran locally, Docs working as expected. Running "npm run dev" no longer shows the warning message.
<img width="385" alt="Screen Shot 2021-09-22 at 2 47 00 PM" src="https://user-images.githubusercontent.com/42796716/134427097-0339686e-2990-48c6-afd9-cf19ab7c31bf.png">
.
