### PR TITLE
updated left nav styles, and docs layout for xl screens

### DIFF
--- a/src/components/LeftNav/LeftNav.jsx
+++ b/src/components/LeftNav/LeftNav.jsx
@@ -96,10 +96,18 @@ class ListItem extends React.Component {
             <title>arrow-sm-right</title>
             <g strokeWidth="1" fill="none" stroke="#212121" strokeLinecap="round" strokeLinejoin="round"><polyline points="6.5,3.5 11,8 6.5,12.5 " /></g>
           </svg> */}
-          <svg onClick={this.toggleActive} className={`caret${this.isActive(name) ? ' active-caret' : ''}`} xmlns="http://www.w3.org/2000/svg" fill="none" height="24" viewBox="0 0 24 24" width="24"><path clipRule="evenodd" d="m16.5303 8.96967c.2929.29289.2929.76777 0 1.06063l-4 4c-.2929.2929-.7677.2929-1.0606 0l-4.00003-4c-.29289-.29286-.29289-.76774 0-1.06063s.76777-.29289 1.06066 0l3.46967 3.46963 3.4697-3.46963c.2929-.29289.7677-.29289 1.0606 0z" fill="#707070" fillRule="evenodd" /></svg>
-          <button type="button" onClick={this.toggleActive} identifier={name}>
-            {replacements[name] ? replacements[name] : name.replace(/-/g, ' ')}
-          </button>
+          <div className="container">
+            <div className="row">
+              <div className="caret-wrapper align-self-top">
+                <svg onClick={this.toggleActive} className={`caret${this.isActive(name) ? ' active-caret' : ''}`} xmlns="http://www.w3.org/2000/svg" fill="none" height="24" viewBox="0 0 24 24" width="24"><path clipRule="evenodd" d="m16.5303 8.96967c.2929.29289.2929.76777 0 1.06063l-4 4c-.2929.2929-.7677.2929-1.0606 0l-4.00003-4c-.29289-.29286-.29289-.76774 0-1.06063s.76777-.29289 1.06066 0l3.46967 3.46963 3.4697-3.46963c.2929-.29289.7677-.29289 1.0606 0z" fill="#707070" fillRule="evenodd" /></svg>
+              </div>
+              <div className="col align-self-top caret-sibling">
+                <button type="button" onClick={this.toggleActive} identifier={name}>
+                  {replacements[name] ? replacements[name] : name.replace(/-/g, ' ')}
+                </button>
+              </div>
+            </div>
+          </div>
         </li>
         <ListItem data={JSON.stringify(data)} />
       </ul>

--- a/src/components/LeftNav/LeftNav.scss
+++ b/src/components/LeftNav/LeftNav.scss
@@ -5,11 +5,23 @@
   height: 100%;
   font-size: 14px;
   font-family: $inter;
-  padding: 32px 8px 8px 20px;
+  padding: 32px 0px 8px 00px;
+  
+  & ul {
+    margin-left: 0;
+    & ul {
+      margin-left: 32px;
+      margin-top: 8px;
+      & ul {
+        margin-left: 32px;
+        margin-top: 12px;
+      }
+    }
+  }
   .active.root > .parent.currentUrl {
     background-color: inherit;
     color: inherit;
-    padding-left: 70px;
+    // padding-left: 70px;
     button:hover{
         color: $grey_60;
       }
@@ -17,7 +29,7 @@
   .parent.currentUrl button:hover {
     color: $grey_90 !important;
     background-color: $grey_05;
-}
+  }
   .root > .parent{
     button {
       font-weight: 400;
@@ -25,20 +37,19 @@
   }
   .parent {
     list-style-type: none;
-    margin-left: -10px;
+    margin-bottom: 4px;
+
+    & .caret-wrapper {
+      width: 24px;
+    }
+
     .caret {
-      position: relative;
-      left: -8px;
       transition: transform .2s ease;
       -webkit-transform: rotate(-90deg);
       -moz-transform: rotate(-90deg);
       -o-transform: rotate(-90deg);
       -ms-transform: rotate(-90deg);
       transform: rotate(-90deg);
-      @media screen and (min-width: 768px) {
-        width: 10%;
-        height: 24px;
-      }
       
       &.active-caret {
         transition: transform .2s ease;
@@ -48,6 +59,10 @@
         -ms-transform: rotate(0deg);
         transform: rotate(0deg);
       }
+    }
+
+    .caret-sibling {
+      padding-left: 0;
     }
 
     & button {
@@ -62,7 +77,6 @@
       text-transform: capitalize;
 
       @media screen and (min-width: 768px) {
-        width: 90%;
       text-align: left;
       }
       &:hover{
@@ -71,10 +85,9 @@
     }
 
     &.currentUrl {
-      // background-color: $grey_60;
-      // color: $white;
-      margin: 0 -8px 0 -80px;
-      padding: 0 0 8px 70px;
+      // margin: 0 -8px 0 -80px;
+      // padding: 0 0 8px 70px;
+      margin-bottom: 8px;
       & button {
         &:hover {
           color: $white;
@@ -86,10 +99,11 @@
   .child {
     margin-left: 28px;
     margin-bottom: 24px;
+    
 
     &.currentUrl{
       font-weight: 600;
-      margin-left: 23px;
+      // margin-left: 23px;
 
       > * {
         vertical-align: middle;
@@ -106,7 +120,7 @@
       // }
 
       a:link, a:visited {
-        margin-left: 5px;
+        // margin-left: 5px;
         background-color: rgb(242, 242, 242);
         color: $grey_90;
         border-radius: 3px;
@@ -133,6 +147,10 @@
   ul.active > .child {
     color: $grey_50;
     margin-bottom: 0;
+    & a {
+      margin-left: 16px;
+      margin-right: 16px;
+    }
   }
 
   ul.inactive > .child, ul.inactive > ul {

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -57,7 +57,7 @@ export default ({ data }) => {
           </nav>
           <div className="col">
             <div className="row row-eq-height">
-              <main className="col-sm-12 col-md-12 col-lg-9 offset-lg-0 col-xl-7 offset-xl-1 doc-page">
+              <main className="col-sm-12 col-md-12 col-lg-9 offset-lg-0 col-xl-7 doc-page ml-xl-5">
                 <h1>{post.frontmatter.title}</h1>
                 <span id="content-container" dangerouslySetInnerHTML={{ __html: post.html }} />
               </main>

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -115,6 +115,15 @@
   // z-index: -1;
   padding-left: 0px !important;
   padding-right: 0px !important;
+  @media screen and (min-width: 768px) {
+    max-width: 350px;
+  }
+
+  & li {
+    &:hover {
+      cursor: pointer;
+    }
+  }
 }
 
 /* Blockquotes */


### PR DESCRIPTION
- left nav styles updated to improve spacing between items
- docs grid layout improved to better support xl screens (see screens below)
- fixed spacing between caret and label to now be linked
- added cursor pointer to caret 
<img width="1526" alt="Screen Shot 2021-09-28 at 10 25 57 AM" src="https://user-images.githubusercontent.com/4358288/135136107-18897a7d-a848-4e82-bcb4-aecd3e764020.png">

