### PR TITLE
[MARKENG-723] removed hover state from linked images

### DIFF
--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -85,6 +85,10 @@
     &:hover {
       text-decoration: none;
       border-bottom: 1px solid $blue_60;
+      & img {
+        border: none !important;
+        display: block;
+      }
     }
 
     &.alternative {


### PR DESCRIPTION
Removes this hover state on linked images, while retaining the bottom-border on inline links.

<img width="818" alt="Screen Shot 2021-09-23 at 3 21 57 PM" src="https://user-images.githubusercontent.com/4358288/134591723-fad5c406-370c-4e74-909e-79f01d8110b6.png">
