### PR TITLE
Switched 'string' to 'default'; updated screenshots

### DIFF
--- a/src/pages/docs/sending-requests/variables.md
+++ b/src/pages/docs/sending-requests/variables.md
@@ -139,7 +139,7 @@ Beyond scope, global and environment variables can be defined by type. The two v
 
 Users with [editor](/docs/collaborating-in-postman/roles-and-permissions/) access on a workspace (for global variables) or environment (for environment variables) can opt to change these variables from default to secret type.
 
-> Postman will store environment and global variables as strings regardless of type.
+> Postman will store environment and global variables as default regardless of type.
 
 To set the variable type, select the Environment quick look <img alt="Environment quick look icon" src="https://assets.postman.com/postman-docs/eye.jpg" width="24px" style="vertical-align:middle;margin-bottom:5px"> in the top right of Postman. Select **Edit** to the right of environment or global variables to open the editor.
 

--- a/src/pages/docs/sending-requests/variables.md
+++ b/src/pages/docs/sending-requests/variables.md
@@ -134,16 +134,16 @@ Variable scopes are suited to different tasks in Postman:
 
 Beyond scope, global and environment variables can be defined by type. The two variable types that you can configure for environment and global variables are:
 
-* **String type** is the default type that is automatically assigned to variables. This type is shown as plain text and has no additional properties.
+* **Default type** is the default type that is automatically assigned to variables. This type is shown as plain text and has no additional properties.
 * **Secret type** masks the [initial and current values](#specifying-variable-detail) for all workspace members and can be used to prevent unintentional disclosure of sensitive data, including API secrets, passwords, tokens, and keys.
 
-Users with [editor](/docs/collaborating-in-postman/roles-and-permissions/) access on a workspace (for global variables) or environment (for environment variables) can opt to change these variables from string to secret type.
+Users with [editor](/docs/collaborating-in-postman/roles-and-permissions/) access on a workspace (for global variables) or environment (for environment variables) can opt to change these variables from default to secret type.
 
 > Postman will store environment and global variables as strings regardless of type.
 
 To set the variable type, select the Environment quick look <img alt="Environment quick look icon" src="https://assets.postman.com/postman-docs/eye.jpg" width="24px" style="vertical-align:middle;margin-bottom:5px"> in the top right of Postman. Select **Edit** to the right of environment or global variables to open the editor.
 
-<img alt="Environment editor with string auth key" src="https://assets.postman.com/postman-docs/env-string-auth-key-9.5.jpg"/>
+<img alt="Environment editor with string auth key" src="https://assets.postman.com/postman-docs/env-default-auth-key-9.5.jpg"/>
 
 > You can also edit an environment by navigating to the workspace it resides in and selecting **Environments** from the left sidebar, then selecting your environment.
 
@@ -151,17 +151,17 @@ To set the variable type, select the Environment quick look <img alt="Environmen
 
 > You must have [editor](/docs/collaborating-in-postman/roles-and-permissions/) access on a workspace (for global variables) or environment (for environment variables) to control variable type.
 
-Select **string** next to the variable you'd like to change to open the dropdown menu, then select **secret** to update the variable type and save your changes to confirm.
+Select **default** next to the variable you'd like to change to open the dropdown menu, then select **secret** to update the variable type and save your changes to confirm.
 
-<img alt="Environment editor with secret auth key" src="https://assets.postman.com/postman-docs/env-secret-auth-key-9.5.jpg"/>
+<img alt="Environment editor with secret auth key" src="https://assets.postman.com/postman-docs/env-secret-auth-key-9.5-b.jpg"/>
 
 All workspace members can view a secret variable's initial and current values by selecting the <img alt="Eye crossed out icon" src="https://assets.postman.com/postman-docs/eye-crossed-out.jpg" width="24px" style="vertical-align:middle;margin-bottom:5px"> eye symbol to the right of the variable.
 
 Editors can change a variable's initial values, which are shared with collaborators, by selecting the <img alt="Eye crossed out icon" src="https://assets.postman.com/postman-docs/eye-crossed-out.jpg" width="24px" style="vertical-align:middle;margin-bottom:5px"> eye symbol to the right of the variable, then selecting the initial value. All collaborators can change a variable's current values by selecting the <img alt="Eye crossed out icon" src="https://assets.postman.com/postman-docs/eye-crossed-out.jpg" width="24px" style="vertical-align:middle;margin-bottom:5px"> eye symbol to the right of the variable, then selecting the current value.
 
-Editors can change the variable type from secret to string at any time, and vice versa. When you change a variable's type from secret back to string, you must confirm by selecting **Change type**.
+Editors can change the variable type from secret to default at any time, and vice versa. When you change a variable's type from secret back to default, you must confirm by selecting **Change type**.
 
-<img alt="Confirm unmark variable as secret" src="https://assets.postman.com/postman-docs/change-var-type-confirmation-9.5.jpg" width="400px"/>
+<img alt="Confirm unmark variable as secret" src="https://assets.postman.com/postman-docs/change-var-type-confirmation-9.5-b.jpg" width="400px"/>
 
 ## Defining variables
 


### PR DESCRIPTION
* switched mentions of 'string' to be 'default'
* uploaded new screenshots (as JPG and optimized.)

Screenshot of section with changes:
![localhost_8000_docs_sending-requests_variables_](https://user-images.githubusercontent.com/4358288/147696382-cfefb6f3-4672-4804-8f9d-03bb1138bbd1.png)

