### PR TITLE
TW-203 add that GitHub Enterprise requires a Postman Enterprise account

### DIFF
--- a/src/pages/docs/designing-and-developing-your-api/versioning-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/versioning-an-api.md
@@ -39,7 +39,7 @@ contextual_links:
     url: "/docs/designing-and-developing-your-api/validating-elements-against-schema/"
 ---
 
-> __[ GitHub Enterprise Server and GitLab Self-Managed integrations are only available on Postman Enterprise plans.](https://www.postman.com/pricing)__
+> __[GitHub Enterprise Server and GitLab Self-Managed integrations are only available on Postman Enterprise plans.](https://www.postman.com/pricing)__
 
 You can manage multiple versions of any APIs you create in Postman. You can then associate mocks, monitors, and documentation to specific versions of APIs.
 

--- a/src/pages/docs/designing-and-developing-your-api/versioning-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/versioning-an-api.md
@@ -39,6 +39,8 @@ contextual_links:
     url: "/docs/designing-and-developing-your-api/validating-elements-against-schema/"
 ---
 
+> __[ GitHub Enterprise Server and GitLab Self-Managed integrations are only available on Postman Enterprise plans.](https://www.postman.com/pricing)__
+
 You can manage multiple versions of any APIs you create in Postman. You can then associate mocks, monitors, and documentation to specific versions of APIs.
 
 > API versioning is different than using version control for collections. For information on how to use version control for collections, see [Using version control](/docs/collaborating-in-postman/version-control-for-collections/).

--- a/src/pages/docs/integrations/available-integrations/github.md
+++ b/src/pages/docs/integrations/available-integrations/github.md
@@ -21,7 +21,7 @@ contextual_links:
     url:  "https://blog.postman.com/how-to-auto-sync-postman-collections-with-aws-codecommit-repositories/"
 ---
 
-> __[ GitHub Enterprise Server integrations are only available on Postman Enterprise plans.](https://www.postman.com/pricing)__
+> __[GitHub Enterprise Server integrations are only available on Postman Enterprise plans.](https://www.postman.com/pricing)__
 
 Postman enables you to back up your collections or synchronize your API schemas on GitHub. For each of these integrations, you'll need to [generate a GitHub personal access token](#generating-a-github-personal-access-token).
 

--- a/src/pages/docs/integrations/available-integrations/github.md
+++ b/src/pages/docs/integrations/available-integrations/github.md
@@ -21,7 +21,9 @@ contextual_links:
     url:  "https://blog.postman.com/how-to-auto-sync-postman-collections-with-aws-codecommit-repositories/"
 ---
 
-Postman enables you to back up your collections (for paid plans only) or synchronize your API schemas on GitHub. For each of these integrations, you'll need to [generate a GitHub personal access token](#generating-a-github-personal-access-token).
+> __[ GitHub Enterprise Server integrations are only available on Postman Enterprise plans.](https://www.postman.com/pricing)__
+
+Postman enables you to back up your collections or synchronize your API schemas on GitHub. For each of these integrations, you'll need to [generate a GitHub personal access token](#generating-a-github-personal-access-token).
 
 > If you are looking to import data into Postman from a GitHub repository, see [Importing via GitHub repositories](/docs/getting-started/importing-and-exporting-data/#importing-via-github-repositories).
 

--- a/src/pages/docs/integrations/available-integrations/gitlab.md
+++ b/src/pages/docs/integrations/available-integrations/gitlab.md
@@ -12,6 +12,8 @@ contextual_links:
     url: "/docs/sending-requests/intro-to-collections/"
 ---
 
+> __[GitLab Self-Managed integrations are only available on Postman Enterprise plans.](https://www.postman.com/pricing)__
+>
 Back up your Postman Collections to GitLab, an open-source Git repository manager, with the Postman to GitLab integration.
 
 Setting up a GitLab integration requires you to get a GitLab Personal Access Token and configure how you would like to back up your collections.


### PR DESCRIPTION
This also covers GitLab self-managed.