### PR TITLE
The Postman chrome extension is deprecated

### DIFF
--- a/src/pages/docs/sending-requests/capturing-request-data/interceptor.md
+++ b/src/pages/docs/sending-requests/capturing-request-data/interceptor.md
@@ -246,8 +246,7 @@ You can use Interceptor to create a Postman collection for a web app or to debug
 
 To use Interceptor with Postman Chrome, you can take the following steps:
 
-1. [Install Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?) from the Chrome Web Store.
-2. Install [Interceptor](https://chrome.google.com/webstore/detail/postman-interceptor/aicmkgpgakddgnaphhhpliifpcfhicfo/) from the Chrome Web Store.
-3. Open Postman, click on the Interceptor icon in the toolbar, and toggle to **On**.
+1. Install [Interceptor](https://chrome.google.com/webstore/detail/postman-interceptor/aicmkgpgakddgnaphhhpliifpcfhicfo/) from the Chrome Web Store.
+2. Open Postman, click on the Interceptor icon in the toolbar, and toggle to **On**.
 
 You can then browse your app or website and monitor requests as they stream in to your Postman history.


### PR DESCRIPTION
As per the chrome web store, the Postman extension for chrome is deprecated and recommend to use the native app.