### PR TITLE
updated interlinking strategy for target="_blank"

### DIFF
--- a/src/components/ContextualLinks/ContextualLinks.jsx
+++ b/src/components/ContextualLinks/ContextualLinks.jsx
@@ -31,7 +31,7 @@ const ContextualLinks = ({ links }) => (
                 <p>
                   You are currently in develop mode.
                   Dynamic blog posts will not be displayed locally.
-                  <a style={{ fontSize: 'inherit' }} href="https://github.com/postmanlabs/postman-docs/blob/develop/CONTRIBUTING.md#to-use-the-dynamic-blog-posts-feature" target="_blank" rel="noopener noreferrer">See Contributing doc for details</a>
+                  <a style={{ fontSize: 'inherit' }} href="https://github.com/postmanlabs/postman-docs/blob/develop/CONTRIBUTING.md#to-use-the-dynamic-blog-posts-feature" target="_blank" rel="noopener">See Contributing doc for details</a>
                   .
                 </p>
               </div>

--- a/src/components/CookieAlert.jsx
+++ b/src/components/CookieAlert.jsx
@@ -56,7 +56,7 @@ class CookieAlert extends React.Component {
           and assist in our marketing efforts. Our Cookie Notice provides more
           information and explains how to amend your cookie settings.
           {' '}
-          <strong><a href="https://www.postman.com/legal/cookies/" target="_blank" rel="noreferrer noopener" style={{ color: 'black', textDecoration: 'underline' }}>Learn more</a></strong>
+          <strong><a href="https://www.postman.com/legal/cookies/" style={{ color: 'black', textDecoration: 'underline' }}>Learn more</a></strong>
         </CookieConsent>
       </div>
     );

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -21,7 +21,7 @@ function relStringGenerator(target) {
     return null;
   }
   if (target === 'blank') {
-    return 'noopener noreferrer';
+    return 'noopener';
   }
   return null;
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -518,7 +518,7 @@ class Header extends React.Component {
                         className="dropdown-item"
                         href="https://store.postman.com/"
                         target="_blank"
-                        rel="noreferrer"
+                        rel="noopener"
                       >
                         Postman swag
                       </a>
@@ -541,7 +541,7 @@ class Header extends React.Component {
                         className="dropdown-item"
                         href="https://status.postman.com/"
                         target="_blank"
-                        rel="noreferrer"
+                        rel="noopener"
                       >
                         Postman status
                       </a>
@@ -577,7 +577,7 @@ class Header extends React.Component {
           </div>
         </nav>
         <nav className="navbar-v6 navbar navbar-expand-lg navbar-light bg-light nav-secondary blurred-container">
-          <a className="navbar-brand" href="/">
+          <a className="navbar-brand" href="/docs/getting-started/introduction/">
             <span id="learning-center-home-link" className="nav-link uber-nav">
               Learning Center
               <span className="sr-only">(current)</span>

--- a/src/components/Hellobar.jsx
+++ b/src/components/Hellobar.jsx
@@ -54,7 +54,7 @@ class HelloBar extends React.Component {
     //     <div className="hellobar__container">
     //       <div className="align-middle hellobar__text">
     //         {bardata.title}
-    //         <a href={bardata.cta.url} className="hellobar__postman-link" target="_blank" rel="noopener noreferrer">{bardata.cta.text}</a>
+    //         <a href={bardata.cta.url} className="hellobar__postman-link" target="_blank" rel="noopener">{bardata.cta.text}</a>
     //       </div>
     //       <div aria-label="HelloBar" type="button" className="hellobar__close-button" onClick={this.closeBar}>X</div>
     //     </div>

--- a/src/components/Shared/EditDoc.jsx
+++ b/src/components/Shared/EditDoc.jsx
@@ -20,7 +20,7 @@ class EditDoc extends Component {
     const classes = className ? `${className}` : '';
     const { pathRoute } = this.state;
     return (
-      <a id="GTM-LC-id" className={classes} href={`https://github.com/postmanlabs/postman-docs/blob/develop/src/pages${pathRoute}.md`} target="_blank" rel="noopener noreferrer nofollow">
+      <a id="GTM-LC-id" className={classes} href={`https://github.com/postmanlabs/postman-docs/blob/develop/src/pages${pathRoute}.md`} target="_blank" rel="noopener nofollow">
         <i>
           <svg className="button-icon--left" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <title>logo-github</title>

--- a/src/components/__snapshots__/CookieAlert.spec.jsx.snap
+++ b/src/components/__snapshots__/CookieAlert.spec.jsx.snap
@@ -44,14 +44,12 @@ exports[`Cookie Notification displays on initial load 1`] = `
         <strong>
           <a
             href="https://www.postman.com/legal/cookies/"
-            rel="noreferrer noopener"
             style={
               Object {
                 "color": "black",
                 "textDecoration": "underline",
               }
             }
-            target="_blank"
           >
             Learn more
           </a>

--- a/src/pages/auto-flex-policy.jsx
+++ b/src/pages/auto-flex-policy.jsx
@@ -30,8 +30,6 @@ class AutoFlexPolicyPage extends React.Component {
                 {' '}
                 <a
                   href="https://blog.postman.com/introducing-auto-flex-for-teams/"
-                  target="_blank"
-                  rel="noreferrer"
                 >
                   Auto-Flex Team Policy
                 </a>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -184,7 +184,11 @@ class IndexPage extends React.Component {
               <div className="sticky-top" style={{ top: '75px', zIndex: '0' }}>
                 <h2 id="upcoming-events">Upcoming Postman Events</h2>
                 <p>
-                  <a className="link-style" href="https://www.twitch.tv/getpostman" target="_blank" rel="noopener noreferrer">
+                  <a 
+                    className="link-style" 
+                    href="https://www.twitch.tv/getpostman" 
+                    target="_blank" 
+                    rel="noopener">
                     Follow us
                   </a>
                   {' '}
@@ -194,7 +198,7 @@ class IndexPage extends React.Component {
                     className="link-style"
                     href="https://www.youtube.com/channel/UCocudCGVb3MmhWQ1aoIgUQw"
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                   >
                     subscribe
                   </a>
@@ -237,7 +241,7 @@ class IndexPage extends React.Component {
                               className="event-link-wrapper link-style"
                               href={event.link}
                               target="_blank"
-                              rel="noopener noreferrer"
+                              rel="noopener"
                             >
                               <span>See details →</span>
                             </OutboundLink>
@@ -260,7 +264,7 @@ class IndexPage extends React.Component {
                             style={{ fontSize: 'inherit' }}
                             href="https://github.com/postmanlabs/postman-docs/blob/develop/CONTRIBUTING.md"
                             target="_blank"
-                            rel="noopener noreferrer"
+                            rel="noopener"
                           >
                             See Contributing doc for details
                           </a>


### PR DESCRIPTION
* removing `noreferrer` from Postman properties
* fixing up interlinkning strategy for all target="_blank" to adhere to latest ruleset
* assigning the 'home' link to go to the main intro doc page instead of the homepage/root.
* ran tests and rebuilt spec