### PR TITLE
Refactored Left Nav to reduce flicker and maintain structure when navigating through pages

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -7,8 +7,8 @@ import './styles/config/print.css'
 import $ from 'jquery';
 import 'jquery.scrollto';
 
-/* eslint-disable import/prefer-default-export */
 export const onClientEntry = () => {
+  console.log(!window.location.hash)
   if (!window.location.hash) {
     window.scrollTo(0, 0);
   } else {

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -8,7 +8,6 @@ import $ from 'jquery';
 import 'jquery.scrollto';
 
 export const onClientEntry = () => {
-  console.log(!window.location.hash)
   if (!window.location.hash) {
     window.scrollTo(0, 0);
   } else {

--- a/src/components/LeftNav/LeftNav.jsx
+++ b/src/components/LeftNav/LeftNav.jsx
@@ -4,43 +4,39 @@ import './LeftNav.scss';
 
 const { v4: uuidv4 } = require('uuid');
 
-const LeftNav = (props) => {
-  const { LeftNavItems = [] } = props;
-  const isRuntime = typeof document === 'object';
-  const sectionHandler = (e) => {
-    document.location.href = e.target.getAttribute('data-section');
-  };
-  const renderTwoLevelList = (item) => {
-    const active = isRuntime ? document.location.pathname.match(item.parentSlug) : '';
-    const indicator = (<svg className={`caret${active ? ' active-caret' : ''}`} xmlns="http://www.w3.org/2000/svg" fill="none" height="24" viewBox="0 0 24 24" width="24"><path clipRule="evenodd" d="m16.5303 8.96967c.2929.29289.2929.76777 0 1.06063l-4 4c-.2929.2929-.7677.2929-1.0606 0l-4.00003-4c-.29289-.29286-.29289-.76774 0-1.06063s.76777-.29289 1.06066 0l3.46967 3.46963 3.4697-3.46963c.2929-.29289.7677-.29289 1.0606 0z" fill="#707070" fillRule="evenodd" /></svg>);
+const sectionHandler = (e) => {
+  document.location.href = e.target.getAttribute('data-section');
+};
 
-    return (
-      <ul key={uuidv4()}>
-        <li className="parent">
-          <div className="container">
-            <div className="row">
-              <div className="caret-wrapper">
-                {isRuntime && (indicator)}
-              </div>
-              <div className="col caret-sibling first-parent">
-                <button
-                  type="button"
-                  data-section={item.url}
-                  onClick={sectionHandler}
-                >
-                  {item.name}
-                </button>
-              </div>
+const renderTwoLevelList = (item, runtime, ) => {
+  const active = runtime ? document.location.pathname.match(item.parentSlug) : '';
+  return (
+    <ul key={uuidv4()}>
+      <li className="parent">
+        <div className="container">
+          <div className="row">
+            <div className="caret-wrapper">
+              {runtime && <svg className={`caret${active ? ' active-caret' : ''}`} xmlns="http://www.w3.org/2000/svg" fill="none" height="24" viewBox="0 0 24 24" width="24"><path clipRule="evenodd" d="m16.5303 8.96967c.2929.29289.2929.76777 0 1.06063l-4 4c-.2929.2929-.7677.2929-1.0606 0l-4.00003-4c-.29289-.29286-.29289-.76774 0-1.06063s.76777-.29289 1.06066 0l3.46967 3.46963 3.4697-3.46963c.2929-.29289.7677-.29289 1.0606 0z" fill="#707070" fillRule="evenodd" /></svg>}
+            </div>
+            <div className="col caret-sibling first-parent">
+              <button
+                type="button"
+                data-section={item.url}
+                onClick={sectionHandler}
+              >
+                {item.name}
+              </button>
             </div>
           </div>
-          {active && (
-            <ul>
-              {item.subMenuItems1.map(
-                (sItem) => (sItem.url && (
-                  <li key={uuidv4()} className={`child ${window.location.pathname === sItem.url ? 'currentUrl' : ''}`}>
-                    <Link to={sItem.url}>{sItem.name}</Link>
-                  </li>
-                )) || (
+        </div>
+        {active && (
+          <ul>
+            {item.subMenuItems1.map(
+              (sItem) => (sItem.url && (
+                <li key={uuidv4()} className={`child ${window.location.pathname === sItem.url ? 'currentUrl' : ''}`}>
+                  <Link to={sItem.url}>{sItem.name}</Link>
+                </li>
+              )) || (
                   <li
                     key={uuidv4()}
                     className="parent sub-parent"
@@ -64,27 +60,48 @@ const LeftNav = (props) => {
                     {document.location.pathname.match(
                       sItem.subParentSlug,
                     ) && (
-                      <ul>
-                        {sItem.subMenuItems2.map(
-                          (ssItem) => ssItem.url && (
-                            <li key={uuidv4()} className={`child ${document.location.pathname === ssItem.url ? 'currentUrl' : ''}`}>
-                              <Link to={ssItem.url} className="ssItem second-child">{ssItem.name}</Link>
-                            </li>
-                          ),
-                        )}
-                      </ul>
-                    )}
+                        <ul>
+                          {sItem.subMenuItems2.map(
+                            (ssItem) => ssItem.url && (
+                              <li key={uuidv4()} className={`child ${document.location.pathname === ssItem.url ? 'currentUrl' : ''}`}>
+                                <Link to={ssItem.url} className="ssItem second-child">{ssItem.name}</Link>
+                              </li>
+                            ),
+                          )}
+                        </ul>
+                      )}
                   </li>
                 ),
-              )}
-            </ul>
-          )}
-        </li>
-      </ul>
-    );
-  };
+            )}
+          </ul>
+        )}
+      </li>
+    </ul>
+  );
+}
 
-  return LeftNavItems.map((item) => renderTwoLevelList(item));
-};
+class LeftNav extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      links: props,
+      runtime: true
+    }
+  }
+  componentDidMount() {
+    const isRuntime = typeof document === 'object';
+    this.setState({
+      runtime: isRuntime,
+    })
+  }
+  render() {
+    const { links, runtime } = this.state
+    console.log(links)
+    const hello = links.LeftNavItems.map((item) => renderTwoLevelList(item, runtime))
+    return (
+      (hello)
+    )
+  }
+}
 
 export default LeftNav;

--- a/src/components/LeftNav/LeftNav.jsx
+++ b/src/components/LeftNav/LeftNav.jsx
@@ -8,7 +8,7 @@ const sectionHandler = (e) => {
   document.location.href = e.target.getAttribute('data-section');
 };
 
-const renderTwoLevelList = (item, runtime, ) => {
+const renderTwoLevelList = (item, runtime,) => {
   const active = runtime ? document.location.pathname.match(item.parentSlug) : '';
   return (
     <ul key={uuidv4()}>
@@ -97,9 +97,8 @@ class LeftNav extends React.Component {
   render() {
     const { links, runtime } = this.state
     console.log(links)
-    const hello = links.LeftNavItems.map((item) => renderTwoLevelList(item, runtime))
     return (
-      (hello)
+      links.LeftNavItems.map((item) => renderTwoLevelList(item, runtime))
     )
   }
 }

--- a/src/components/LeftNav/LeftNav.jsx
+++ b/src/components/LeftNav/LeftNav.jsx
@@ -84,7 +84,7 @@ class LeftNav extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      links: props,
+      props,
       runtime: true
     }
   }
@@ -95,9 +95,10 @@ class LeftNav extends React.Component {
     })
   }
   render() {
-    const { links, runtime } = this.state
+    const { props, runtime } = this.state;
+    const { leftNavItems = [] } = props;
     return (
-      links.LeftNavItems.map((item) => renderTwoLevelList(item, runtime))
+      leftNavItems.map((item) => renderTwoLevelList(item, runtime))
     )
   }
 }

