### PR TITLE
[MARKENG-957][c] eliminate potential race condition for load events with pm-tech

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const sh = require('shelljs');
+const base64 = require('base-64');
 const crypto = require('crypto');
 const pingWebHook = require('./scripts/pingWebHook');
 const fetchBlogPosts = require('./scripts/fetchBlogPosts');
@@ -8,43 +9,14 @@ const fetchPmTech = require('./scripts/fetchPmTech');
 
 const delay = 1000;
 const runtime = {
-  pm: ['bff-data/pmTech.js'],
+  pm: [''],
 };
 
-if (process.env.NPM_TOKEN) {
+if (process.env.PM_TECH) {
   sh.exec('mkdir -p public');
 
   Object.keys(runtime).forEach((key) => {
-    const fileBuffer = fs.readFileSync(runtime[key][0]);
-    const hashSum = crypto.createHash('sha1');
-    const ext = runtime[key][0]
-      .split('/')
-      .pop()
-      .split('.')
-      .pop();
-
-    hashSum.update(fileBuffer);
-
-    const hex = hashSum.digest('hex');
-
-    runtime[key].push(`_${hex}.${ext}`);
-
-    sh.exec(`cp ${runtime[key][0]} public/${runtime[key][1]}`);
-  });
-}
-
-const prefetch = async (dir, response) => {
-  sh.exec('mkdir -p bff-data');
-  await pingWebHook();
-  fetchBlogPosts();
-  fetchEvents();
-
-  if (process.env.PM_TECH) {
-    await fetchPmTech();
-
-    sh.exec('mkdir -p public');
-
-    Object.keys(runtime).forEach((key) => {
+    if (runtime[key][0]) {
       const fileBuffer = fs.readFileSync(runtime[key][0]);
       const hashSum = crypto.createHash('sha1');
       const ext = runtime[key][0]
@@ -59,9 +31,46 @@ const prefetch = async (dir, response) => {
 
       runtime[key].push(`_${hex}.${ext}`);
 
-      setTimeout(() => {
-        sh.exec(`cp ${runtime[key][0]} public/${runtime[key][1]}`);
-      }, delay);
+      sh.exec(`cp ${runtime[key][0]} public/${runtime[key][1]}`);
+    }
+  });
+}
+
+const prefetch = async () => {
+  sh.exec('mkdir -p bff-data');
+  await pingWebHook();
+  fetchBlogPosts();
+  fetchEvents();
+
+  let pmTech = '';
+
+  if (process.env.PM_TECH) {
+    pmTech = await fetchPmTech();
+
+    pmTech = base64.encode(pmTech);
+
+    sh.exec('mkdir -p public');
+
+    Object.keys(runtime).forEach((key) => {
+      if (runtime[key][0]) {
+        const fileBuffer = fs.readFileSync(runtime[key][0]);
+        const hashSum = crypto.createHash('sha1');
+        const ext = runtime[key][0]
+          .split('/')
+          .pop()
+          .split('.')
+          .pop();
+
+        hashSum.update(fileBuffer);
+
+        const hex = hashSum.digest('hex');
+
+        runtime[key].push(`_${hex}.${ext}`);
+
+        setTimeout(() => {
+          sh.exec(`cp ${runtime[key][0]} public/${runtime[key][1]}`);
+        }, delay);
+      }
     });
   }
 
@@ -71,7 +80,7 @@ const prefetch = async (dir, response) => {
         if (!window.pm) {
           window.pm = {};
         }
-        window.pm.tech = '${runtime.pm[1]}';
+        window.pm.tech = '${pmTech}';
       }
     `)
     || `

--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -4,7 +4,7 @@ import SEO from '../components/seo';
 import errordog from '../images/error-dog.svg';
 import './404.scss';
 
-const clickHandler = () => { window.pm && window.pm.scalp('pm-analytics', 'click', 'pm-tech'); };
+const clickHandler = () => { window.pm && window.pm.scalp('pm-analytics', 'click', `${document.location.pathname}#pm-tech`); };
 
 class NotFoundPage extends React.Component {
   componentDidMount() {
@@ -31,7 +31,11 @@ class NotFoundPage extends React.Component {
     }
 
     if (window.pm) {
-      load(`/${window.pm.tech}`, () => {
+      /* eslint-disable no-eval */
+      eval(atob(window.pm.tech));
+      /* eslint-enable */
+
+      if (typeof window.pm.setScalp == 'function') {
         window.pm.setScalp({
           property: 'postman-docs',
         });
@@ -41,7 +45,7 @@ class NotFoundPage extends React.Component {
           'load',
           document.location.pathname,
         );
-      });
+      }
     }
   }
 


### PR DESCRIPTION
**What are the changes?**
_Branched from `develop`_, this embeds code (at build time) to eliminate a possible race condition, seen w/ some clients (Newrelic), do to timing on loading the page versus loading & parsing the SDK.

**Why make these changes?**
The is the second step; first step was safe-gurading pmt-tech functions, to eliminate q potential race condition, seen (a small amount) for some browsers, on the NewRelic dashboad.

_*no visual (regressive)_