### PR TITLE
[MARKENG-1077] added print stylesheet

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -2,6 +2,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import 'jquery/dist/jquery.min';
 import 'popper.js/dist/popper.min';
 import 'bootstrap/dist/js/bootstrap.min';
+import './styles/config/print.css'
 
 import $ from 'jquery';
 import 'jquery.scrollto';

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -176,6 +176,7 @@ module.exports = {
         ignore: [
           '/prism-tomorrow.css',
           '/doc.scss',
+          '/print.css',
         ], // Ignore files/folders
         // purgeOnly : ['components/', '/main.css', 'bootstrap/'], // Purge only these files/folders
 

--- a/styles/config/print.css
+++ b/styles/config/print.css
@@ -1,0 +1,136 @@
+/**
+* Print Stylesheet
+*/
+
+@media print {
+ 
+    /* Setting content width, unsetting floats and margins */
+    /* Attention: the classes and IDs vary from theme to theme. Thus, set own classes here */
+    main {
+        width: 100%; 
+        margin: 0; 
+        float: none;
+    }
+        
+    /** Setting margins */       
+    @page { margin: 2cm }
+
+    /* Set background to white and font to black.*/
+    /* This saves ink */
+    body {
+        line-height: 1.3;
+        background: #ffffff !important;
+        color: #000000;
+    }
+
+    h1 {
+        font-size: 24pt;
+    }
+
+    h2, h3, h4 {
+        font-size: 14pt;
+        margin-top: 25px;
+    }    
+    
+    /* Defining all page breaks */
+    a, blockquote, table, pre {
+        page-break-inside: avoid;
+    }
+    h1, h2, h3, h4, h5, h6 { 
+        page-break-after: avoid; 
+        page-break-inside: avoid
+    }
+    img {
+        page-break-inside: avoid; 
+        page-break-after: avoid;
+    }
+    ul, ol, dl {
+        page-break-before: avoid
+    }
+        
+    /* Displaying link color and link behaviour */
+    a:link, a:visited, a {
+        background: transparent;
+        color: #520;
+        font-weight: bold;
+        text-decoration: underline;
+        text-align: left;
+    }
+
+    a {
+        page-break-inside:avoid
+    }
+
+    a[href^=http]:after {
+        content:" <" attr(href) "> ";
+    }
+
+    a:after > img {
+        content: "";
+    }
+
+    article a[href^="#"]:after {
+        content: "";
+    }
+
+    a:not(:local-link):after {
+        content:" <" attr(href) "> ";
+    }
+        
+    /**
+    * Making intergated videos disappear, and removing the iframes' whitespace to zero. 
+    */
+    .entry iframe, ins {
+        display: none;
+        width: 0 !important;
+        height: 0 !important;
+        overflow: hidden !important;
+        line-height: 0pt !important;
+        white-space: nowrap;
+    }
+    .embed-youtube, .embed-responsive {
+        position: absolute;
+        height: 0;
+        overflow: hidden;
+    }
+        
+    /* Hiding unnecessary elements for the print */
+    #header-widgets, nav, aside.mashsb-container, 
+    .sidebar, .mashshare-top, .mashshare-bottom, 
+    .content-ads, .make-comment, .author-bio, 
+    .heading, .related-posts, #decomments-form-add-comment, 
+    #breadcrumbs, footer, .post-byline, .meta-single, 
+    .site-title img, .post-tags, .readability,
+    #onetrust-consent-sdk, .right-column
+    {
+        display: none;
+    }
+    /* Make images half-width to save space */
+    img {
+        width: 50%;
+        height: auto;
+        display: block;
+    }
+        
+    /* Adding custom messages before and after the content */
+    .entry:after {
+        content: "\ All Rights Reserved. © 2021 Postman, Inc.";
+        color: #999 !important;
+        font-size: 1em;
+        padding-top: 30px;
+    }
+
+    /* Wichtige Elemente definieren */    
+    p, address, li, dt, dd, blockquote {
+        font-size: 100%
+    }
+
+    ul, ol {
+        list-style: square; margin-left: 18pt;
+        margin-bottom: 20pt;    
+    }
+
+    li {
+        line-height: 1.6em;
+    }
+}


### PR DESCRIPTION
* added basic print stylesheet
* hid everything but the main doc / content area
* made images 50% page-width to save space and retain readability.
* converted text to full black and backgrounds to full white to save ink
* excluded it from purge CSS plugin
* cmd-p / cntrl-p to see print dialog and print example.
<img width="1230" alt="Screen Shot 2021-12-07 at 3 04 59 PM" src="https://user-images.githubusercontent.com/4358288/145120815-5daeb1f3-6c01-4136-a0dc-36118da33788.png">


