### PR TITLE
MARKENG-118 removed npm qs package dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3055,9 +3055,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.176",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
-      "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
+      "version": "4.14.177",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
+      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
     },
     "@types/mdast": {
       "version": "3.0.10",
@@ -3156,9 +3156,9 @@
       }
     },
     "@types/react": {
-      "version": "17.0.34",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.34.tgz",
-      "integrity": "sha512-46FEGrMjc2+8XhHXILr+3+/sTe3OfzSPU9YGKILLrUYbQ1CLQC9Daqo1KzENGXAWwrFwiY0l4ZbF20gRvgpWTg==",
+      "version": "17.0.36",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.36.tgz",
+      "integrity": "sha512-CUFUp01OdfbpN/76v4koqgcpcRGT3sYOq3U3N6q0ZVGcyeP40NUdVU+EWe3hs34RNaTefiYyBzOpxBBidCc5zw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -6422,9 +6422,9 @@
       },
       "dependencies": {
         "type-fest": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.5.3.tgz",
-          "integrity": "sha512-7VNmE7FlsrdcWjKbtuRuynZz96Gmf35p5DvoR2tbceNP0vd58ISx87PvUUInlhtRC49vSX6qlxEKc7AoiHRirg=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.6.0.tgz",
+          "integrity": "sha512-XN1FDGGtaSDA6CFsCW5iolTQqFsnJ+ZF6JqSz0SqXoh4F8GY0xqUv5RYnTilpmL+sOH8OH4FX8tf9YyAPM2LDA=="
         }
       }
     },
@@ -6968,9 +6968,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
-      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -7024,9 +7024,9 @@
       "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
     },
     "date-fns": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
-      "integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w=="
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.26.0.tgz",
+      "integrity": "sha512-VQI812dRi3cusdY/fhoBKvc6l2W8BPWU1FNVnFH9Nttjx4AFBRzfSVb/Eyc7jBT6e9sg1XtAGsYpBQ6c/jygbg=="
     },
     "debug": {
       "version": "4.3.2",
@@ -7062,6 +7062,14 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
+    },
+    "decode-named-character-reference": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.0.tgz",
+      "integrity": "sha512-KTiXDlRp9MMm/nlgI8rDGKoNNKiTJBl0RPjnBM680m2HlgJEA4JTASspK44lsvE4GQJildMRFp2HdEBiG+nqng==",
+      "requires": {
+        "character-entities": "^2.0.0"
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -18153,9 +18161,9 @@
       }
     },
     "loglevel": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
-      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
     },
     "longest-streak": {
       "version": "3.0.1",
@@ -18424,12 +18432,13 @@
       }
     },
     "mdast-util-from-markdown": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.0.4.tgz",
-      "integrity": "sha512-BlL42o885QO+6o43ceoc6KBdp/bi9oYyamj0hUbeu730yhP1WDC7m2XYSBfmQkOb0TdoHSAJ3de3SMqse69u+g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
+      "integrity": "sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==",
       "requires": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
         "mdast-util-to-string": "^3.1.0",
         "micromark": "^3.0.0",
         "micromark-util-decode-numeric-character-reference": "^1.0.0",
@@ -18437,7 +18446,6 @@
         "micromark-util-normalize-identifier": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.0",
-        "parse-entities": "^3.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
       }
@@ -18461,14 +18469,14 @@
       }
     },
     "mdast-util-mdx-jsx": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-1.1.1.tgz",
-      "integrity": "sha512-C4W4hXmagipaeMwi5O8y+lVWE4qP2MDxfKlIh0lZN6MZWSPpQTK5RPwKBH4DdYHorgjbV2rKk84rNWlRtvoZCg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-1.2.0.tgz",
+      "integrity": "sha512-5+ot/kfxYd3ChgEMwsMUO71oAfYjyRI3pADEK4I7xTmWLGQ8Y7ghm1CG36zUoUvDPxMlIYwQV/9DYHAUWdG4dA==",
       "requires": {
         "@types/estree-jsx": "^0.0.1",
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.0.0",
-        "parse-entities": "^3.0.0",
+        "parse-entities": "^4.0.0",
         "stringify-entities": "^4.0.0",
         "unist-util-remove-position": "^4.0.0",
         "unist-util-stringify-position": "^3.0.0",
@@ -18502,9 +18510,9 @@
       }
     },
     "mdast-util-to-markdown": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.4.tgz",
