### PR TITLE
TW-301 Convert absolute URLs to relative

### DIFF
--- a/DOCS_STYLE_GUIDE.md
+++ b/DOCS_STYLE_GUIDE.md
@@ -312,9 +312,9 @@ Use meaningful text for links, avoiding phrases such as "click here" when possib
 
 ---
 
-:thumbsdown::no_entry_sign: Click [here](https://learning.postman.com/docs/postman/scripts/intro_to_scripts/) for more details on scripts.
+:thumbsdown::no_entry_sign: Click [here](/docs/postman/scripts/intro_to_scripts/) for more details on scripts.
 
-:thumbsup::white_check_mark: For more on scripting in Postman, see [Intro to Scripts](https://learning.postman.com/docs/postman/scripts/intro_to_scripts/).
+:thumbsup::white_check_mark: For more on scripting in Postman, see [Intro to Scripts](/docs/postman/scripts/intro_to_scripts/).
 
 ---
 
@@ -322,7 +322,15 @@ An exception to this is the __Run in Postman__ button, which you can refer to di
 
 Include links to relevant supporting docs inline throughout your pages, but in general only link to the same location once per page—usually the first time you mention the term.
 
-Use relative links between docs.
+Use relative links between docs:
+
+---
+
+:thumbsdown::no_entry_sign: `For more on scripting in Postman, see [Intro to Scripts](https://learning.postman.com/docs/postman/scripts/intro_to_scripts/).`
+
+:thumbsup::white_check_mark: `For more on scripting in Postman, see [Intro to Scripts](/docs/postman/scripts/intro_to_scripts/).`
+
+---
 
 Don't display a raw URL in text, unless seeing the URL is essential to the learning objective:
 

--- a/src/pages/docs/administration/managing-your-team/configuring-scim.md
+++ b/src/pages/docs/administration/managing-your-team/configuring-scim.md
@@ -44,7 +44,7 @@ You can enable SCIM with the [SCIM API](#enabling-scim-with-the-scim-api) or uti
 
 Postman supports the following provisioning features:
 
-* Create user: Creates a new user account in Postman, adds the account to your organization's Postman team, and activates authentication for the user. If an account with the same email ID exists, an [email invite](https://learning.postman.com/docs/administration/managing-your-team/managing-your-team/#invites) to join your Postman team is sent to the user. Once the user accepts the invite, they will be added to your team.
+* Create user: Creates a new user account in Postman, adds the account to your organization's Postman team, and activates authentication for the user. If an account with the same email ID exists, an [email invite](/docs/administration/managing-your-team/managing-your-team/#invites) to join your Postman team is sent to the user. Once the user accepts the invite, they will be added to your team.
 
 > The newly added user will have the developer role in Postman by default. You can later [update account roles in Postman](/docs/administration/managing-your-team/managing-your-team/#managing-roles).
 
@@ -105,7 +105,7 @@ Name your key and click **Generate**. Copy your new API key for later use and cl
 
 Postman is available as an app in the Okta Integration Network, allowing you to enable user provisioning directly through Okta.
 
-Prior to enabling SCIM in Okta, you must [add the Postman app in Okta](https://www.okta.com/integrations/postman/) and [configure Okta's SSO for your Postman team](https://learning.postman.com/docs/administration/sso/saml-okta/).
+Prior to enabling SCIM in Okta, you must [add the Postman app in Okta](https://www.okta.com/integrations/postman/) and [configure Okta's SSO for your Postman team](/docs/administration/sso/saml-okta/).
 
 To set up provisioning with the Postman Okta app, take the following steps:
 

--- a/src/pages/docs/administration/team-merge.md
+++ b/src/pages/docs/administration/team-merge.md
@@ -77,9 +77,9 @@ See [performing centralized migration](#performing-centralized-migration) to cho
 
 You can carry out distributed migration with any type of Postman account.
 
-You can export your personal workspace and shared workspaces for any team you have joined and can choose to only export collections from a specific workspace. See [exporting data](https://learning.postman.com/docs/getting-started/importing-and-exporting-data/#exporting-postman-data) for detail.
+You can export your personal workspace and shared workspaces for any team you have joined and can choose to only export collections from a specific workspace. See [exporting data](/docs/getting-started/importing-and-exporting-data/#exporting-postman-data) for detail.
 
-If you have an individual account and are not part of a team, but want to maintain your current account while migrating company data to an authorized team, you can [export specific data](https://learning.postman.com/docs/getting-started/importing-and-exporting-data/#exporting-postman-data) or [export a dump of all data](https://learning.postman.com/docs/getting-started/importing-and-exporting-data/#exporting-data-dumps).
+If you have an individual account and are not part of a team, but want to maintain your current account while migrating company data to an authorized team, you can [export specific data](/docs/getting-started/importing-and-exporting-data/#exporting-postman-data) or [export a dump of all data](/docs/getting-started/importing-and-exporting-data/#exporting-data-dumps).
 
 If you have a personal account and want to disable it and join an authorized team, you can accept the team invite and all personal Postman data will be transferred to to your new team automatically.
 

--- a/src/pages/docs/designing-and-developing-your-api/view-and-analyze-api-reports.md
+++ b/src/pages/docs/designing-and-developing-your-api/view-and-analyze-api-reports.md
@@ -122,7 +122,7 @@ The **Team details** report provides an overview of your team and members, inclu
 * **Total team members** - The current number of user accounts in the team.
 * **Team members over time** - The size of the team over time.
 * **Team roles** - The number of team members with Admin, Billing, Community Manager, or Developer roles.
-* **SSO identity provider** - Any [single sign-on provider](https://learning.postman.com/docs/administration/sso/intro-sso/) you have configured for team members to access their Postman accounts.
+* **SSO identity provider** - Any [single sign-on provider](/docs/administration/sso/intro-sso/) you have configured for team members to access their Postman accounts.
 * **Billing Cycle** - Your account's billing cycle (annual or monthly).
 * **Renewal Date** - The date your current Postman plan will renew.
 

--- a/src/pages/docs/getting-started/exploring-public-api-network.md
+++ b/src/pages/docs/getting-started/exploring-public-api-network.md
@@ -40,7 +40,7 @@ There are a variety of ways to find APIs, workspaces, teams, and collections:
 * Under **Browse**, you can select to view **Teams**, **Workspaces**, **APIs**, and **Collections**. You can sort results using the **Featured**, **Most Viewed**, and **Latest** tabs just below the header.
     * You can also sort Collections and Workspaces by category using the filters below the header.
 
-To import a collection from a public workspace to your workspace, create a fork of it. See [forking a collection](https://learning.postman.com/docs/collaborating-in-postman/version-control-for-collections/#forking-a-collection).
+To import a collection from a public workspace to your workspace, create a fork of it. See [forking a collection](/docs/collaborating-in-postman/version-control-for-collections/#forking-a-collection).
 
 Check out some useful collections for getting started learning about APIs, requests, and Postman:
 

--- a/src/pages/docs/getting-started/postman-account.md
+++ b/src/pages/docs/getting-started/postman-account.md
@@ -151,7 +151,7 @@ You can manage your [active Postman sessions](https://go.postman.co/settings/me/
 
 If you have a free account, you can upgrade it by navigating to [Postman](https://go.postman.co/) and selecting **Upgrade** in the top-right corner.
 
-If you have a paid account, you can upgrade your Postman plan by navigating to your [billing dashboard](https://go.postman.co/billing/overview/) and selecting **Edit Plan** on the right. To learn more about upgrading and managing your Postman plan, see our [Billing](https://learning.postman.com/docs/administration/billing/#changing-your-plan) guide.
+If you have a paid account, you can upgrade your Postman plan by navigating to your [billing dashboard](https://go.postman.co/billing/overview/) and selecting **Edit Plan** on the right. To learn more about upgrading and managing your Postman plan, see our [Billing](/docs/administration/billing/#changing-your-plan) guide.
 
 > The cost of your upgraded plan or additional seats will be prorated based on the time left in your team's current billing cycle. For more information, [contact Postman's sales team](mailto:sales@postman.com).
 

--- a/src/pages/docs/integrations/intro-integrations.md
+++ b/src/pages/docs/integrations/intro-integrations.md
@@ -56,9 +56,9 @@ Once you whitelist this IP address, calls for the integrations and webhooks will
 
 Postman supports implementing static IP addresses for the following integrations and webhooks:
 
-* [Custom Webhooks](https://learning.postman.com/docs/integrations/webhooks/)
-* [GitHub Custom Domain Backup](https://learning.postman.com/docs/integrations/available-integrations/github/#backup-collections-to-github-on-custom-domain)
-* [GitLab Custom Domain Backup](https://learning.postman.com/docs/integrations/available-integrations/gitlab/#backup-your-postman-collections-to-gitlab-on-a-custom-domain)
+* [Custom Webhooks](/docs/integrations/webhooks/)
+* [GitHub Custom Domain Backup](/docs/integrations/available-integrations/github/#backup-collections-to-github-on-custom-domain)
+* [GitLab Custom Domain Backup](/docs/integrations/available-integrations/gitlab/#backup-your-postman-collections-to-gitlab-on-a-custom-domain)
 
 ## CI integrations
 

--- a/src/pages/docs/monitoring-your-api/intro-monitors.md
+++ b/src/pages/docs/monitoring-your-api/intro-monitors.md
@@ -55,7 +55,7 @@ Once the monitor is running you’ll get alerted to any failures, so you can qui
 
 ## Collection-based monitors
 
-A collection-based monitor runs a series of requests from the Postman cloud on a schedule you set. When creating a monitor, you choose a [collection](/docs/sending-requests/intro-to-collections/) with the requests you want to run. These can be basic requests that simply indicate an endpoint is up and reachable. More complex collections can make use of [chained requests](https://www.youtube.com/watch?v=shYn3Ys3ygE), [test scripts](https://learning.postman.com/docs/writing-scripts/test-scripts/), and [environment variables](/docs/sending-requests/managing-environments/) to validate API responses and functionality.
+A collection-based monitor runs a series of requests from the Postman cloud on a schedule you set. When creating a monitor, you choose a [collection](/docs/sending-requests/intro-to-collections/) with the requests you want to run. These can be basic requests that simply indicate an endpoint is up and reachable. More complex collections can make use of [chained requests](https://www.youtube.com/watch?v=shYn3Ys3ygE), [test scripts](/docs/writing-scripts/test-scripts/), and [environment variables](/docs/sending-requests/managing-environments/) to validate API responses and functionality.
 
 You can configure your monitors to run as frequently as you would like, depending on your [Postman plan](https://www.postman.com/pricing/). For paid plans, monitors can be scheduled to run as often as every five minutes. For free plans, monitors can be scheduled to run as often as every hour. You can even specify which region of the world you’d like to run the collection from (paid plans only).
 

--- a/src/pages/docs/monitoring-your-api/setting-up-monitor.md
+++ b/src/pages/docs/monitoring-your-api/setting-up-monitor.md
@@ -151,7 +151,7 @@ When creating or editing a monitor, you can choose to receive email notification
 
 You can find detailed information on your monitor results by navigating to your workspace, selecting **Monitors** in the left sidebar, then selecting your monitor.
 
-> You can also utilize [Postman integrations](https://learning.postman.com/docs/integrations/intro-integrations/) to send monitor data and configure notifications using your desired platform, such as [Slack](/docs/integrations/available-integrations/slack/) or [Datadog](/docs/integrations/available-integrations/datadog/).
+> You can also utilize [Postman integrations](/docs/integrations/intro-integrations/) to send monitor data and configure notifications using your desired platform, such as [Slack](/docs/integrations/available-integrations/slack/) or [Datadog](/docs/integrations/available-integrations/datadog/).
 
 ### Using retry on failure
 

--- a/src/pages/docs/running-collections/collection-webhooks.md
+++ b/src/pages/docs/running-collections/collection-webhooks.md
@@ -19,7 +19,7 @@ A webhook provides a way to automatically send data from one application to anot
 
 With a collection webhook, data is sent to the webhook URL using a POST request when certain events are triggered. (It's up to you to configure the application that sends the data and what the trigger events are.) The data sent to the webhook is accessible inside the collection in the [globals object](/docs/sending-requests/variables/). Using [scripts](/docs/writing-scripts/intro-to-scripts/), you can parse that data and use it during the collection run in any way possible.
 
-Webhooks for a collection can only be created using the [Postman API](https://learning.postman.com/docs/developer/intro-api/). To create a webhook, refer to the [documentation for **api.getpostman.com/webhooks**](https://documenter.getpostman.com/view/12959542/UV5XjJV8#8bec7537-cc5d-4ed7-a995-c7753e55ed28).
+Webhooks for a collection can only be created using the [Postman API](/docs/developer/intro-api/). To create a webhook, refer to the [documentation for **api.getpostman.com/webhooks**](https://documenter.getpostman.com/view/12959542/UV5XjJV8#8bec7537-cc5d-4ed7-a995-c7753e55ed28).
 
 ### Accessing the request body in scripts
 

--- a/src/pages/docs/writing-scripts/script-references/postman-sandbox-api-reference.md
+++ b/src/pages/docs/writing-scripts/script-references/postman-sandbox-api-reference.md
@@ -508,7 +508,7 @@ pm.cookies.toObject():Function → Object
 
 You can also use `pm.cookies.jar` to specify a domain for access to request cookies.
 
-To enable programmatic access via the `pm.cookies.jar` methods, first [whitelist](https://learning.postman.com/docs/sending-requests/cookies/) the cookie URL.
+To enable programmatic access via the `pm.cookies.jar` methods, first [whitelist](/docs/sending-requests/cookies/) the cookie URL.
 
 * Access the cookie jar object:
 


### PR DESCRIPTION
* Converts absolute LC URLs to relative URLs: `https://learning.postman.com/docs/<rest of the URL>` becomes `/docs/<rest of the URL>`

