### PR TITLE
updated to reflect node v14.15.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please note we have a [code of conduct](https://www.postman.com/code-of-conduct)
 
 ### Prerequisites
 
-This site was built with node v12.13.0. We recommend installing and using [nvm](https://github.com/nvm-sh/nvm), a version manager for node. After you install nvm, use it to set your node version to v12.13.0.
+This site was built with node v14.15.0. We recommend installing and using [nvm](https://github.com/nvm-sh/nvm), a version manager for node. After you install nvm, use it to set your node version to v14.15.0.
 
 **Note for Mac users**: If you are using a MacBook with an Apple M1 chip, you may need to create a Rosetta version of Terminal in order to correctly download both nvm and the dependencies needed by this GitHub repo. For more information, see this guide on [creating a Rosetta terminal](https://www.courier.com/blog/tips-and-tricks-to-setup-your-apple-m1-for-development). After you create a Rosetta terminal, use it to install nvm, then proceed with the rest of the workflow outlined here.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We would love for you to contribute to the Learning Center! To contribute to thi
 
 ```
 
-**NOTE:** this site was built with node v12.13.0. We recommend installing and using [nvm](https://github.com/nvm-sh/nvm) and setting your node version to v12.13.0.
+**NOTE:** this site was built with node v14.15.0. We recommend installing and using [nvm](https://github.com/nvm-sh/nvm) and setting your node version to v14.15.0.
 
 ### Build using Docker
 
@@ -42,7 +42,7 @@ You can build the Learning Center and run it in a Docker container by creating a
 
     ```shell
 
-    FROM node:12
+    FROM node:14
 
     EXPOSE 8000
 


### PR DESCRIPTION
Updated READMEs to instruct contributors to use Node v14.15.0.
This is required by the latest Gatsby v4 (we just updated from Gatsby v2).