### PR TITLE
Removed @-moz-document url-prefix() causing lighter text issues on Doc pages

### DIFF
--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -16,12 +16,6 @@ body {
   text-rendering: geometricPrecision;
   letter-spacing: -0.16px;
 }
-/** * Firefox specific rule */
-@-moz-document url-prefix() {
-  body {
-    font-weight: lighter !important;
-  }
-}
 
 code {
   font-family: $ibm;
@@ -36,17 +30,6 @@ h3,
   font-family: $degular;
   font-weight: 600;
   font-feature-settings: 'kern' 1, 'ss01' 1, 'salt' 1;
-}
-/** * Firefox specific rule */
-@-moz-document url-prefix() {
-  h1,
-  .h1,
-  h2,
-  .h2,
-  h3,
-  .h3 {
-    font-weight: lighter !important;
-  }
 }
 
 h4,


### PR DESCRIPTION
Updated layout.scss and removed the @-moz-document rule causing the text to look very thin with high contrast.
<img width="1412" alt="Screen Shot 2021-12-22 at 11 27 10 AM" src="https://user-images.githubusercontent.com/42796716/147145406-ba1c55f9-0963-496e-8eb6-6e90b7cb5656.png">