-      "integrity": "sha512-Wive3NvrNS4OY5yYKBADdK1QSlbJUZyZ2ssanITUzNQ7sxMfBANTVjLrAA9BFXshaeG9G77xpOK/z+TTret5Hg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.6.tgz",
+      "integrity": "sha512-doJZmTEGagHypWvJ8ltinmwUsT9ZaNgNIQW6Gl7jNdsI1QZkTHTimYW561Niy2s8AEPAqEgV0dIh2UOVlSXUJA==",
       "requires": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -18713,12 +18721,13 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromark": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.7.tgz",
-      "integrity": "sha512-67ipZ2CzQVsDyH1kqNLh7dLwe5QMPJwjFBGppW7JCLByaSc6ZufV0ywPOxt13MIDAzzmj3wctDL6Ov5w0fOHXw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.9.tgz",
+      "integrity": "sha512-aWPjuXAqiFab4+oKLjH1vSNQm8S9GMnnf5sFNLrQaIggGYMBcQ9CS0Tt7+BJH6hbyv783zk3vgDhaORl3K33IQ==",
       "requires": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
         "micromark-core-commonmark": "^1.0.1",
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -18732,7 +18741,6 @@
         "micromark-util-subtokenize": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
-        "parse-entities": "^3.0.0",
         "uvu": "^0.5.0"
       },
       "dependencies": {
@@ -18747,10 +18755,11 @@
       }
     },
     "micromark-core-commonmark": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.4.tgz",
-      "integrity": "sha512-HAtoZisp1M/sQFuw2zoUKGo1pMKod7GSvdM6B2oBU0U2CEN5/C6Tmydmi1rmvEieEhGQsjMyiiSoYgxISNxGFA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.5.tgz",
+      "integrity": "sha512-ZNtWumX94lpiyAu/lxvth6I5+XzxF+BLVUB7u60XzOBy4RojrbZqrx0mcRmbfqEMO6489vyvDfIQNv5hdulrPg==",
       "requires": {
+        "decode-named-character-reference": "^1.0.0",
         "micromark-factory-destination": "^1.0.0",
         "micromark-factory-label": "^1.0.0",
         "micromark-factory-space": "^1.0.0",
@@ -18765,14 +18774,13 @@
         "micromark-util-subtokenize": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
-        "parse-entities": "^3.0.0",
         "uvu": "^0.5.0"
       }
     },
     "micromark-extension-mdx-expression": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.2.tgz",
-      "integrity": "sha512-KbkM9D9x/ZOV6gLwaN8izl2ZMI3sg+C4JLuUSmd8zJ4Z2d3mSWrznJRLuXkZcyN9lLaRm4Dz2VPjae3AkC5X1A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.3.tgz",
+      "integrity": "sha512-TjYtjEMszWze51NJCZmhv7MEBcgYRgb3tJeMAJ+HQCAaZHHRBaDCccqQzGizR/H4ODefP44wRTgOn2vE5I6nZA==",
       "requires": {
         "micromark-factory-mdx-expression": "^1.0.0",
         "micromark-factory-space": "^1.0.0",
@@ -18823,9 +18831,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+          "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw=="
         }
       }
     },
@@ -18866,9 +18874,9 @@
       }
     },
     "micromark-factory-mdx-expression": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.4.tgz",
-      "integrity": "sha512-1mS1Cg/GmvvafgHQvxz4OqhcO1JGwzzTuGh1C8NIUrmnr6/3A1dJiAphHz7kJKI/b9WIr69Q8VswuwyWo576yQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.5.tgz",
+      "integrity": "sha512-1DSMCBeCUj4m01P8uYbNWvOsv+FtpDTcBUcDCdE06sENTBX54lndRs9neWOgsNWfLDm2EzCyNKiUaoJ+mWa/WA==",
       "requires": {
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -18957,14 +18965,14 @@
       }
     },
     "micromark-util-decode-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.1.tgz",
