### PR TITLE
Added link to Postman Answers on homepage

### DIFF
--- a/src/assets/icons/solution.svg
+++ b/src/assets/icons/solution.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_1_);}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_00000074413588759276044370000002697867463564075153_);}
+	.st2{fill:none;stroke:#6B6B6B;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="34.5" y1="33.125" x2="34.5" y2="3.875" gradientTransform="matrix(1 0 0 -1 0 50)">
+	<stop  offset="0" style="stop-color:#EE7C48"/>
+	<stop  offset="1" style="stop-color:#EDAA52"/>
+</linearGradient>
+<path class="st0" d="M22.9,24c0-0.6,0.5-1.1,1.1-1.1h6.4v-1.1c0-1.3,0.5-2.5,1.4-3.4c0.9-0.9,2.2-1.4,3.4-1.4s2.5,0.5,3.4,1.4
+	c0.9,0.9,1.4,2.2,1.4,3.4v1.1H45c0.6,0,1.1,0.5,1.1,1.1v21c0,0.6-0.5,1.1-1.1,1.1H24c-0.6,0-1.1-0.5-1.1-1.1v-6
+	c0-0.6,0.5-1.1,1.1-1.1h2.2c0.7,0,1.4-0.3,1.9-0.8c0.5-0.5,0.8-1.2,0.8-1.9s-0.3-1.4-0.8-1.9c-0.5-0.5-1.2-0.8-1.9-0.8H24
+	c-0.6,0-1.1-0.5-1.1-1.1V24z"/>
+<linearGradient id="SVGID_00000047061464868238174530000009440628732587799945_" gradientUnits="userSpaceOnUse" x1="13.5" y1="18.875" x2="13.5" y2="48.125" gradientTransform="matrix(1 0 0 -1 0 50)">
+	<stop  offset="0" style="stop-color:#EE7C48"/>
+	<stop  offset="1" style="stop-color:#EDAA52"/>
+</linearGradient>
+<path style="fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_00000047061464868238174530000009440628732587799945_);" d="
+	M25.1,24c0,0.6-0.5,1.1-1.1,1.1h-6.4v1.1c0,1.3-0.5,2.5-1.4,3.4c-0.9,0.9-2.2,1.4-3.4,1.4s-2.5-0.5-3.4-1.4
+	c-0.9-0.9-1.4-2.2-1.4-3.4v-1.1H3c-0.6,0-1.1-0.5-1.1-1.1V3c0-0.6,0.5-1.1,1.1-1.1h21c0.6,0,1.1,0.5,1.1,1.1v6
+	c0,0.6-0.5,1.1-1.1,1.1h-2.2c-0.7,0-1.4,0.3-1.9,0.8c-0.5,0.5-0.8,1.2-0.8,1.9s0.3,1.4,0.8,1.9c0.5,0.5,1.2,0.8,1.9,0.8H24
+	c0.6,0,1.1,0.5,1.1,1.1V24z"/>
+<path class="st2" d="M3,24h6v2.2c0,1,0.4,1.9,1.1,2.7c0.7,0.7,1.7,1.1,2.7,1.1s1.9-0.4,2.7-1.1c0.7-0.7,1.1-1.7,1.1-2.7V24h15v-2.2
+	c0-1,0.4-1.9,1.1-2.7c0.7-0.7,1.7-1.1,2.7-1.1l0,0c1,0,1.9,0.4,2.7,1.1c0.7,0.7,1.1,1.7,1.1,2.7V24h6"/>
+<path class="st2" d="M24,45v-6h2.2c1,0,1.9-0.4,2.7-1.1c0.7-0.7,1.1-1.7,1.1-2.7s-0.4-1.9-1.1-2.7c-0.7-0.7-1.7-1.1-2.7-1.1H24v-15
+	h-2.2c-1,0-1.9-0.4-2.7-1.1c-0.7-0.7-1.1-1.7-1.1-2.7s0.4-1.9,1.1-2.7C19.8,9.4,20.8,9,21.8,9H24V3"/>
+<path class="st2" d="M45,3H3v42h42V3z"/>
+</svg>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -288,7 +288,7 @@ class IndexPage extends React.Component {
             <hr/>
           </div>
           <section className="row section">
-            <div className="col-md-6 col-lg-4 mb-3 mb-md-4 pr-md-5">
+            <div className="col-sm-6 col-lg-3 mb-3 mb-md-4 pr-md-5">
               <LandingCard
                 title="Postman support"
                 description="Reach out to our support team."
@@ -297,7 +297,7 @@ class IndexPage extends React.Component {
                 link="https://support.postman.com/hc/en-us/requests/new/"
               />
             </div>
-            <div className="col-md-6 col-lg-4 mb-3 mb-md-4 pr-md-5">
+            <div className="col-sm-6 col-lg-3 mb-3 mb-md-4 pr-md-5">
               <LandingCard
                 title="Bugs and feature requests"
                 description="Check out the app support repo."
@@ -306,7 +306,7 @@ class IndexPage extends React.Component {
                 link="https://github.com/postmanlabs/postman-app-support/"
               />
             </div>
-            <div className="col-md-6 col-lg-4 mb-3 mb-md-4 pr-md-5">
+            <div className="col-sm-6 col-lg-3 mb-3 mb-md-4 pr-md-5">
               <LandingCard
                 title="Community"
                 description="Join the Postman community."
@@ -315,7 +315,7 @@ class IndexPage extends React.Component {
                 link="https://community.postman.com/"
               />
             </div>
-            <div className="col-md-6 col-lg-4 mb-3 mb-md-4 pr-md-5">
+            <div className="col-sm-6 col-lg-3 mb-3 mb-md-4 pr-md-5">
               <LandingCard
                 title="Postman Answers"
                 description="Code samples for most commonly asked questions."

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -288,7 +288,7 @@ class IndexPage extends React.Component {
             <hr/>
           </div>
           <section className="row section">
-            <div className="col-sm-6 col-lg-3 mb-3 mb-md-4 pr-md-5">
+            <div className="col-sm-6 col-lg-3 mb-sm-4 mb-md-0 pr-md-5">
               <LandingCard
                 title="Postman support"
                 description="Reach out to our support team."
@@ -297,7 +297,7 @@ class IndexPage extends React.Component {
                 link="https://support.postman.com/hc/en-us/requests/new/"
               />
             </div>
-            <div className="col-sm-6 col-lg-3 mb-3 mb-md-4 pr-md-5">
+            <div className="col-sm-6 col-lg-3 mb-sm-4 mb-md-0 pr-md-5">
               <LandingCard
                 title="Bugs and feature requests"
                 description="Check out the app support repo."
@@ -306,7 +306,7 @@ class IndexPage extends React.Component {
                 link="https://github.com/postmanlabs/postman-app-support/"
               />
             </div>
-            <div className="col-sm-6 col-lg-3 mb-3 mb-md-4 pr-md-5">
+            <div className="col-sm-6 col-lg-3 mb-sm-4 mb-md-0 pr-md-5">
               <LandingCard
                 title="Community"
                 description="Join the Postman community."
@@ -315,7 +315,7 @@ class IndexPage extends React.Component {
                 link="https://community.postman.com/"
               />
             </div>
-            <div className="col-sm-6 col-lg-3 mb-3 mb-md-4 pr-md-5">
+            <div className="col-sm-6 col-lg-3 mb-sm-4 mb-md-0">
               <LandingCard
                 title="Postman Answers"
                 description="Code samples for most commonly asked questions."

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -17,6 +17,7 @@ import VideoImage from '../assets/icons/movie.svg';
 import SupportImage from '../assets/icons/support.svg';
 import BugImage from '../assets/icons/bug.svg';
 import CommunityImage from '../assets/icons/community.svg';
+import SolutionImage from '../assets/icons/solution.svg';
 
 import { LandingCard } from '../components/MarketingPages/Cards';
 import '../../styles/config/normalize.css';
@@ -312,6 +313,15 @@ class IndexPage extends React.Component {
                 cta="Visit forum"
                 icon={CommunityImage}
                 link="https://community.postman.com/"
+              />
+            </div>
+            <div className="col-md-6 col-lg-4 mb-3 mb-md-4 pr-md-5">
+              <LandingCard
+                title="Postman Answers"
+                description="Code samples for most commonly asked questions."
+                cta="Visit Postman Answers"
+                icon={SolutionImage}
+                link="https://www.postman.com/postman/workspace/postman-answers/"
               />
             </div>
           </section>


### PR DESCRIPTION
Hey there! 👋 

The [Postman Answers public workspace](https://www.postman.com/postman/workspace/postman-answers) is pretty popular so we wanted to highlight it on the LC too, I've currently added it at the bottom of the homepage but if you can think of specific pages where it would make sense to highlight it, or to plug some specific collections I'm happy to add it there too. 

Also this creates a new line of icons at the bottom which I didn't feel was a problem, but happy to work on it and make them all fit on one line (if possible) when on full screen. 👍 