### PR TITLE
[MARKENG-1128] update with instructions for using `npm run nvmrc; nvm use`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ We would love for you to contribute to the Learning Center! To contribute to thi
 
    $ git clone https://github.com/postmanlabs/postman-docs.git
    $ cd postman-docs
+   $ npm run nvmrc
+   $ nvm use
    $ npm install
    $ npm install -g gatsby-cli
    $ npm run dev

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "bff": "NODE_ENV=development node bff.js",
     "build": "npm run bff && GATSBY_NEWRELIC_ENV=production GATSBY_ACTIVE_ENV=development gatsby build",
     "build:dev": "npm run build",
-    "build:nvmrc": "echo $(node -p -e 'require(\"./package\").engines.node.split(\">=\").join(\"\")') > .nvmrc",
+    "nvmrc": "echo $(node -p -e 'require(\"./package\").engines.node.split(\">=\").join(\"\")') > .nvmrc",
     "build:prod": "NODE_ENV=production node bff.js && GATSBY_NEWRELIC_ENV=production GATSBY_ACTIVE_ENV=production gatsby build",
     "clean": "gatsby clean",
     "dev": "npm run bff && gatsby develop",


### PR DESCRIPTION
**What are the changes?**
_Branched from `develop`_, this updates the README file to explain how to use `npm run nvmrc; nvm use` to ensure the correct version of node (& npm).

**Why make these changes?**
The web app has a convenience script, but the workflow is not documented anywhere. This update make the app more consistent with the other Postman web apps.

*no visuals; _regressive_