-      "integrity": "sha512-Wf3H6jLaO3iIlHEvblESXaKAr72nK7JtBbLLICPwuZc3eJkMcp4j8rJ5Xv1VbQWMCWWDvKUbVUbE2MfQNznwTA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
+      "integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
       "requires": {
+        "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^1.0.0",
         "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "parse-entities": "^3.0.0"
+        "micromark-util-symbol": "^1.0.0"
       }
     },
     "micromark-util-encode": {
@@ -19033,9 +19041,9 @@
       "integrity": "sha512-NZA01jHRNCt4KlOROn8/bGi6vvpEmlXld7EHcRH+aYWUfL3Wc8JLUNNlqUMKa0hhz6GrpUWsHtzPmKof57v0gQ=="
     },
     "micromark-util-types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.1.tgz",
-      "integrity": "sha512-UT0ylWEEy80RFYzK9pEaugTqaxoD/j0Y9WhHpSyitxd99zjoQz7JJ+iKuhPAgOW2MiPSUAx+c09dcqokeyaROA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
+      "integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w=="
     },
     "micromatch": {
       "version": "4.0.4",
@@ -20621,14 +20629,15 @@
       }
     },
     "parse-entities": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
-      "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.0.tgz",
+      "integrity": "sha512-5nk9Fn03x3rEhGaX1FU6IDwG/k+GxLXlFAkgrbM1asuAFl3BhdQWvASaIsmwWypRNcZKHPYnIuOSfIWEyEQnPQ==",
       "requires": {
         "@types/unist": "^2.0.0",
         "character-entities": "^2.0.0",
         "character-entities-legacy": "^3.0.0",
         "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
         "is-alphanumerical": "^2.0.0",
         "is-decimal": "^2.0.0",
         "is-hexadecimal": "^2.0.0"
@@ -23116,9 +23125,9 @@
       "integrity": "sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ=="
     },
     "remark-mdx": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.0.0-rc.1.tgz",
-      "integrity": "sha512-y3cj3wDwpXTE1boMco/nsquHj2noK0mtnXwBC8FJ/CtU06y66jOBWX1kLknluBl06pYbxtx1ypAOHKvjgT4vsA==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.0.0-rc.2.tgz",
+      "integrity": "sha512-TMgFSEVx42/YzJWjDY+GKw7CGSbp3XKqBraXPxFS27r8iD9U6zuOZKXH4MoLl9JqiTOmQi0M1zJwT2YhPs32ug==",
       "requires": {
         "mdast-util-mdx": "^1.0.0",
         "micromark-extension-mdxjs": "^1.0.0"
@@ -24631,9 +24640,9 @@
       }
     },
     "slugify": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.2.tgz",
-      "integrity": "sha512-XMtI8qD84LwCpthLMBHlIhcrj10cgA+U/Ot8G6FD6uFuWZtMfKK75JO7l81nzpFJsPlsW6LT+VKqWQJW3+6New=="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.3.tgz",
+      "integrity": "sha512-1MPyqnIhgiq+/0iDJyqSJHENdnH5MMIlgJIBxmkRMzTNKlS/QsN5dXsB+MdDq4E6w0g9jFA4XOTRkVDjDae/2w=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -24754,9 +24763,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.33",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
-          "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g=="
+          "version": "14.17.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.34.tgz",
+          "integrity": "sha512-USUftMYpmuMzeWobskoPfzDi+vkpe0dvcOBRNOscFrGxVp4jomnRxWuVohgqBow2xyIPC0S3gjxV/5079jhmDg=="
         }
       }
     },
@@ -26947,9 +26956,9 @@
           }
         },
         "camelcase": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+          "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA=="
         },
         "chalk": {
           "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "prettier": "^1.18.2",
     "prismjs": "^1.24.1",
     "prop-types": "^15.7.2",
-    "qs": "^6.9.4",
     "react": "^16.9.0",
     "react-cookie-consent": "^4.1.0",
     "react-dom": "^16.9.0",


### PR DESCRIPTION
* `depcheck` listed npm `qs` package as unused.
* removing qs and running `npm i` shows no issues calling out qs as missing
* running `npm list qs` shows a small handful of plugins require it, and pull it in themselves
* running `npm run dev` shows no errors after qs is removed
<img width="581" alt="Screen Shot 2021-11-23 at 3 16 49 PM" src="https://user-images.githubusercontent.com/4358288/143143799-26098cc6-da76-4fd5-bb06-cbe6ddd40951.png">
.
