### PR TITLE
Update for plan changes dec 1

### DIFF
--- a/src/pages/docs/administration/audit-logs.md
+++ b/src/pages/docs/administration/audit-logs.md
@@ -14,7 +14,7 @@ contextual_links:
     url: "/docs/administration/managing-your-team/managing-your-team/"
 ---
 
-> __[Audit logs are available on Postman Business and Enterprise plans.](https://www.postman.com/pricing)__
+> __[Audit logs are available on Postman Professional and Enterprise plans.](https://www.postman.com/pricing)__
 
 Audit logs list important team events. An admin can review audit logs to determine:
 

--- a/src/pages/docs/administration/billing.md
+++ b/src/pages/docs/administration/billing.md
@@ -73,7 +73,7 @@ The Postman [billing dashboard](http://go.postman.co/billing) allows you to mana
 
 When navigating to your [billing dashboard](http://go.postman.co/billing), you will first see your billing overview. You can view the details of your Postman plan, including your subscription cycle and a calculation of your expected cost upon renewal.
 
-<img alt="Billing overview" src="https://assets.postman.com/postman-docs/billing-dashboard-overview-v9.1.0.jpg" />
+<img alt="Billing overview" src="https://assets.postman.com/postman-docs/billing-plan-and-payments-dash-v9.1.jpg" />
 
 ### Managing add-ons
 
@@ -93,7 +93,7 @@ You can also [Purchase Add-ons](#purchasing-add-ons).
 
 In your [billing dashboard](http://go.postman.co/billing), select **Plan and payments** on the left, then **History**.
 
-<img alt="Account history view" src="https://assets.postman.com/postman-docs/plan-and-payments-history.jpg" />
+<img alt="Account history view" src="https://assets.postman.com/postman-docs/billing-history-v9.1.jpg" />
 
 Items such as updates to your Postman subscription, card changes, payments, and charges are all listed in chronological order.
 
@@ -101,7 +101,7 @@ Items such as updates to your Postman subscription, card changes, payments, and 
 
 In your [billing dashboard](http://go.postman.co/billing), select **Plan and payments** on the left, then **Invoices**. You can get a copy of your past invoices by selecting the download icon to the right of the invoice you would like to retrieve.
 
-<img alt="Invoices view" src="https://assets.postman.com/postman-docs/plan-and-payments-invoices.jpg" />
+<img alt="Invoices view" src="https://assets.postman.com/postman-docs/billing-invoices-v9.1.jpg" />
 
 To add or edit the information on an invoice, see [adding custom information to invoices](#adding-custom-information-to-invoices).
 
@@ -153,7 +153,7 @@ You can change your team's plan and billing cycle in your [billing dashboard](ht
 
 To change your plan immediately, navigate to your [billing dashboard](https://go.postman.co/billing/overview) and select **Edit Plan** on the right.
 
-<img alt="Edit plan page" src="https://assets.postman.com/postman-docs/billing-edit-plan-add-members-v9.1.0.jpg"/>
+<img alt="Edit plan page" src="https://assets.postman.com/postman-docs/billing-edit-plan-v9.1.jpg"/>
 
 You can opt to apply changes immediately or on renewal. You can adjust your team size, billing frequency, and plan type. Select **Next** to adjust your team's add-ons, including monitoring blocks, mock server blocks, and custom domains. Select **Next** to then **Confirm Changes**.
 
@@ -169,11 +169,11 @@ The cost of your new plan and/or additional seats will be prorated based on the 
 
 To set instructions to determine what will happen at the end of your current billing cycle, navigate to your [billing dashboard](https://go.postman.co/billing/overview) and select **Set instructions** on the right under your subtotal.
 
-<img alt="Set instructions in billing dashboard" src="https://assets.postman.com/postman-docs/billing-dashboard-set-instructions-v9.1.0.jpg"/>
+<img alt="Set instructions in billing dashboard" src="https://assets.postman.com/postman-docs/billing-overview-set-instructions-v9.1.jpg"/>
 
 You can view your current plan and opt to **Edit Standing Instructions**. Select your preferred option from the drop-down menu, then select **Proceed** to move forward with your plan changes.
 
-<img alt="Set instructions for next cycle" src="https://assets.postman.com/postman-docs/billing-set-instructions-for-next-billing-cycle-v9.1.0.jpg" width="400px"/>
+<img alt="Set instructions for next cycle" src="https://assets.postman.com/postman-docs/billing-set-instructions-v9.1.jpg" width="400px"/>
 
 > You can change your standing instructions at any time before the end of your current billing cycle.
 
@@ -191,7 +191,7 @@ The base number of monitoring requests, mock server calls, and custom domains in
 
 You can purchase additional blocks of monitoring requests, mock server calls, and custom domains by navigating to your [billing dashboard](http://go.postman.co/billing), selecting **Resource usage** on the left, then **Purchase Add-ons** on the right.
 
-<img alt="Add-ons purchase form" src="https://assets.postman.com/postman-docs/billing-dashboard-edit-plan-add-ons-v9.1.0.jpg"/>
+<img alt="Add-ons purchase form" src="https://assets.postman.com/postman-docs/billing-edit-plan-add-ons-v9.1.jpg"/>
 
 Update the number of monitoring blocks, mock server blocks, and custom domains you would like to have included in your team plan, then select **Next** to confirm your changes.
 
@@ -205,7 +205,7 @@ Update the number of monitoring blocks, mock server blocks, and custom domains y
 
 You can enable auto-flex for your team by navigating to your [billing dashboard](http://go.postman.co/billing).
 
-<img alt="Auto-flex opt in early notification" src="https://assets.postman.com/postman-docs/auto-flex-opt-in-early-notification.jpg" />
+<img alt="Auto-flex opt in early notification" src="https://assets.postman.com/postman-docs/auto-flex-opt-in-notification-v9.1.jpg" />
 
 Select **Get Early Access**.
 
@@ -241,7 +241,7 @@ You will not be billed if the number of users has remained unchanged during your
 
 You can view your current number of additional team members, how much you will be billed at the end of your cycle (unless you add or remove team members in the interim), and additional information about your auto-flex and regular billing cycles at any time in your [billing dashboard](http://go.postman.co/billing).
 
-<img alt="Billing overview" src="https://assets.postman.com/postman-docs/billing-dashboard-overview-v9.1.0.jpg" />
+<img alt="Billing overview" src="https://assets.postman.com/postman-docs/billing-plan-and-payments-dash-v9.1.jpg" />
 
 > [Contact Postman support](https://www.postman.com/support/) with any questions regarding auto-flex.
 

--- a/src/pages/docs/administration/billing.md
+++ b/src/pages/docs/administration/billing.md
@@ -199,7 +199,7 @@ Update the number of monitoring blocks, mock server blocks, and custom domains y
 
 [Auto-flex](https://learning.postman.com/auto-flex-policy/) is a flexible billing feature available to Postman teams. With auto-flex enabled, your team admins can add users without having to pay in advance for additional seats. Instead, you can utilize auto-flex to determine the value of adding users to your Postman team, and opt to retain or remove them prior to being [billed](#billing-for-auto-flex).
 
-> Auto-flex is automatically enabled for all Postman Basic and Business plans purchased after April 8, 2021. Teams created before this date can opt in immediately by enabling auto-flex via their [billing dashboard](http://go.postman.co/billing). All teams will have auto-flex automatically enabled when their plan first renews after July 1, 2021.
+> Auto-flex is automatically enabled for all Postman Basic and Professional plans purchased after April 8, 2021. Teams created before this date can opt in immediately by enabling auto-flex via their [billing dashboard](http://go.postman.co/billing). All teams will have auto-flex automatically enabled when their plan first renews after July 1, 2021.
 
 #### Opting in to auto-flex
 

--- a/src/pages/docs/administration/billing.md
+++ b/src/pages/docs/administration/billing.md
@@ -199,7 +199,7 @@ Update the number of monitoring blocks, mock server blocks, and custom domains y
 
 [Auto-flex](https://learning.postman.com/auto-flex-policy/) is a flexible billing feature available to Postman teams. With auto-flex enabled, your team admins can add users without having to pay in advance for additional seats. Instead, you can utilize auto-flex to determine the value of adding users to your Postman team, and opt to retain or remove them prior to being [billed](#billing-for-auto-flex).
 
-> Auto-flex is automatically enabled for all Postman Team and Business plans purchased after April 8, 2021. Teams created before this date can opt in immediately by enabling auto-flex via their [billing dashboard](http://go.postman.co/billing). All teams will have auto-flex automatically enabled when their plan first renews after July 1, 2021.
+> Auto-flex is automatically enabled for all Postman Basic and Business plans purchased after April 8, 2021. Teams created before this date can opt in immediately by enabling auto-flex via their [billing dashboard](http://go.postman.co/billing). All teams will have auto-flex automatically enabled when their plan first renews after July 1, 2021.
 
 #### Opting in to auto-flex
 

--- a/src/pages/docs/administration/buying.md
+++ b/src/pages/docs/administration/buying.md
@@ -22,7 +22,7 @@ contextual_links:
 
 ---
 
-Visit the [pricing page](https://www.postman.com/pricing) to purchase a Postman Basic, Business, or Enterprise plan. Click __Buy Now__ for your chosen plan. If you are [upgrading from an existing paid account](/docs/administration/billing/#team-and-plan-changes), you can use the links in your [billing dashboard](http://go.postman.co/billing).
+Visit the [pricing page](https://www.postman.com/pricing) to purchase a Postman Basic, Professional, or Enterprise plan. Click __Buy Now__ for your chosen plan. If you are [upgrading from an existing paid account](/docs/administration/billing/#team-and-plan-changes), you can use the links in your [billing dashboard](http://go.postman.co/billing).
 
 ## Configuring your plan
 

--- a/src/pages/docs/administration/buying.md
+++ b/src/pages/docs/administration/buying.md
@@ -22,7 +22,7 @@ contextual_links:
 
 ---
 
-Visit the [pricing page](https://www.postman.com/pricing) to purchase a Postman Team, Business, or Enterprise plan. Click __Buy Now__ for your chosen plan. If you are [upgrading from an existing paid account](/docs/administration/billing/#team-and-plan-changes), you can use the links in your [billing dashboard](http://go.postman.co/billing).
+Visit the [pricing page](https://www.postman.com/pricing) to purchase a Postman Basic, Business, or Enterprise plan. Click __Buy Now__ for your chosen plan. If you are [upgrading from an existing paid account](/docs/administration/billing/#team-and-plan-changes), you can use the links in your [billing dashboard](http://go.postman.co/billing).
 
 ## Configuring your plan
 

--- a/src/pages/docs/administration/managing-enterprise-deployment.md
+++ b/src/pages/docs/administration/managing-enterprise-deployment.md
@@ -18,25 +18,39 @@ contextual_links:
 
 ---
 
-> __[The Postman Enterprise Application is only available to Postman Enterprise teams and is currently in beta.](https://www.postman.com/pricing)__
+> __[Postman app versioning and the Postman Enterprise Application (currently in beta) are only available to Postman Enterprise teams.](https://www.postman.com/pricing)__
 
-Postman's Enterprise Application is a variant of Postman’s Desktop Application that offers greater control to administrators looking to deploy Postman at an enterprise level. It is available as an MSI package for Windows and supports silent installation, system-wide installation, and additional configurations to control how Postman is installed on users' devices.
-
-To get started, reach out to your Postman Account Manager or [contact Postman support](https://www.postman.com/support/).
+Postman Enterprise offers greater control to administrators looking to deploy and manage Postman at scale. Team admins can choose to [manage Postman app versioning](#managing-postman-app-versioning) via Postman support, or [deploy the Postman Enterprise app](#deploying-the-postman-enterprise-app) to their organization.
 
 ## Contents
 
-* [Downloading the Postman Enterprise app](#downloading-the-postman-enterprise-app)
+* [Managing Postman app versioning](#managing-postman-app-versioning)
 
-* [Installing the Postman Enterprise app](#installing-the-postman-enterprise-app)
+* [Deploying the Postman Enterprise app](#deploying-the-postman-enterprise-app)
 
-    * [Enabling verbose logging for installation](#enabling-verbose-logging-for-installation)
+    * [Downloading the Postman Enterprise app](#downloading-the-postman-enterprise-app)
 
-* [Updating the Postman Enterprise app](#updating-the-postman-enterprise-app)
+    * [Installing the Postman Enterprise app](#installing-the-postman-enterprise-app)
 
-* [Uninstalling the Postman Enterprise app](#uninstalling-the-postman-enterprise-app)
+        * [Enabling verbose logging for installation](#enabling-verbose-logging-for-installation)
 
-## Downloading the Postman Enterprise app
+    * [Updating the Postman Enterprise app](#updating-the-postman-enterprise-app)
+
+    * [Uninstalling the Postman Enterprise app](#uninstalling-the-postman-enterprise-app)
+
+## Managing Postman app versioning
+
+Postman app versioning allows you to set a team-wide version of Postman. You can choose to set Postman v8 or Postman v9 as your team's version. App versioning is a back-end operation and must be requested by a [Postman team admin](/docs/collaborating-in-postman/roles-and-permissions/#team-roles).
+
+To request this change, reach out to your Postman Account Manager or [contact Postman support](https://www.postman.com/support/).
+
+> Check out [Postman's release notes](https://www.postman.com/downloads/release-notes/) to compare app versions, or reach out to your Postman Account Manager for assistance in selecting your team's version.
+
+## Deploying the Postman Enterprise app
+
+Postman's Enterprise Application is a variant of Postman’s Desktop Application that offers greater control to administrators looking to deploy Postman at an enterprise level. It is available as an MSI package for Windows and supports silent installation, system-wide installation, and additional configurations to control how Postman is installed on users' devices.
+
+### Downloading the Postman Enterprise app
 
 You must be a [Postman team admin](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) to access the Postman Enterprise app package.
 
@@ -44,11 +58,13 @@ To download, navigate to Postman and select **Team** in the upper right, then **
 
 <img alt="Postman Enterprise app download" src="https://assets.postman.com/postman-docs/postman-enterprise-app-download-v9.jpg" />
 
-## Installing the Postman Enterprise app
+> Reach out to your Postman Account Manager or [contact Postman support](https://www.postman.com/support/) for assistance with the Postman Enterprise app.
+
+### Installing the Postman Enterprise app
 
 Once you've downloaded the Postman Enterprise MSI package, you can move forward with installing the app.
 
-### INSTALLDIR
+#### INSTALLDIR
 
 The `INSTALLDIR` public property is used to select a custom installation directory. If this public property is not manually overwritten, it defaults to `%PROGRAMFILES%\Postman\"Postman Enterprise"` for system-wide installations and `%USERPROFILE%\AppData\Local\Programs\Postman\"Postman Enterprise"` for per-user installations.
 
@@ -58,7 +74,7 @@ For example, you can run the following command to perform a system-wide installa
 msiexec /i path/to/package.msi INSTALLDIR=C:\custom
 ```
 
-### MSIINSTALLPERUSER
+#### MSIINSTALLPERUSER
 
 The standard `MSIINSTALLPERUSER` option is used to install the application per-user instead of system-wide. By default, the MSI performs a system-wide installation. Set `MSIINSTALLPERUSER` to `1` to perform a per-user installation.
 
@@ -74,7 +90,7 @@ This public property can be used in conjunction with `INSTALLDIR` to perform a p
 msiexec /i path/to/package.msi MSIINSTALLPERUSER=1 INSTALLDIR=%USERPROFILE%\custom
 ```
 
-### Silent installation
+#### Silent installation
 
 A silent installation or uninstallation is performed by passing the `/qn` option to `msiexec`:
 
@@ -86,7 +102,7 @@ Note that running in silent installation mode will omit error messages. If the i
 
 It is always recommended to [run silent installations with logging enabled](#enabling-verbose-logging-for-installation).
 
-### Enabling verbose logging for installation
+#### Enabling verbose logging for installation
 
 The `msiexec` tool can be configured to output debug log information about the installation process with the `/l*v` option. For example, you can output debug information to `C:\log.txt`:
 
@@ -94,7 +110,7 @@ The `msiexec` tool can be configured to output debug log information about the i
 msiexec /i path\to\package.msi /l*v C:\log.txt
 ```
 
-## Updating the Postman Enterprise app
+### Updating the Postman Enterprise app
 
 To upgrade the Postman Enterprise app, you can install the new version of the MSI package. Windows Installer will recognize this updated installation as an upgrade.
 
@@ -108,7 +124,7 @@ INSTALLDIR=C:\custom and MSIINSTALLPERUSER=1
 
 > Downgrading the Postman Enterprise app is not supported and attempts to do so will result in an error message. You can force a downgrade by manually removing the current version and then installing an older version of Postman Enterprise.
 
-## Uninstalling the Postman Enterprise app
+### Uninstalling the Postman Enterprise app
 
 The `msiexec` command-line tool can be used to remove an existing application using the `/x` option:
 

--- a/src/pages/docs/administration/managing-your-team/managing-your-team.md
+++ b/src/pages/docs/administration/managing-your-team/managing-your-team.md
@@ -17,7 +17,7 @@ contextual_links:
 
 ---
 
-> __[Certain team options are only available on Postman Basic, Business, and Enterprise plans.](https://www.postman.com/pricing)__
+> __[Certain team options are only available on Postman Basic, Professional, and Enterprise plans.](https://www.postman.com/pricing)__
 
 Postman provides a number of ways to manage your team.
 
@@ -40,7 +40,7 @@ Everyone in your team is a member. Each member has certain roles, which allow th
 
 An admin can modify the roles of other team members individually by navigating to [Team](https://go.postman.co/team) > **Manage Roles**.
 
-An admin can manage which team members have **Admin** and **Developer** roles. If you are on a Postman Business or Enterprise plan, an admin will also have the option of assigning a **Community Manager**.
+An admin can manage which team members have **Admin** and **Developer** roles. If you are on a Postman Professional or Enterprise plan, an admin will also have the option of assigning a **Community Manager**.
 
 Only a team member with the billing role can grant the **Billing** role to or remove it from other team members.
 

--- a/src/pages/docs/administration/managing-your-team/managing-your-team.md
+++ b/src/pages/docs/administration/managing-your-team/managing-your-team.md
@@ -17,7 +17,7 @@ contextual_links:
 
 ---
 
-> __[Certain team options are only available on Postman Team, Business, and Enterprise plans.](https://www.postman.com/pricing)__
+> __[Certain team options are only available on Postman Basic, Business, and Enterprise plans.](https://www.postman.com/pricing)__
 
 Postman provides a number of ways to manage your team.
 

--- a/src/pages/docs/administration/onboarding-checklist.md
+++ b/src/pages/docs/administration/onboarding-checklist.md
@@ -87,6 +87,6 @@ If you have any questions or run into any issues setting up Postman for your tea
 
 Check out [Security and Compliance: A Shared Responsibility Model](https://www.postman.com/shared-responsibility/) for important security considerations.
 
-Make sure to [configure SSO](/docs/administration/sso/admin-sso/) if you are subscribed to the Business or Enterprise plan.
+Make sure to [configure SSO](/docs/administration/sso/admin-sso/) if you are subscribed to the Professional or Enterprise plan.
 
 Finally, head over to [Managing Your Team](/docs/administration/managing-your-team/managing-your-team/) to learn about managing roles, inviting to workspaces, and how to adjust your team size.

--- a/src/pages/docs/administration/sso/admin-sso.md
+++ b/src/pages/docs/administration/sso/admin-sso.md
@@ -11,7 +11,7 @@ contextual_links:
     url: "/docs/administration/sso/intro-sso/"
 ---
 
-> __[SSO is available on Postman Business and Enterprise plans.](https://www.postman.com/pricing)__
+> __[SSO is available on Postman Professional and Enterprise plans.](https://www.postman.com/pricing)__
 
 ## Configuring single sign-on
 
@@ -92,7 +92,7 @@ The **Automatically add new users** checkbox in your SSO configuration determine
 
 ### Managing team logins
 
-By default, Postman only supports Service Provider initiated logins for Postman Business or Enterprise teams utilizing SSO. Your team will be required to head to the [Enterprise login page](https://identity.getpostman.com/enterprise/login) in order to log in to Postman. If you require users be able to log in from your SSO portal, you can generate and copy the RelayState from your [Postman team settings](http://go.postman.co/settings/team/auth) and save it in your IDP configuration. This ensures an additional level of security when logins are initiated through a source unknown to Postman.
+By default, Postman only supports Service Provider initiated logins for Postman Professional or Enterprise teams utilizing SSO. Your team will be required to head to the [Enterprise login page](https://identity.getpostman.com/enterprise/login) in order to log in to Postman. If you require users be able to log in from your SSO portal, you can generate and copy the RelayState from your [Postman team settings](http://go.postman.co/settings/team/auth) and save it in your IDP configuration. This ensures an additional level of security when logins are initiated through a source unknown to Postman.
 
 ### Removing team access
 

--- a/src/pages/docs/administration/sso/intro-sso.md
+++ b/src/pages/docs/administration/sso/intro-sso.md
@@ -46,7 +46,7 @@ An example of SSO is Google's implementation of login for their products, such a
 
 ### SSO setup for SAML 2.0 compliant IdPs
 
-Most SAML 2.0 compliant identity providers require the same information about the service provider for setup (Postman is the service provider). These values are specific to a Postman Team and are available after configuring SSO in the Edit Team Page.
+Most SAML 2.0 compliant identity providers require the same information about the service provider for setup (Postman is the service provider). These values are specific to a Postman team and are available after configuring SSO in the Edit Team Page.
 
 Learn more about [setting up SSO](/docs/administration/sso/admin-sso/).
 

--- a/src/pages/docs/administration/sso/intro-sso.md
+++ b/src/pages/docs/administration/sso/intro-sso.md
@@ -13,7 +13,7 @@ contextual_links:
     url: "https://blog.postman.com/announcing-updated-postman-plans-and-pricing/"
 ---
 
-> __[SSO is available on Postman Business and Enterprise plans.](https://www.postman.com/pricing)__
+> __[SSO is available on Postman Professional and Enterprise plans.](https://www.postman.com/pricing)__
 
 ## What is SSO?
 

--- a/src/pages/docs/administration/sso/user-sso.md
+++ b/src/pages/docs/administration/sso/user-sso.md
@@ -11,7 +11,7 @@ contextual_links:
     url: "/docs/administration/sso/intro-sso/"
 ---
 
-> __[SSO is available on Postman Business and Enterprise plans.](https://www.postman.com/pricing)__
+> __[SSO is available on Postman Professional and Enterprise plans.](https://www.postman.com/pricing)__
 
 When your team admin has enabled single sign-on (**SSO**) for Postman, you can log in to Postman with a [configured Identity provider](/docs/administration/sso/intro-sso/).
 

--- a/src/pages/docs/administration/team-merge.md
+++ b/src/pages/docs/administration/team-merge.md
@@ -36,9 +36,9 @@ Team migration can occur in different ways depending on your needs and preferred
 
 ## Who can perform team migration
 
-* All plan types (Free, Basic, Business, and Enterprise)
+* All plan types (Free, Basic, Professional, and Enterprise)
 * [Team admins and team developers](/docs/collaborating-in-postman/roles-and-permissions/#team-roles)
-* Information Technology / System Administrator for [Single Sign-On provisioning](/docs/administration/sso/intro-sso/) (available to [Business and Enterprise plans](https://www.postman.com/pricing/))
+* Information Technology / System Administrator for [Single Sign-On provisioning](/docs/administration/sso/intro-sso/) (available to [Professional and Enterprise plans](https://www.postman.com/pricing/))
 
 ## Before you start migrating
 
@@ -145,6 +145,6 @@ All collections in your personal workspace and any workspaces that you have join
 
 ## Next Steps
 
-[Configure SSO](/docs/administration/sso/admin-sso/) if you are subscribed to a Postman Business or Enterprise plan.
+[Configure SSO](/docs/administration/sso/admin-sso/) if you are subscribed to a Postman Professional or Enterprise plan.
 
 Learn how to [manage your team roles, invite team members to workspaces, and adjust your team size](/docs/administration/managing-your-team/managing-your-team/).

--- a/src/pages/docs/administration/team-merge.md
+++ b/src/pages/docs/administration/team-merge.md
@@ -36,7 +36,7 @@ Team migration can occur in different ways depending on your needs and preferred
 
 ## Who can perform team migration
 
-* All plan types (Free, Team, Business, and Enterprise)
+* All plan types (Free, Basic, Business, and Enterprise)
 * [Team admins and team developers](/docs/collaborating-in-postman/roles-and-permissions/#team-roles)
 * Information Technology / System Administrator for [Single Sign-On provisioning](/docs/administration/sso/intro-sso/) (available to [Business and Enterprise plans](https://www.postman.com/pricing/))
 

--- a/src/pages/docs/administration/team-settings.md
+++ b/src/pages/docs/administration/team-settings.md
@@ -74,7 +74,7 @@ View [Adding custom information to invoices](/docs/administration/billing/#addin
 
 ## Editing authentication methods
 
-> SSO is available on Postman Business and Enterprise plans.
+> SSO is available on Postman Professional and Enterprise plans.
 
 Select **Authentication** from the left-hand menu to configure or reconfigure your team's authentication methods.
 

--- a/src/pages/docs/api-security/token-scanner.md
+++ b/src/pages/docs/api-security/token-scanner.md
@@ -79,7 +79,7 @@ By default, tokens issued by the following service providers are scanned:
 
 Custom alerts can be used to scan your team's proprietary and third-party app tokens that are not scanned by default.
 
-> **[Custom alerts are available only on Postman Enterprise plan](https://www.postman.com/pricing/)**.
+> **[Custom alerts are available on Postman Enterprise plans only](https://www.postman.com/pricing/)**.
 
 Your team can add a total of five alerts. You must be a **Community Manager** or member with both **Developer** and **Admin** roles to add custom alerts.
 

--- a/src/pages/docs/collaborating-in-postman/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/adding-private-network.md
@@ -108,7 +108,7 @@ From the overview page, select **Create Folder** on the right to create a new fo
 
 ![New folder in Private Network](https://assets.postman.com/postman-docs/add-new-folder-api-network-overview-v9.jpg)
 
-Once you've created the folder, you can add APIs to get started. Make your API selection from the dropdown under **Select APIs** to add them to your Team's Private API Network. You can select as many APIs you want to add to the Private API Network at one time. Select __Add API__.
+Once you've created the folder, you can add APIs to get started. Make your API selection from the dropdown under **Select APIs** to add them to your team's Private API Network. You can select as many APIs you want to add to the Private API Network at one time. Select __Add API__.
 
 <img alt="Add API Modal" src="https://assets.postman.com/postman-docs/add-to-private-api-network-v9.jpg" width="400px"/>
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -29,7 +29,8 @@ contextual_links:
     url: "/docs/collaborating-in-postman/adding-private-network/"
 
 ---
-> Free collaboration is available in version 6.2 and above.
+
+> Postman Free allows teams of up to three to collaborate at no cost. To collaborate with additional team members, features, and increased usage limits, see [Plans and Pricing](https://www.postman.com/pricing/).
 
 Postman allows all users to collaborate with their teams through Team Workspaces. Using this feature, you can easily collaborate and share your collections, environments, integrations, history, mocks, monitors, and more.
 

--- a/src/pages/docs/collaborating-in-postman/public-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/public-workspaces.md
@@ -65,7 +65,7 @@ You can also convert an existing workspace to a public workspace. Open the works
 
 <img alt="Visibility" src="https://assets.postman.com/postman-docs/workspace-settings-request-visibility-change-v9.1.0.jpg" width="400px"/>
 
-If you are on a Postman Business or Enterprise plan, you need a community manager's approval to change a workspace's visibility to __Public__.
+If you are on a Postman Professional or Enterprise plan, you need a community manager's approval to change a workspace's visibility to __Public__.
 
 When you make a workspace public, a notification is sent to all workspace members. Select the notification bell in the top right corner to view notifications.
 

--- a/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
+++ b/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
@@ -21,7 +21,7 @@ contextual_links:
     url: "https://blog.postman.com/postman-team-workspaces-and-permissions/"
 ---
 
-> Certain team options are only available on **[Postman Team, Business, and Enterprise plans](https://www.postman.com/pricing)**. To see which roles are available on your plan, go to your **[web dashboard](https://go.postman.co/settings/team/roles)**.
+> Certain team options are only available on **[Postman Basic, Business, and Enterprise plans](https://www.postman.com/pricing)**. To see which roles are available on your plan, go to your **[web dashboard](https://go.postman.co/settings/team/roles)**.
 
 In Postman you can assign roles and permissions to provide access control.
 
@@ -82,7 +82,7 @@ Team roles provide high-level access control:
 | Approve requests to change workspace visibility&ast;&ast; | | | | &#x2714;
 | Enable public team profile | &#x2714; | | | &#x2714;
 
-&ast; On Postman Team and Free plans, any developer can change visibility of workspaces
+&ast; On Postman Basic and Free plans, any developer can change visibility of workspaces
 
 &ast;&ast; Enterprise and Business plans only
 
@@ -111,7 +111,7 @@ The following roles control access at a workspace level:
 | Add monitors and mock servers | &#x2714; | &#x2714; | |
 | Send requests | &#x2714; | &#x2714; | &#x2714; |
 
-&ast; On Business and Enterprise plans, workspace admins must request to change a workspace's visibility to public. This request will go to the [Community Manager](/docs/collaborating-in-postman/roles-and-permissions/#team-roles). On Team and Free plans, or if a team has no Community Manager assigned, workspace admins can control visibility.
+&ast; On Business and Enterprise plans, workspace admins must request to change a workspace's visibility to public. This request will go to the [Community Manager](/docs/collaborating-in-postman/roles-and-permissions/#team-roles). On Basic and Free plans, or if a team has no Community Manager assigned, workspace admins can control visibility.
 
 ### API roles
 

--- a/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
+++ b/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
@@ -21,7 +21,7 @@ contextual_links:
     url: "https://blog.postman.com/postman-team-workspaces-and-permissions/"
 ---
 
-> Certain team options are only available on **[Postman Basic, Business, and Enterprise plans](https://www.postman.com/pricing)**. To see which roles are available on your plan, go to your **[web dashboard](https://go.postman.co/settings/team/roles)**.
+> Certain team options are only available on **[Postman Basic, Professional, and Enterprise plans](https://www.postman.com/pricing)**. To see which roles are available on your plan, go to your **[web dashboard](https://go.postman.co/settings/team/roles)**.
 
 In Postman you can assign roles and permissions to provide access control.
 
@@ -53,12 +53,12 @@ With these roles, you and your teammates can manage access for each individual, 
 
 ### Team roles
 
-You can [assign](/docs/administration/managing-your-team/managing-your-team/) one or more role types to team members: **Admin**, **Billing**, and **Developer**. If you are on a [Postman Business or Enterprise plan](https://www.postman.com/pricing), you will also have the option of assigning a **Community Manager**.
+You can [assign](/docs/administration/managing-your-team/managing-your-team/) one or more role types to team members: **Admin**, **Billing**, and **Developer**. If you are on a [Postman Professional or Enterprise plan](https://www.postman.com/pricing), you will also have the option of assigning a **Community Manager**.
 
 * **Admin**: manage team members and team settings
 * **Billing**: manage team plan and payments
 * **Developer**: access team resources and workspaces
-* **Community Manager**: manage public visibility of workspaces and team profile (Business and Enterprise plans only)
+* **Community Manager**: manage public visibility of workspaces and team profile (Professional and Enterprise plans only)
 
 Each user must have at least one role attached to them, and can hold multiple roles simultaneously.
 
@@ -84,7 +84,7 @@ Team roles provide high-level access control:
 
 &ast; On Postman Basic and Free plans, any developer can change visibility of workspaces
 
-&ast;&ast; Enterprise and Business plans only
+&ast;&ast; Enterprise and Professional plans only
 
 ### Workspace roles
 
@@ -111,7 +111,7 @@ The following roles control access at a workspace level:
 | Add monitors and mock servers | &#x2714; | &#x2714; | |
 | Send requests | &#x2714; | &#x2714; | &#x2714; |
 
-&ast; On Business and Enterprise plans, workspace admins must request to change a workspace's visibility to public. This request will go to the [Community Manager](/docs/collaborating-in-postman/roles-and-permissions/#team-roles). On Basic and Free plans, or if a team has no Community Manager assigned, workspace admins can control visibility.
+&ast; On Professional and Enterprise plans, workspace admins must request to change a workspace's visibility to public. This request will go to the [Community Manager](/docs/collaborating-in-postman/roles-and-permissions/#team-roles). On Basic and Free plans, or if a team has no Community Manager assigned, workspace admins can control visibility.
 
 ### API roles
 

--- a/src/pages/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections.md
@@ -19,7 +19,7 @@ contextual_links:
 warning: false
 ---
 
-> **[Changelog is available on Postman Basic, Business, and Enterprise plans.](https://www.postman.com/pricing/)**
+> **[Changelog is available on Postman Basic, Professional, and Enterprise plans.](https://www.postman.com/pricing/)**
 
 Your Postman collections display a changelog for reviewing create, update, and delete events. You can use the changelog to keep track of any updates you and your collaborators make to your private and team collections. The changelog also lets you rollback a collection and restore it to any previous point in time. Postman also tracks activity within teams and accounts.
 
@@ -38,7 +38,7 @@ The changelog indicates the date of each update, the user who carried it out, wh
 
 ![Collection changelog](https://assets.postman.com/postman-docs/collection-changelog-v8.jpg)
 
-With a Postman Basic, Business, or Enterprise account, you can see generated diffs detailing changes to a collection.
+With a Postman Basic, Professional, or Enterprise account, you can see generated diffs detailing changes to a collection.
 
 <img alt="Changelog diffs" src ="https://assets.postman.com/postman-docs/changelog-diff-v8.jpg" width=400px/>
 
@@ -82,7 +82,7 @@ To filter by entity, click **Entity** at the top of the activity feed and select
 
 ## Viewing team activity
 
-You can review the activity for a team with a Postman Basic, Business, or Enterprise account. In [Postman](https://go.postman.co/), use the __Workspaces__ dropdown to select your team, then navigate to the __Activity__ feed to view the events.
+You can review the activity for a team with a Postman Basic, Professional, or Enterprise account. In [Postman](https://go.postman.co/), use the __Workspaces__ dropdown to select your team, then navigate to the __Activity__ feed to view the events.
 
 ## Viewing user activity
 
@@ -90,7 +90,7 @@ You can review the activity for your own account in [Postman](https://go.postman
 
 ## Restoring collections and folders
 
-With a Postman Basic, Business, or Enterprise account, you can use the changelog to restore a collection to a previous point in time. Click __Restore__ under a change to revert the collection to the point immediately _after_ the change was applied. The changelog will update and Postman will display a confirmation message indicating the time the collection has been restored to.
+With a Postman Basic, Professional, or Enterprise account, you can use the changelog to restore a collection to a previous point in time. Click __Restore__ under a change to revert the collection to the point immediately _after_ the change was applied. The changelog will update and Postman will display a confirmation message indicating the time the collection has been restored to.
 
 <img alt="Restore from changelog" src="https://assets.postman.com/postman-docs/restore-changelog-v8.jpg" width="400px"/>
 
@@ -106,7 +106,7 @@ Postman will prompt you to resolve any conflicts that may cause you to lose unsa
 
 ## Exporting team activity to other platforms
 
-With a Postman Basic, Business, or Enterprise account, you can pipe team activity feeds to external communication channels:
+With a Postman Basic, Professional, or Enterprise account, you can pipe team activity feeds to external communication channels:
 
 * [Slack integration](/docs/integrations/available-integrations/slack/)
 * [Microsoft Teams integration](/docs/integrations/available-integrations/microsoft-teams/)  

--- a/src/pages/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections.md
@@ -19,7 +19,7 @@ contextual_links:
 warning: false
 ---
 
-> **[Changelog is available on Postman Team, Business, and Enterprise plans.](https://www.postman.com/pricing/)**
+> **[Changelog is available on Postman Basic, Business, and Enterprise plans.](https://www.postman.com/pricing/)**
 
 Your Postman collections display a changelog for reviewing create, update, and delete events. You can use the changelog to keep track of any updates you and your collaborators make to your private and team collections. The changelog also lets you rollback a collection and restore it to any previous point in time. Postman also tracks activity within teams and accounts.
 
@@ -38,7 +38,7 @@ The changelog indicates the date of each update, the user who carried it out, wh
 
 ![Collection changelog](https://assets.postman.com/postman-docs/collection-changelog-v8.jpg)
 
-With a Postman Team, Business, or Enterprise account, you can see generated diffs detailing changes to a collection.
+With a Postman Basic, Business, or Enterprise account, you can see generated diffs detailing changes to a collection.
 
 <img alt="Changelog diffs" src ="https://assets.postman.com/postman-docs/changelog-diff-v8.jpg" width=400px/>
 
@@ -82,7 +82,7 @@ To filter by entity, click **Entity** at the top of the activity feed and select
 
 ## Viewing team activity
 
-You can review the activity for a team with a Postman Team, Business, or Enterprise account. In [Postman](https://go.postman.co/), use the __Workspaces__ dropdown to select your team, then navigate to the __Activity__ feed to view the events.
+You can review the activity for a team with a Postman Basic, Business, or Enterprise account. In [Postman](https://go.postman.co/), use the __Workspaces__ dropdown to select your team, then navigate to the __Activity__ feed to view the events.
 
 ## Viewing user activity
 
@@ -90,7 +90,7 @@ You can review the activity for your own account in [Postman](https://go.postman
 
 ## Restoring collections and folders
 
-With a Postman Team, Business, or Enterprise account, you can use the changelog to restore a collection to a previous point in time. Click __Restore__ under a change to revert the collection to the point immediately _after_ the change was applied. The changelog will update and Postman will display a confirmation message indicating the time the collection has been restored to.
+With a Postman Basic, Business, or Enterprise account, you can use the changelog to restore a collection to a previous point in time. Click __Restore__ under a change to revert the collection to the point immediately _after_ the change was applied. The changelog will update and Postman will display a confirmation message indicating the time the collection has been restored to.
 
 <img alt="Restore from changelog" src="https://assets.postman.com/postman-docs/restore-changelog-v8.jpg" width="400px"/>
 
@@ -106,7 +106,7 @@ Postman will prompt you to resolve any conflicts that may cause you to lose unsa
 
 ## Exporting team activity to other platforms
 
-With a Postman Team, Business, or Enterprise account, you can pipe team activity feeds to external communication channels:
+With a Postman Basic, Business, or Enterprise account, you can pipe team activity feeds to external communication channels:
 
 * [Slack integration](/docs/integrations/available-integrations/slack/)
 * [Microsoft Teams integration](/docs/integrations/available-integrations/microsoft-teams/)  

--- a/src/pages/docs/collaborating-in-postman/using-workspaces/creating-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/creating-workspaces.md
@@ -51,7 +51,7 @@ Workspaces can also create visibility for the projects within a team, since coll
 
 _Workspace as an entity_ represents a whole container where being an admin gives you full access to the workspace. This concept works like the inheritance property where you will have editor access to all the elements within that particular workspace.
 
-> For Postman Business and Enterprise teams, a private workspace is a team workspace that is only visible to the user who created it, plus team members who have been invited to join it. Private workspaces allow teams to restrict access to collections, environments, mocks, and monitors that are relevant only to a particular group.
+> For Postman Professional and Enterprise teams, a private workspace is a team workspace that is only visible to the user who created it, plus team members who have been invited to join it. Private workspaces allow teams to restrict access to collections, environments, mocks, and monitors that are relevant only to a particular group.
 
 ## Creating a new workspace
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -153,7 +153,7 @@ Reviewers can [comment on your pull request or decide to merge](#reviewing-pull-
 
 ### Pull request settings
 
-Pull request settings are available on [Postman Business and Enterprise plans](https://www.postman.com/pricing) in the __Manage Roles__ section of a collection.
+Pull request settings are available on [Postman Professional and Enterprise plans](https://www.postman.com/pricing) in the __Manage Roles__ section of a collection.
 
 <img alt="Collection Manage Roles" src="https://assets.postman.com/postman-docs/collection-manage-roles-v9.1.jpg" width="300px"/>
 

--- a/src/pages/docs/designing-and-developing-your-api/view-and-analyze-api-reports.md
+++ b/src/pages/docs/designing-and-developing-your-api/view-and-analyze-api-reports.md
@@ -26,7 +26,7 @@ contextual_links:
     url: "/docs/designing-and-developing-your-api/validating-elements-against-schema/"
 ---
 
-> [__API reporting is available on all Postman Enterprise and select Postman Business plans.__](https://www.postman.com/pricing)
+> [__API reporting is available on all Postman Enterprise and select Postman Professional plans.__](https://www.postman.com/pricing)
 
 Postman generates reports that enable you to visualize data for team metrics and usage, and for API activities such as creation, collection execution, and test runs. Use reports to get insights on performance, troubleshooting, and SLA adherence. You can access API reports in your [Postman dashboard](https://go.postman.co/reports/summary).
 
@@ -38,7 +38,7 @@ Postman generates reports that enable you to visualize data for team metrics and
 * [All Workspaces reports](#all-workspaces-reports)
 * [All APIs reports](#all-apis-reports)
 * [Security Audit](#security-audit-reports)
-* [Business reports](#business-reports)
+* [Postman Professional reports](#postman-professional-reports)
 * [Troubleshooting](#troubleshooting)
 * [Next Steps](#next-steps)
 
@@ -72,7 +72,7 @@ To navigate within a report:
 
     <img src="https://assets.postman.com/postman-docs/reports-drilldown.jpg" alt="reports data point" width="100%" />
 
-> [Postman Enterprise](https://www.postman.com/pricing/get-started-postman-plans/) teams have access to detailed team and API reports. Postman Business teams created after 2020 have access to a limited set of reports. For more information, see [business reports](#business-reports).
+> [Postman Enterprise](https://www.postman.com/pricing/get-started-postman-plans/) teams have access to detailed team and API reports. Postman Professional teams created after 2020 have access to a limited set of reports. For more information, see [Postman Professional reports](#postman-professional-reports).
 
 ## Reports Summary
 
@@ -275,9 +275,9 @@ The **Security Audit** report provides the following information:
 * __Exposed tokens by type__ - The number of exposed tokens by type.
 * __Exposed tokens over time__ - The number of exposed tokens over time.
 
-## Business reports
+## Postman Professional reports
 
-Postman Business teams created after January 2020 do not benefit from API reporting. To gain access to API reporting, [upgrade to Postman Enterprise](https://www.postman.com/pricing/get-started-postman-plans/). [Contact Postman support](https://www.postman.com/support/) for information and assistance regarding your team's plan and feature set.
+Postman Professional teams created after January 2020 do not benefit from API reporting. To gain access to API reporting, [upgrade to Postman Enterprise](https://www.postman.com/pricing/get-started-postman-plans/). [Contact Postman support](https://www.postman.com/support/) for information and assistance regarding your team's plan and feature set.
 
 The __Team__ &gt; __Overview__ report provides organization level metrics, including new and active APIs, team size, and workspaces. Select a particular metric to view more data.
 

--- a/src/pages/docs/getting-started/postman-account.md
+++ b/src/pages/docs/getting-started/postman-account.md
@@ -107,7 +107,7 @@ You can sign into Postman by selecting **Sign In** in the upper-right corner, se
 > You can opt out of the login process at any time by navigating back to Postman and selecting **Skip and take me to Postman Desktop App**.
 > You must complete the process of signing in within five minutes once you initiate login from Postman. If you go beyond this time, you must return to Postman and restart the sign in process.
 
-Log into Postman in your browser by entering your account credentials or signing in with Google. If you are on a Postman Business or Enterprise plan, opt to **Sign in with Single Sign-On (SSO)**.
+Log into Postman in your browser by entering your account credentials or signing in with Google. If you are on a Postman Professional or Enterprise plan, opt to **Sign in with Single Sign-On (SSO)**.
 
 > Check **Keep me signed in** if you would like to remain signed in after your current session for 30 days before re-authenticating. If you do not want to remain signed in on the computer you are working on, uncheck this option. Note that you will be prompted to sign in again after 30 minutes.
 

--- a/src/pages/docs/getting-started/postman-account.md
+++ b/src/pages/docs/getting-started/postman-account.md
@@ -137,7 +137,7 @@ If you have a free account, you can upgrade it by navigating to [Postman](https:
 
 If you have a paid account, you can upgrade your Postman plan by navigating to your [billing dashboard](https://go.postman.co/billing/overview) and selecting **Edit Plan** on the right.
 
-[![Edit plan option in billing dashboard](https://assets.postman.com/postman-docs/billing-dashboard-edit-plan-v9.1.0.jpg)](https://assets.postman.com/postman-docs/billing-dashboard-edit-plan-v9.1.0.jpg)
+[![Edit plan option in billing dashboard](https://assets.postman.com/postman-docs/billing-edit-plan-selected-v9.1.jpg)](https://assets.postman.com/postman-docs/billing-edit-plan-selected-v9.1.jpg)
 
 > The cost of your upgraded plan and/or additional seats will be prorated based on the time left in your team's current billing cycle. For more information, [contact Postman's sales team](mailto:sales@postman.com).
 

--- a/src/pages/docs/integrations/available-integrations/github.md
+++ b/src/pages/docs/integrations/available-integrations/github.md
@@ -49,7 +49,7 @@ In order to set up an integration, you will need a GitHub Personal Access Token.
 
  You can back up and sync your Postman collections with a GitHub repo. Once the integration is complete, any new changes to your collection in Postman will also appear in the repository.
 
- > Backing up collections on GitHub is available for Basic, Business and Enterprise plans only.
+ > Backing up collections on GitHub is available for Basic, Professional, and Enterprise plans only.
 
 1. From the **[Home](https://go.postman.co/home)** page select **[Integrations](https://go.postman.co/integrations)**.
 

--- a/src/pages/docs/integrations/available-integrations/github.md
+++ b/src/pages/docs/integrations/available-integrations/github.md
@@ -49,7 +49,7 @@ In order to set up an integration, you will need a GitHub Personal Access Token.
 
  You can back up and sync your Postman collections with a GitHub repo. Once the integration is complete, any new changes to your collection in Postman will also appear in the repository.
 
- > Backing up collections on GitHub is available for Team, Business and Enterprise plans only.
+ > Backing up collections on GitHub is available for Basic, Business and Enterprise plans only.
 
 1. From the **[Home](https://go.postman.co/home)** page select **[Integrations](https://go.postman.co/integrations)**.
 

--- a/src/pages/docs/integrations/available-integrations/keen.md
+++ b/src/pages/docs/integrations/available-integrations/keen.md
@@ -13,7 +13,7 @@ contextual_links:
 
 You can use Keen IO for API-based computation, Amazon S3 backups, and building visualizations and dashboards for your APIs. Connect your Postman Monitor results to Keen Streams with the Postman to Keen Integration.
 
-Setting up a Keen integration requires you to get a project ID and API key before configuring Postman Monitors to push to Keen steams. After you set up the integration, you can view all monitoring data in Keen IO.
+Setting up a Keen integration requires you to get a project ID and API key before configuring Postman Monitors to push to Keen streams. After you set up the integration, you can view all monitoring data in Keen IO.
 
 ## Retrieving your Keen IO project ID and API Key
 

--- a/src/pages/docs/monitoring-your-api/faqs-monitors.md
+++ b/src/pages/docs/monitoring-your-api/faqs-monitors.md
@@ -42,7 +42,7 @@ There is nearly no limit to the amount of data that can be sent or received per 
 
 ### Are static IP addresses dedicated to individual customers or shared?
 
-The provided static IP addresses are fixed to their specified region and shared by all customers who enable this feature, which is available to Postman Business and Enterprise teams. For more information, see [Running Postman monitors using static IPs](/docs/monitoring-your-api/using-static-IPs-to-monitor/).
+The provided static IP addresses are fixed to their specified region and shared by all customers who enable this feature, which is available to Postman Professional and Enterprise teams. For more information, see [Running Postman monitors using static IPs](/docs/monitoring-your-api/using-static-IPs-to-monitor/).
 
 ### How do I troubleshoot problems?
 

--- a/src/pages/docs/monitoring-your-api/intro-monitors.md
+++ b/src/pages/docs/monitoring-your-api/intro-monitors.md
@@ -113,7 +113,7 @@ If you are on a paid plan, you can select one or more geographic regions you'd l
 
 ### Accessible APIs
 
-Because monitors run in the Postman cloud, all URLs must be publicly available on the Internet. A monitor cannot directly access your `localhost` or run requests behind a firewall. You can [run monitors using static IPs](/docs/monitoring-your-api/using-static-IPs-to-monitor/) to overcome this issue. Static IPs are available on [Postman Business and Enterprise plans](https://www.postman.com/pricing).
+Because monitors run in the Postman cloud, all URLs must be publicly available on the Internet. A monitor cannot directly access your `localhost` or run requests behind a firewall. You can [run monitors using static IPs](/docs/monitoring-your-api/using-static-IPs-to-monitor/) to overcome this issue. Static IPs are available on [Postman Professional and Enterprise plans](https://www.postman.com/pricing).
 
 ## Next steps
 

--- a/src/pages/docs/monitoring-your-api/setting-up-monitor.md
+++ b/src/pages/docs/monitoring-your-api/setting-up-monitor.md
@@ -135,7 +135,7 @@ You can allow Postman to auto-select a region for your monitor or you can opt to
 
 ### Using static IPs
 
-Static IPs are available on Postman Business and Enterprise plans. This option allows you to securely monitor private APIs using a direct channel to Postman. Learn how you can [monitor using static IPs](/docs/monitoring-your-api/using-static-IPs-to-monitor/).
+Static IPs are available on Postman Professional and Enterprise plans. This option allows you to securely monitor private APIs using a direct channel to Postman. Learn how you can [monitor using static IPs](/docs/monitoring-your-api/using-static-IPs-to-monitor/).
 
 ### Updating email preferences
 

--- a/src/pages/docs/monitoring-your-api/using-static-IPs-to-monitor.md
+++ b/src/pages/docs/monitoring-your-api/using-static-IPs-to-monitor.md
@@ -16,9 +16,9 @@ contextual_links:
     url: "/docs/integrations/intro-integrations/"
 ---
 
-> __[Static IP address monitoring is available on Postman Business and Enterprise plans.](https://www.postman.com/pricing)__
+> __[Static IP address monitoring is available on Postman Professional and Enterprise plans.](https://www.postman.com/pricing)__
 
-Postman's static IP feature allows you to monitor your APIs that are behind a restricted firewall. This feature is available to all Postman Business and Enterprise customers, provided your IT team [whitelists](#whitelisting-static-ip-addresses) the associated static IP addresses.
+Postman's static IP feature allows you to monitor your APIs that are behind a restricted firewall. This feature is available to all Postman Professional and Enterprise customers, provided your IT team [whitelists](#whitelisting-static-ip-addresses) the associated static IP addresses.
 
 The provided static IP addresses are fixed to their specified region and shared by all customers who utilize this feature.
 

--- a/src/pages/docs/monitoring-your-api/using-static-IPs-to-monitor.md
+++ b/src/pages/docs/monitoring-your-api/using-static-IPs-to-monitor.md
@@ -18,13 +18,13 @@ contextual_links:
 
 > __[Static IP address monitoring is available on Postman Professional and Enterprise plans.](https://www.postman.com/pricing)__
 
-Postman's static IP feature allows you to monitor your APIs that are behind a restricted firewall. This feature is available to all Postman Professional and Enterprise customers, provided your IT team [whitelists](#whitelisting-static-ip-addresses) the associated static IP addresses.
+Postman's static IP feature allows you to monitor your APIs that are behind a restricted firewall. This feature is available to all Postman Professional and Enterprise customers, provided your IT team [allowlists](#allowlisting-static-ip-addresses) the associated static IP addresses.
 
 The provided static IP addresses are fixed to their specified region and shared by all customers who utilize this feature.
 
 ## Contents
 
-* [Whitelisting static IP addresses](#whitelisting-static-ip-addresses)
+* [Allowlisting static IP addresses](#allowlisting-static-ip-addresses)
 
 * [Creating a new monitor to run from a static IP address](#creating-a-new-monitor-to-run-from-a-static-ip-address)
 
@@ -32,9 +32,9 @@ The provided static IP addresses are fixed to their specified region and shared 
 
 * [Next steps](#next-steps)
 
-## Whitelisting static IP addresses
+## Allowlisting static IP addresses
 
-Static IP addresses are available for US east and US west regions. Contact your IT team to whitelist the following IP addresses:
+Static IP addresses are available for US east and US west regions. Contact your IT team to allowlist the following IP addresses:
 
 * US East: `34.201.186.27`
 * US West: `52.89.173.88`

--- a/src/pages/docs/publishing-your-api/custom-doc-domains.md
+++ b/src/pages/docs/publishing-your-api/custom-doc-domains.md
@@ -19,7 +19,7 @@ contextual_links:
 warning: false
 ---
 
-> __[Custom documentation domains are available on Postman Team, Business, and Enterprise plans.](https://www.postman.com/pricing)__
+> __[Custom documentation domains are available on Postman Basic, Business, and Enterprise plans.](https://www.postman.com/pricing)__
 
 You can use a custom domain for your API documentation.
 

--- a/src/pages/docs/publishing-your-api/custom-doc-domains.md
+++ b/src/pages/docs/publishing-your-api/custom-doc-domains.md
@@ -19,7 +19,7 @@ contextual_links:
 warning: false
 ---
 
-> __[Custom documentation domains are available on Postman Basic, Business, and Enterprise plans.](https://www.postman.com/pricing)__
+> __[Custom documentation domains are available on Postman Basic, Professional, and Enterprise plans.](https://www.postman.com/pricing)__
 
 You can use a custom domain for your API documentation.
 

--- a/src/pages/docs/sending-requests/intro-to-collections.md
+++ b/src/pages/docs/sending-requests/intro-to-collections.md
@@ -123,7 +123,7 @@ Recovery options depend on your Postman plan:
 
 * With a free account you can recover collections up to one day old.
 * With Postman Basic you can recover collections up to 30 days.
-* With Postman Business and Enterprise you can recover collections up to 90 days.
+* With Postman Professional and Enterprise you can recover collections up to 90 days.
 
 > You cannot recover a deleted collection that is larger than 30 MB.
 

--- a/src/pages/docs/sending-requests/intro-to-collections.md
+++ b/src/pages/docs/sending-requests/intro-to-collections.md
@@ -122,7 +122,7 @@ You can recover deleted collections in Postman using __Trash__. Click `...` next
 Recovery options depend on your Postman plan:
 
 * With a free account you can recover collections up to one day old.
-* Team accounts can recover collections up to 30 days.
+* With Postman Basic you can recover collections up to 30 days.
 * With Postman Business and Enterprise you can recover collections up to 90 days.
 
 > You cannot recover a deleted collection that is larger than 30 MB.


### PR DESCRIPTION
This PR updates plan names and screenshots in the docs for the dec 1st plan/pricing change.

Summary of changes:
```
Free -> Free, no changes
Team -> Basic, no pricing or feature changes
Business -> Professional, price change but no feature change
Enterprise -> Enterprise, price change and optional control over app version (must be requested, not an external feature)
```