### PR TITLE
removed polyfil plugin in favor of loading specific features of polyfil

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -34,7 +34,6 @@ module.exports = {
         defer: true,
       },
     },
-    'gatsby-plugin-polyfill-io',
     {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10677,14 +10677,6 @@
         }
       }
     },
-    "gatsby-plugin-polyfill-io": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-polyfill-io/-/gatsby-plugin-polyfill-io-1.1.0.tgz",
-      "integrity": "sha512-v2uiJvuAhtUU/30c257+KBj+hA0pMxpsCdq7PIcXLdGZlVhXJTporD5WIEPP5jeGl3zOp4y3FdQF1C10wlt1MA==",
-      "requires": {
-        "babel-runtime": "^6.26.0"
-      }
-    },
     "gatsby-plugin-react-helmet": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "gatsby-plugin-manifest": "^2.4.17",
     "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-newrelic": "^1.0.5",
-    "gatsby-plugin-polyfill-io": "^1.1.0",
     "gatsby-plugin-react-helmet": "^3.1.8",
     "gatsby-plugin-robots-txt": "^1.5.1",
     "gatsby-plugin-sass": "^2.1.15",


### PR DESCRIPTION
* in support of #3522 
* removes Gatsby package
* removes two additional requests to polyfil in network tab

BEFORE:
<img width="952" alt="Screen Shot 2021-09-28 at 11 11 32 AM" src="https://user-images.githubusercontent.com/4358288/135142695-7b7b51d9-398b-4559-96f5-13e78e28a361.png">

AFTER:
<img width="950" alt="Screen Shot 2021-09-28 at 11 10 55 AM" src="https://user-images.githubusercontent.com/4358288/135142781-843baddf-af50-4ef6-a652-fdbe5549bf71.png">