--- a/src/components/LeftNav/LeftNav.jsx
+++ b/src/components/LeftNav/LeftNav.jsx
@@ -96,7 +96,6 @@ class LeftNav extends React.Component {
   }
   render() {
     const { links, runtime } = this.state
-    console.log(links)
     return (
       links.LeftNavItems.map((item) => renderTwoLevelList(item, runtime))
     )

--- a/src/components/LeftNav/LeftNav.jsx
+++ b/src/components/LeftNav/LeftNav.jsx
@@ -21,6 +21,7 @@ const renderTwoLevelList = (item, runtime,) => {
             <div className="col caret-sibling first-parent">
               <button
                 type="button"
+                data-click={item.name}
                 data-section={item.url}
                 onClick={sectionHandler}
               >
@@ -34,7 +35,7 @@ const renderTwoLevelList = (item, runtime,) => {
             {item.subMenuItems1.map(
               (sItem) => (sItem.url && (
                 <li key={uuidv4()} className={`child ${window.location.pathname === sItem.url ? 'currentUrl' : ''}`}>
-                  <Link to={sItem.url}>{sItem.name}</Link>
+                  <Link data-click={sItem.name} to={sItem.url}>{sItem.name}</Link>
                 </li>
               )) || (
                   <li
@@ -48,7 +49,8 @@ const renderTwoLevelList = (item, runtime,) => {
                         </div>
                         <div className="col caret-sibling second-parent">
                           <button
-                            type="button"
+                          type="button"
+                            data-click= {sItem.name}
                             data-section={sItem.slug}
                             onClick={sectionHandler}
                           >
@@ -64,7 +66,7 @@ const renderTwoLevelList = (item, runtime,) => {
                           {sItem.subMenuItems2.map(
                             (ssItem) => ssItem.url && (
                               <li key={uuidv4()} className={`child ${document.location.pathname === ssItem.url ? 'currentUrl' : ''}`}>
-                                <Link to={ssItem.url} className="ssItem second-child">{ssItem.name}</Link>
+                                <Link to={ssItem.url} data-click={sItem.name} className="ssItem second-child">{ssItem.name}</Link>
                               </li>
                             ),
                           )}

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -26,7 +26,7 @@ const DocPage = ({ data }) => {
       <div className="container-fluid">
         <div className="row row-eq-height">
           <nav className="col-sm-12 col-md-4 col-lg-3 left-nav-re">
-            <LeftNav LeftNavItems={leftNavItems} />
+            <LeftNav leftNavItems={leftNavItems} />
           </nav>
           <div className="col">
             <div className="row row-eq-height">


### PR DESCRIPTION
- Created Class component for LeftNav to use state
- Broke out the sectionHandler() and renderTwoLevelList() functions outside of class component
- Why? Calling the functions inside the render causes the component to completely re-render when a user clicks on a link
- Updated test due to capitalization on L and l for leftNavLinks

New behavior:
- No flickering up and down when user clicks link
- Side nav maintains active link
- Navigating between sub menus is much cleaner 

For visual, compare current side nav versus this branch locally. 