### PR TITLE
TW 206 Refresh collaboration intro

### DIFF
--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -64,9 +64,9 @@ All admins will be notified when someone makes a request to join your team, incl
 
 ## Collaborating in team workspaces
 
-Team workspaces allow you to collaboratively work on collections with your team.
+Team workspaces allow you to collaborate on APIs, collections, environments, integrations, mocks, and monitors with your team.
 
-> Postman creates a default team workspace for every team. You can rename this workspace, but it cannot be deleted.
+> Postman creates a default "Team Workspace" for every team. You can rename this workspace, but it cannot be deleted.
 
 ### Inviting a team member to a workspace
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -29,10 +29,10 @@ contextual_links:
 
 > Postman Free allows teams of up to three to collaborate at no cost. To collaborate with additional team members, features, and increased usage limits, see [Plans and Pricing](https://www.postman.com/pricing/).
 
-Postman allows you to collaborate and share your collections, environments, integrations, history, mocks, monitors, and more with your team.
+Postman provides you with many tools to help you work with your team, allowing you to collaborate and share your work.
 
 <!-- Can be brief and link elsewhere:
-Collections
+
 workspaces
 Roles and permissions
 Version control
@@ -41,9 +41,14 @@ Team profiles -->
 ## Contents
 
 * [Collaborating in team workspaces](#collaborating-in-team-workspaces)
+
+    * [Inviting a team member to a workspace](#inviting-a-team-member-to-a-workspace)
+
+    * [Finding teams within your organization](#finding-teams-within-your-organization)
+
+    * [Leaving a team](#leaving-a-team)
+
 * [Enabling team discovery](#enabling-team-discovery)
-* [Finding teams within your organization](#finding-teams-within-your-organization)
-* [Leaving a team](#leaving-a-team)
 * [Team usage limits](#team-usage-limits)
 
     * [Recovering archived collections](#recovering-your-archived-collections)
@@ -52,13 +57,43 @@ Team profiles -->
 
 ## Collaborating in team workspaces
 
-Postman allows you to collaborate with your team through team workspaces.
+Team workspaces allow you to collaboratively work on collections with your team.
 
-Postman creates a default team workspace for every team. You can rename this workspace, but it cannot be deleted.
+> Postman creates a default team workspace for every team. You can rename this workspace, but it cannot be deleted.
+
+### Inviting a team member to a workspace
 
 You can invite team members to join a [new](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/) or existing workspace. For more details about how to invite a team member to a workspace, see [Sharing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#sharing-workspaces).
 
 > Postman will alert you with notifications when activities occur within your team and workspace. You can view and opt in or out notifications by selecting your avatar in the upper right and selecting **Notification Preferences**.
+
+### Finding teams within your organization
+
+When you log in to the Postman web dashboard using a verified email address for your company or organization, you can see available teams to join by selecting your avatar > **Your Team**. You will also be prompted with available teams when you first sign into your Postman account with a verified address.
+
+[![Choose Team](https://assets.postman.com/postman-docs/join-team-from-list.jpg)](https://assets.postman.com/postman-docs/join-team-from-list.jpg)
+
+You will see a list of the available teams within your organization. Select a team. Answer the question set by the team admin, if there is one. You can also add an optional note. Select **Request to join**. <!-- TODO: should these be groups -->
+
+<img alt="Team Join Question" src="https://assets.postman.com/postman-docs/team-join-question-entry.jpg" width="400px"/>
+
+The team admin will receive a notification that you asked to join the team. Once they approve your request, you will be able to access the team and collaborate on API projects within it.
+
+### Leaving a team
+
+You can leave a Postman team by navigating to your [Postman Dashboard](https://go.postman.co/home), selecting your avatar in the top-right corner, then **Account Settings**. Select **Team** on the left. You can then opt to **Leave Team**.
+
+<img src="https://assets.postman.com/postman-docs/leave-team-v9.1.jpg" alt="Leave team"/>
+
+> If your team has [SCIM configured](/docs/administration/managing-your-team/configuring-scim/), you must contact your Postman team admins to leave the team.
+
+When you leave a team, you no longer have access to the team's workspaces or any of the elements in them. You will still have access to your personal workspaces.
+
+If you are the last member to leave your team, you will have the option to transfer collections to a personal workspace.
+
+<img src="https://assets.postman.com/postman-docs/leave-and-delete-team.jpg" alt="Leave and delete team" width="400px"/>
+
+> If you are invited to a new team and you are the last member in your current team, all team data will be transferred to your personal default workspace.
 
 ## Enabling team discovery
 
@@ -77,34 +112,6 @@ You can optionally add a question for pending team members to answer when they r
 You will receive a notification when anyone makes a request to join your team, including their answer to any question you set, or an optional note.
 
 [![Team Request Approval](https://assets.postman.com/postman-docs/admin-team-join-requests.jpg)](https://assets.postman.com/postman-docs/admin-team-join-requests.jpg)
-
-## Finding teams within your organization
-
-When you log in to the Postman web dashboard using a verified email address for your company or organization, you can see available teams to join by selecting your avatar > **Your Team**. You will also be prompted with available teams when you first sign into your Postman account with a verified address.
-
-[![Choose Team](https://assets.postman.com/postman-docs/join-team-from-list.jpg)](https://assets.postman.com/postman-docs/join-team-from-list.jpg)
-
-You will see a list of the available teams within your organization. Select a team. Answer the question set by the team admin, if there is one. You can also add an optional note. Select **Request to join**. <!-- TODO: should these be groups -->
-
-<img alt="Team Join Question" src="https://assets.postman.com/postman-docs/team-join-question-entry.jpg" width="400px"/>
-
-The team admin will receive a notification that you asked to join the team. Once they approve your request, you will be able to access the team and collaborate on API projects within it.
-
-## Leaving a team
-
-You can leave a Postman team by navigating to your [Postman Dashboard](https://go.postman.co/home), selecting your avatar in the top-right corner, then **Account Settings**. Select **Team** on the left. You can then opt to **Leave Team**.
-
-<img src="https://assets.postman.com/postman-docs/leave-team-v9.1.jpg" alt="Leave team"/>
-
-> If your team has [SCIM configured](/docs/administration/managing-your-team/configuring-scim/), you must contact your Postman team admins to leave the team.
-
-When you leave a team, you no longer have access to the team's workspaces or any of the elements in them. You will still have access to your personal workspaces.
-
-If you are the last member to leave your team, you will have the option to transfer collections to a personal workspace.
-
-<img src="https://assets.postman.com/postman-docs/leave-and-delete-team.jpg" alt="Leave and delete team" width="400px"/>
-
-> If you are invited to a new team and you are the last member in your current team, all team data will be transferred to your personal default workspace.
 
 ## Team usage limits
 
@@ -139,6 +146,8 @@ Alternatively, you can download your archived data directly within Postman. To l
 
 ## Next steps
 
-For a more in-depth introduction to workspaces and how they can help organize your API development, check out [Creating Workspaces](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/).
+Postman has many features that help you collaborate with your team:
 
-To see how you can share the APIs that your teams use internally, check out [Your private API Network](/docs/collaborating-in-postman/adding-private-network/).
+* You can you can assign _roles and permissions_ to define Postman access at the team level. Learn more in the [Defining roles](/docs/collaborating-in-postman/roles-and-permissions/) guide.
+* _Version control_ allows you to collaborate with teammates by working on different forks of the same Postman collection. Learn more in the [Using version control](/docs/collaborating-in-postman/version-control-for-collections/) guide.
+* A _Private API Network_ allows you to easily and securely share the APIs that your team uses internally. Learn more in the [Your Private API Network](/docs/collaborating-in-postman/adding-private-network/) guide.

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -36,14 +36,9 @@ Postman will alert you with notifications when activities occur within your team
 ## Contents
 
 * [Working with team workspaces](#working-with-team-workspaces)
-* [Team discovery](#team-discovery)
-
-    * [Making your team discoverable](#making-your-team-discoverable)
-
-    * [Finding teams within your organization](#finding-teams-within-your-organization)
-
+* [Enabling team discovery](#enabling-team-discovery)
+* [Finding teams within your organization](#finding-teams-within-your-organization)
 * [Leaving a team](#leaving-a-team)
-
 * [Usage limit](#usage-limit)
 
     * [How archiving works](#how-archiving-works)
@@ -54,19 +49,13 @@ Postman will alert you with notifications when activities occur within your team
 
 ## Working with team workspaces
 
-A team workspace allows you to ... <!-- TODO: fill this in -->
+Postman creates a default team workspace for every team. You can rename this workspace, but it cannot be deleted.
 
-Postman creates a default Team Workspace. You cannot delete this workspace but you can rename it.
+You can invite team members to join a [new](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/) or existing workspace. For more details about how to invite a team member to a workspace, see [Sharing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#sharing-workspaces).
 
-You can invite team members to join a [new](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/ ) or existing workspace. For more details about how to invite a team member to a workspace, see [Sharing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#sharing-workspaces).
-
-You can create a new team workspace and invite members.
-
-## Team discovery
+## Enabling team discovery
 
 Enabling team discovery encourages collaboration and eases the onboarding process by allowing users accessing Postman with their company email address to request to join pre-existing teams within their organization.
-
-### Making your team discoverable
 
 You can enable team discovery in the dashboard by selecting **Team** > **Team Settings** > [**Team Discovery**](https://go.postman.co/settings/team/discovery).
 
@@ -82,7 +71,7 @@ You will receive a notification when anyone makes a request to join your team, i
 
 [![Team Request Approval](https://assets.postman.com/postman-docs/admin-team-join-requests.jpg)](https://assets.postman.com/postman-docs/admin-team-join-requests.jpg)
 
-### Finding teams within your organization
+## Finding teams within your organization
 
 When you log in to the Postman web dashboard using a verified email address for your company or organization, you can see available teams to join by selecting your avatar > **Your Team**. You will also be prompted with available teams when you first sign into your Postman account with a verified address.
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -29,35 +29,42 @@ contextual_links:
 
 > Postman Free allows teams of up to three to collaborate at no cost. To collaborate with additional team members, features, and increased usage limits, see [Plans and Pricing](https://www.postman.com/pricing/).
 
-Postman allows all users to collaborate with their teams through Team Workspaces. Using this feature, you can easily collaborate and share your collections, environments, integrations, history, mocks, monitors, and more.
+Postman allows you to collaborate and share your collections, environments, integrations, history, mocks, monitors, and more with your team.
 
-Postman will alert you with notifications when activities occur within your team and workspace. You can view and opt in or out notifications by selecting your avatar in the upper right and selecting **Notification Preferences**.
+<!-- Can be brief and link elsewhere:
+Collections
+workspaces
+Roles and permissions
+Version control
+Team profiles -->
 
 ## Contents
 
-* [Working with team workspaces](#working-with-team-workspaces)
+* [Collaborating in team workspaces](#collaborating-in-team-workspaces)
 * [Enabling team discovery](#enabling-team-discovery)
 * [Finding teams within your organization](#finding-teams-within-your-organization)
 * [Leaving a team](#leaving-a-team)
-* [Usage limit](#usage-limit)
-
-    * [How archiving works](#how-archiving-works)
+* [Team usage limits](#team-usage-limits)
 
     * [Recovering archived collections](#recovering-your-archived-collections)
 
 * [Next steps](#next-steps)
 
-## Working with team workspaces
+## Collaborating in team workspaces
+
+Postman allows you to collaborate with your team through team workspaces.
 
 Postman creates a default team workspace for every team. You can rename this workspace, but it cannot be deleted.
 
 You can invite team members to join a [new](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/) or existing workspace. For more details about how to invite a team member to a workspace, see [Sharing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#sharing-workspaces).
 
+> Postman will alert you with notifications when activities occur within your team and workspace. You can view and opt in or out notifications by selecting your avatar in the upper right and selecting **Notification Preferences**.
+
 ## Enabling team discovery
 
 Enabling team discovery encourages collaboration and eases the onboarding process by allowing users accessing Postman with their company email address to request to join pre-existing teams within their organization.
 
-You can enable team discovery in the dashboard by selecting **Team** > **Team Settings** > [**Team Discovery**](https://go.postman.co/settings/team/discovery).
+You can enable team discovery for your team in the dashboard by selecting **Team** > **Team Settings** > [**Team Discovery**](https://go.postman.co/settings/team/discovery).
 
 [![Enable team discovery](https://assets.postman.com/postman-docs/team-discovery-enable-v9.1.0.jpg)](https://assets.postman.com/postman-docs/team-discovery-enable-v9.1.0.jpg)
 
@@ -77,7 +84,7 @@ When you log in to the Postman web dashboard using a verified email address for 
 
 [![Choose Team](https://assets.postman.com/postman-docs/join-team-from-list.jpg)](https://assets.postman.com/postman-docs/join-team-from-list.jpg)
 
-You will see a list of the available teams within your organization. Select a team. Answer the question set by the team admin, if there is one. You can also add an optional note. Select **Request to join**.
+You will see a list of the available teams within your organization. Select a team. Answer the question set by the team admin, if there is one. You can also add an optional note. Select **Request to join**. <!-- TODO: should these be groups -->
 
 <img alt="Team Join Question" src="https://assets.postman.com/postman-docs/team-join-question-entry.jpg" width="400px"/>
 
@@ -99,38 +106,34 @@ If you are the last member to leave your team, you will have the option to trans
 
 > If you are invited to a new team and you are the last member in your current team, all team data will be transferred to your personal default workspace.
 
-## Usage limit
+## Team usage limits
 
-You can check your usage limits within Postman. Free users can select the drop-down menu to the right of **Upgrade** in the app. Paid users can access the menu by selecting a team name.
+The Postman usage menu allows you to review your team's limits for APIs, shared requests and history, mocks, monitors, and public documentation.
 
-The usage menu allows you to review limits for APIs, shared requests and history, mocks, monitors, and public documentation. Select **Resource Usage** to view your usage period.
+* Free users: Next to your avatar, select the menu to the right of **Upgrade**.
+* Paid users: Next to your avatar, select **Team**.
+
+For more details and to view your usage period, select **Resource Usage**.
 
 [![usage info](https://assets.postman.com/postman-docs/Screen%20Shot%202019-11-11%20at%205.38.16%20PM.png)](https://assets.postman.com/postman-docs/Screen%20Shot%202019-11-11%20at%205.38.16%20PM.png)
 
-If your free team's collaboration exceeds usage limits, Postman will archive collections to bring your team within usage limits. Collections that have gone the longest without being revised will be archived first, based on the last edit date.
+### Recovering your archived collections
 
-### How archiving works
-
-Postman archives collections when a free team's collaboration exceeds usage limits. Archived collections cannot be collaborated on, however they are still accessible to users. You will receive an in-app notification when a collection is archived.
-
-Postman chooses which collection(s) to archive based on last edit date. The collections that have gone the longest without a revision will be archived in order to bring your team within usage limits.
-
-Postman indicates the number of archived collections at the bottom of the left sidebar.
+If your free team's collaboration exceeds usage limits, Postman will archive collections to bring your team within usage limits. Collections that have gone the longest without being revised will be archived first, based on the last edit date. Postman indicates the number of archived collections at the bottom of the left sidebar.
 
 [![archived message](https://assets.postman.com/postman-docs/ArchiveMsg2.png)](https://assets.postman.com/postman-docs/ArchiveMsg2.png)
-
-### Recovering your archived collections
 
 To recover archived collections, select **Archived Collections**.
 
 You will then be directed to your dashboard. Select **Download your data** > **Request data export** > **Request an archive**.
+
 [![export data1](https://assets.postman.com/postman-docs/Recovering_ArchivedCol1.png)](https://assets.postman.com/postman-docs/Recovering_ArchivedCol1.png)
 
-You will then be able to select **Download** to retrieve your archived data.
+Select **Download** to retrieve your archived data.
 
 [![Download Data](https://assets.postman.com/postman-docs/Download_Data1.png)](https://assets.postman.com/postman-docs/Download_Data1.png)
 
-> The `archive.json` inside the downloaded ZIP archive is not a Postman collection that can be imported; it is simply an index of files present in the archive. A collections folder contains all the files that can be imported.
+> The `archive.json` inside the downloaded ZIP archive is not a Postman collection that can be imported. Instead, it is an index of files present in the archive. A collections folder contains all the files that can be imported.
 
 Alternatively, you can download your archived data directly within Postman. To learn how, refer to [Settings](/docs/getting-started/settings/).
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -29,7 +29,7 @@ contextual_links:
 
 > Postman Free allows teams of up to three to collaborate at no cost. To collaborate with additional team members, features, and increased usage limits, see [Plans and Pricing](https://www.postman.com/pricing/).
 
-Postman provides you with many tools to help you work with your team, allowing you to collaborate and share your work.
+Postman enables collaboration through [shared workspaces](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/). Workspaces allow you to share your work with your teammates, including APIs, collections, environments, integrations, mocks, and monitors.
 
 ## Contents
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -111,7 +111,7 @@ The Postman usage menu allows you to review your team's limits for APIs, shared 
 
 For more details and to view your usage period, select **Resource Usage**.
 
-![Usage limit information](https://assets.postman.com/postman-docs/team-resource-limits-v9.7.jpg)
+<img src="https://assets.postman.com/postman-docs/team-resource-limits-v9.7.jpg" alt="Usage limit information" width="400px"/>
 
 ## Next steps
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -35,15 +35,12 @@ Postman provides you with many tools to help you work with your team, allowing y
 
 * [Enabling team discovery](#enabling-team-discovery)
 * [Collaborating in team workspaces](#collaborating-in-team-workspaces)
-
     * [Inviting a team member to a workspace](#inviting-a-team-member-to-a-workspace)
 
     * [Finding teams within your organization](#finding-teams-within-your-organization)
 
     * [Leaving a team](#leaving-a-team)
 * [Team usage limits](#team-usage-limits)
-
-    * [Recovering archived collections](#recovering-your-archived-collections)
 * [Next steps](#next-steps)
 
 ## Enabling team discovery
@@ -59,7 +56,7 @@ On your Team Settings page, select **Team discovery**, then select the toggle to
 
 > Team admins will receive an email notification when team discovery is enabled.
 
-You can optionally add a question for pending team members to answer when they request to join your team. Enter your question and select **Update Question**. Anyone who requests to join the team will be prompted with the question. If you do not specify a question, team members can still add a note when they ask to join.
+You can optionally add a question for pending team members to answer when they request to join your team. Enter your question and select **Update Question**. Anyone who requests to join the team will be prompted with the question. If you do not specify a question, team members can still add a note when they request to join the team.
 
 You will be notified when someone makes a request to join your team, including their answer to any question you set, or an optional note.
 
@@ -109,32 +106,12 @@ If you are the last member to leave your team, you will have the option to trans
 
 The Postman usage menu allows you to review your team's limits for APIs, shared requests and history, mocks, monitors, and public documentation.
 
-* Free users: Next to your avatar, select the menu to the right of **Upgrade**.
-* Paid users: Next to your avatar, select **Team**.
+* **Free users**: Next to your avatar, select the menu to the right of **Upgrade**.
+* **Paid users**: Next to your avatar, select **Team**.
 
 For more details and to view your usage period, select **Resource Usage**.
 
 ![Usage limit information](https://assets.postman.com/postman-docs/team-resource-limits-v9.7.jpg)
-
-### Recovering your archived collections
-
-If your free team's collaboration exceeds usage limits, Postman will archive collections to bring your team within usage limits. Collections that have gone the longest without being revised will be archived first, based on the last edit date. Postman indicates the number of archived collections at the bottom of the left sidebar.
-
-[![archived message](https://assets.postman.com/postman-docs/ArchiveMsg2.png)](https://assets.postman.com/postman-docs/ArchiveMsg2.png)
-
-To recover archived collections, select **Archived Collections**.
-
-You will then be directed to your dashboard. Select **Download your data** > **Request data export** > **Request an archive**.
-
-[![export data1](https://assets.postman.com/postman-docs/Recovering_ArchivedCol1.png)](https://assets.postman.com/postman-docs/Recovering_ArchivedCol1.png)
-
-Select **Download** to retrieve your archived data.
-
-[![Download Data](https://assets.postman.com/postman-docs/Download_Data1.png)](https://assets.postman.com/postman-docs/Download_Data1.png)
-
-> The `archive.json` inside the downloaded ZIP archive is not a Postman collection that can be imported. Instead, it is an index of files present in the archive. A collections folder contains all the files that can be imported.
-
-Alternatively, you can download your archived data directly within Postman. To learn how, refer to [Settings](/docs/getting-started/settings/).
 
 ## Next steps
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -52,7 +52,7 @@ When you enable team discovery, users who have a verified email address with you
 
 On your Team Settings page, select **Team discovery** on the left, then select the toggle to turn team discovery on.
 
-[![Enable team discovery](https://assets.postman.com/postman-docs/team-discovery-enable-v9.7.jpg)](https://assets.postman.com/postman-docs/team-discovery-enable-v9.7.jpg)
+[![Enable team discovery](https://assets.postman.com/postman-docs/team-discovery-enable-v9.7.0.jpg)](https://assets.postman.com/postman-docs/team-discovery-enable-v9.7.0.jpg)
 
 > Team admins will receive an email notification when team discovery is enabled.
 
@@ -60,7 +60,7 @@ You can optionally add a question for pending team members to answer when they r
 
 All admins will be notified when someone makes a request to join your team, including their answer to any question you set, or an optional note.
 
-[![Team Request Approval](https://assets.postman.com/postman-docs/admin-team-join-requests-v9.7.jpg)](https://assets.postman.com/postman-docs/admin-team-join-requests-v9.7.jpg)
+[![Team Request Approval](https://assets.postman.com/postman-docs/admin-team-join-requests-v9.7.0.jpg)](https://assets.postman.com/postman-docs/admin-team-join-requests-v9.7.0.jpg)
 
 ## Collaborating in team workspaces
 
@@ -82,7 +82,7 @@ When you log in to the Postman web dashboard using a verified email address for 
 
 You will see a list of the available teams within your organization. Select a team. Answer the question set by the team admin, if there is one. You can also add an optional note. Select **Request to join**.
 
-<img alt="Team Join Question" src="https://assets.postman.com/postman-docs/team-join-question-v9.7.jpg" width="400px"/>
+<img alt="Team Join Question" src="https://assets.postman.com/postman-docs/team-join-question-v9.7.0.jpg" width="400px"/>
 
 Team admins will receive a notification when you ask to join the team. Once they approve your request, you'll be able to access the team and collaborate on API projects within it.
 
@@ -111,7 +111,7 @@ The Postman usage menu allows you to review your team's limits for APIs, shared 
 
 For more details and to view your usage period, select **Resource Usage**.
 
-<img src="https://assets.postman.com/postman-docs/team-resource-limits-v9.7.jpg" alt="Usage limit information" width="400px"/>
+<img src="https://assets.postman.com/postman-docs/team-resource-limits-v9.7.0.jpg" alt="Usage limit information" width="400px"/>
 
 ## Next steps
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -68,11 +68,11 @@ Team workspaces allow you to collaborate on APIs, collections, environments, int
 
 > Postman creates a default "Team Workspace" for every team. You can rename this workspace, but it cannot be deleted.
 
+Postman notifies you when activities occur within your team workspace. You can opt in to or out of these notifications by selecting your avatar in the upper right and selecting **Notification Preferences**.
+
 ### Inviting a team member to a workspace
 
 You can invite team members to join a [new](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/) or existing workspace. For more details about how to invite a team member to a workspace, see [Sharing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#sharing-workspaces).
-
-> Postman will alert you with notifications when activities occur within your team and workspace. You can view and opt in to or out of notifications by selecting your avatar in the upper right and selecting **Notification Preferences**.
 
 ### Finding teams within your organization
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -55,6 +55,24 @@ Team profiles -->
 
 * [Next steps](#next-steps)
 
+## Enabling team discovery
+
+Enabling team discovery encourages collaboration and eases the onboarding process by allowing users accessing Postman with their company email address to request to join pre-existing teams within their organization.
+
+You can enable team discovery for your team in the dashboard by selecting **Team** > **Team Settings** > [**Team Discovery**](https://go.postman.co/settings/team/discovery).
+
+[![Enable team discovery](https://assets.postman.com/postman-docs/team-discovery-enable-v9.1.0.jpg)](https://assets.postman.com/postman-docs/team-discovery-enable-v9.1.0.jpg)
+
+> Team admins will receive an email notification when team discovery is enabled.
+
+You can optionally add a question for pending team members to answer when they request to join your team. Enter your question and select **Update Question**. Anyone who requests to join the team will be prompted with the question.
+
+> If you do not specify a question, team members can still add a note when they ask to join.
+
+You will receive a notification when anyone makes a request to join your team, including their answer to any question you set, or an optional note.
+
+[![Team Request Approval](https://assets.postman.com/postman-docs/admin-team-join-requests.jpg)](https://assets.postman.com/postman-docs/admin-team-join-requests.jpg)
+
 ## Collaborating in team workspaces
 
 Team workspaces allow you to collaboratively work on collections with your team.
@@ -94,24 +112,6 @@ If you are the last member to leave your team, you will have the option to trans
 <img src="https://assets.postman.com/postman-docs/leave-and-delete-team.jpg" alt="Leave and delete team" width="400px"/>
 
 > If you are invited to a new team and you are the last member in your current team, all team data will be transferred to your personal default workspace.
-
-## Enabling team discovery
-
-Enabling team discovery encourages collaboration and eases the onboarding process by allowing users accessing Postman with their company email address to request to join pre-existing teams within their organization.
-
-You can enable team discovery for your team in the dashboard by selecting **Team** > **Team Settings** > [**Team Discovery**](https://go.postman.co/settings/team/discovery).
-
-[![Enable team discovery](https://assets.postman.com/postman-docs/team-discovery-enable-v9.1.0.jpg)](https://assets.postman.com/postman-docs/team-discovery-enable-v9.1.0.jpg)
-
-> Team admins will receive an email notification when team discovery is enabled.
-
-You can optionally add a question for pending team members to answer when they request to join your team. Enter your question and select **Update Question**. Anyone who requests to join the team will be prompted with the question.
-
-> If you do not specify a question, team members can still add a note when they ask to join.
-
-You will receive a notification when anyone makes a request to join your team, including their answer to any question you set, or an optional note.
-
-[![Team Request Approval](https://assets.postman.com/postman-docs/admin-team-join-requests.jpg)](https://assets.postman.com/postman-docs/admin-team-join-requests.jpg)
 
 ## Team usage limits
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -45,12 +45,12 @@ Postman provides you with many tools to help you work with your team, allowing y
 
 ## Enabling team discovery
 
-When you enable team discovery, users who have a verified email address for your company or organization can join pre-existing teams within your organization. This encourages collaboration and eases the onboarding process for your team members.
+When you enable team discovery, users who have a verified email address with your company's domain can request to join pre-existing teams within your organization. This encourages collaboration and eases the onboarding process for your team members.
 
 * Free users: Next to your avatar, select the menu to the right of **Upgrade**, then select **Manage Team**.
 * Paid users: Next to your avatar, select **Team**, then select **Manage Team**.
 
-On your Team Settings page, select **Team discovery**, then select the toggle to turn team discovery on.
+On your Team Settings page, select **Team discovery** on the left, then select the toggle to turn team discovery on.
 
 [![Enable team discovery](https://assets.postman.com/postman-docs/team-discovery-enable-v9.7.jpg)](https://assets.postman.com/postman-docs/team-discovery-enable-v9.7.jpg)
 
@@ -58,7 +58,7 @@ On your Team Settings page, select **Team discovery**, then select the toggle to
 
 You can optionally add a question for pending team members to answer when they request to join your team. Enter your question and select **Update Question**. Anyone who requests to join the team will be prompted with the question. If you do not specify a question, team members can still add a note when they request to join the team.
 
-You will be notified when someone makes a request to join your team, including their answer to any question you set, or an optional note.
+All admins will be notified when someone makes a request to join your team, including their answer to any question you set, or an optional note.
 
 [![Team Request Approval](https://assets.postman.com/postman-docs/admin-team-join-requests-v9.7.jpg)](https://assets.postman.com/postman-docs/admin-team-join-requests-v9.7.jpg)
 
@@ -72,7 +72,7 @@ Team workspaces allow you to collaboratively work on collections with your team.
 
 You can invite team members to join a [new](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/) or existing workspace. For more details about how to invite a team member to a workspace, see [Sharing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#sharing-workspaces).
 
-> Postman will alert you with notifications when activities occur within your team and workspace. You can view and opt in or out notifications by selecting your avatar in the upper right and selecting **Notification Preferences**.
+> Postman will alert you with notifications when activities occur within your team and workspace. You can view and opt in to or out of notifications by selecting your avatar in the upper right and selecting **Notification Preferences**.
 
 ### Finding teams within your organization
 
@@ -84,7 +84,7 @@ You will see a list of the available teams within your organization. Select a te
 
 <img alt="Team Join Question" src="https://assets.postman.com/postman-docs/team-join-question-v9.7.jpg" width="400px"/>
 
-The team admin will receive a notification that you asked to join the team. Once they approve your request, you will be able to access the team and collaborate on API projects within it.
+Team admins will receive a notification when you ask to join the team. Once they approve your request, you'll be able to access the team and collaborate on API projects within it.
 
 ### Leaving a team
 
@@ -115,7 +115,7 @@ For more details and to view your usage period, select **Resource Usage**.
 
 ## Next steps
 
-Postman has many features that help you collaborate with your team:
+Postman has many features to help you collaborate with your team:
 
 * You can you can assign _roles and permissions_ to define Postman access at the team level. Learn more in the [Defining roles](/docs/collaborating-in-postman/roles-and-permissions/) guide.
 * _Version control_ allows you to collaborate with teammates by working on different forks of the same Postman collection. Learn more in the [Using version control](/docs/collaborating-in-postman/version-control-for-collections/) guide.

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -117,6 +117,6 @@ For more details and to view your usage period, select **Resource Usage**.
 
 Postman has many features to help you collaborate with your team:
 
-* You can you can assign _roles and permissions_ to define Postman access at the team level. Learn more in the [Defining roles](/docs/collaborating-in-postman/roles-and-permissions/) guide.
-* _Version control_ allows you to collaborate with teammates by working on different forks of the same Postman collection. Learn more in the [Using version control](/docs/collaborating-in-postman/version-control-for-collections/) guide.
-* A _Private API Network_ allows you to easily and securely share the APIs that your team uses internally. Learn more in the [Your Private API Network](/docs/collaborating-in-postman/adding-private-network/) guide.
+* Assign [roles and permissions](/docs/collaborating-in-postman/roles-and-permissions/) to define Postman access at the team, workspace, and entity level.
+* Use [version control](/docs/collaborating-in-postman/version-control-for-collections/) to collaborate with teammates on different forks of a shared collection or [versioning](/docs/designing-and-developing-your-api/versioning-an-api/) to collaborate on different versions of a shared API.
+* Use your [Private API Network](/docs/collaborating-in-postman/adding-private-network/) to securely share the APIs that your team uses internally.

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -31,16 +31,11 @@ contextual_links:
 
 Postman allows all users to collaborate with their teams through Team Workspaces. Using this feature, you can easily collaborate and share your collections, environments, integrations, history, mocks, monitors, and more.
 
-Postman will alert you with notifications when activities occur within your team and workspace. You can view and opt in or out notifications by selecting your avatar in the upper-right corner of Postman and selecting **Notification Preferences**.
+Postman will alert you with notifications when activities occur within your team and workspace. You can view and opt in or out notifications by selecting your avatar in the upper right and selecting **Notification Preferences**.
 
 ## Contents
 
 * [Working with team workspaces](#working-with-team-workspaces)
-
-    * [Inviting a team member to a workspace](#inviting-a-team-member-to-a-workspace)
-
-    * [Creating a new workspace](#creating-a-new-workspace-from-the-menu)
-
 * [Team discovery](#team-discovery)
 
     * [Making your team discoverable](#making-your-team-discoverable)
@@ -59,27 +54,13 @@ Postman will alert you with notifications when activities occur within your team
 
 ## Working with team workspaces
 
-Create a Team Workspace by inviting a team member to join a personal workspace or create a new one.
+A team workspace allows you to ... <!-- TODO: fill this in -->
 
-> Postman creates a default Team Workspace. You cannot delete this workspace but you can rename it.
+Postman creates a default Team Workspace. You cannot delete this workspace but you can rename it.
 
-### Inviting a team member to a workspace
+You can invite team members to join a [new](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/ ) or existing workspace. For more details about how to invite a team member to a workspace, see [Sharing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#sharing-workspaces).
 
-You can invite team members, [groups](/docs/administration/managing-your-team/user-groups/), and external users to collaborate in a workspace by navigating to the workspace and selecting **Invite** in the upper-right corner.
-
-<img alt="Share team workspace" src="https://assets.postman.com/postman-docs/share-workspace-9.4.jpg" width="400px"/>
-
-For more details, see [Sharing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#sharing-workspaces).
-
-### Creating a new workspace from the menu
-
-Select **Workspaces** in the upper left, then **Create Workspace**.
-
-<img alt="Create workspace from Workspaces menu" src="https://assets.postman.com/postman-docs/workspace-switcher-with-new-wkspc-v9.1.jpg" width="350px"/>
-
-Specify a workspace name and summary, then define the workspace **Visibility**. Select **Create Workspace** to complete the process.
-
-<img alt="Create workspace form" src="https://assets.postman.com/postman-docs/create-workspace-v9.1.jpg" width="400px"/>
+You can create a new team workspace and invite members.
 
 ## Team discovery
 
@@ -107,11 +88,11 @@ When you log in to the Postman web dashboard using a verified email address for 
 
 [![Choose Team](https://assets.postman.com/postman-docs/join-team-from-list.jpg)](https://assets.postman.com/postman-docs/join-team-from-list.jpg)
 
-You will see a list of available teams within your org. Select a team, answer the question set by the team admin if there is one (otherwise you can add an optional note), and select **Request to join**.
+You will see a list of the available teams within your organization. Select a team. Answer the question set by the team admin, if there is one. You can also add an optional note. Select **Request to join**.
 
 <img alt="Team Join Question" src="https://assets.postman.com/postman-docs/team-join-question-entry.jpg" width="400px"/>
 
-The team administrator will receive a notification that you’ve asked to join the team. Once they approve your request, you will be able to access the team and collaborate on API projects within it.
+The team admin will receive a notification that you asked to join the team. Once they approve your request, you will be able to access the team and collaborate on API projects within it.
 
 ## Leaving a team
 
@@ -137,11 +118,11 @@ The usage menu allows you to review limits for APIs, shared requests and history
 
 [![usage info](https://assets.postman.com/postman-docs/Screen%20Shot%202019-11-11%20at%205.38.16%20PM.png)](https://assets.postman.com/postman-docs/Screen%20Shot%202019-11-11%20at%205.38.16%20PM.png)
 
+If your free team's collaboration exceeds usage limits, Postman will archive collections to bring your team within usage limits. Collections that have gone the longest without being revised will be archived first, based on the last edit date.
+
 ### How archiving works
 
- Postman archives collections when a free team's collaboration exceeds usage limits. Archived collections cannot be collaborated on, however they are still accessible to users. You will receive an in-app notification when a collection is archived.
-
-[![archived message](https://assets.postman.com/postman-docs/Screen%20Shot%202019-11-11%20at%205.44.36%20PM.png)](https://assets.postman.com/postman-docs/Screen%20Shot%202019-11-11%20at%205.44.36%20PM.png)
+Postman archives collections when a free team's collaboration exceeds usage limits. Archived collections cannot be collaborated on, however they are still accessible to users. You will receive an in-app notification when a collection is archived.
 
 Postman chooses which collection(s) to archive based on last edit date. The collections that have gone the longest without a revision will be archived in order to bring your team within usage limits.
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -40,6 +40,7 @@ Team profiles -->
 
 ## Contents
 
+* [Enabling team discovery](#enabling-team-discovery)
 * [Collaborating in team workspaces](#collaborating-in-team-workspaces)
 
     * [Inviting a team member to a workspace](#inviting-a-team-member-to-a-workspace)
@@ -47,27 +48,25 @@ Team profiles -->
     * [Finding teams within your organization](#finding-teams-within-your-organization)
 
     * [Leaving a team](#leaving-a-team)
-
-* [Enabling team discovery](#enabling-team-discovery)
 * [Team usage limits](#team-usage-limits)
 
     * [Recovering archived collections](#recovering-your-archived-collections)
-
 * [Next steps](#next-steps)
 
 ## Enabling team discovery
 
-Enabling team discovery encourages collaboration and eases the onboarding process by allowing users accessing Postman with their company email address to request to join pre-existing teams within their organization.
+When you enable team discovery, users who have a verified email address for your company or organization can join pre-existing teams within your organization. This encourages collaboration and eases the onboarding process for your team members.
 
-You can enable team discovery for your team in the dashboard by selecting **Team** > **Team Settings** > [**Team Discovery**](https://go.postman.co/settings/team/discovery).
+* Free users: Next to your avatar, select the menu to the right of **Upgrade**, then select **Manage Team**.
+* Paid users: Next to your avatar, select **Team**, then select **Manage Team**.
+
+On your Team Settings page, select **Team discovery**, then select the toggle to turn team discovery on.
 
 [![Enable team discovery](https://assets.postman.com/postman-docs/team-discovery-enable-v9.1.0.jpg)](https://assets.postman.com/postman-docs/team-discovery-enable-v9.1.0.jpg)
 
 > Team admins will receive an email notification when team discovery is enabled.
 
-You can optionally add a question for pending team members to answer when they request to join your team. Enter your question and select **Update Question**. Anyone who requests to join the team will be prompted with the question.
-
-> If you do not specify a question, team members can still add a note when they ask to join.
+You can optionally add a question for pending team members to answer when they request to join your team. Enter your question and select **Update Question**. Anyone who requests to join the team will be prompted with the question. If you do not specify a question, team members can still add a note when they ask to join.
 
 You will receive a notification when anyone makes a request to join your team, including their answer to any question you set, or an optional note.
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -29,7 +29,7 @@ contextual_links:
 
 > Postman Free allows teams of up to three to collaborate at no cost. To collaborate with additional team members, features, and increased usage limits, see [Plans and Pricing](https://www.postman.com/pricing/).
 
-Postman enables collaboration through [shared workspaces](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/). You can use Workspaces to share your work with your teammates, including APIs, collections, environments, integrations, mock servers, and monitors.
+Postman enables collaboration through [shared workspaces](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/). You can use workspaces to share your work with your teammates, including APIs, collections, environments, integrations, mock servers, and monitors.
 
 ## Contents
 

--- a/src/pages/docs/collaborating-in-postman/collaboration-intro.md
+++ b/src/pages/docs/collaborating-in-postman/collaboration-intro.md
@@ -31,13 +31,6 @@ contextual_links:
 
 Postman provides you with many tools to help you work with your team, allowing you to collaborate and share your work.
 
-<!-- Can be brief and link elsewhere:
-
-workspaces
-Roles and permissions
-Version control
-Team profiles -->
-
 ## Contents
 
 * [Enabling team discovery](#enabling-team-discovery)
@@ -62,15 +55,15 @@ When you enable team discovery, users who have a verified email address for your
 
 On your Team Settings page, select **Team discovery**, then select the toggle to turn team discovery on.
 
-[![Enable team discovery](https://assets.postman.com/postman-docs/team-discovery-enable-v9.1.0.jpg)](https://assets.postman.com/postman-docs/team-discovery-enable-v9.1.0.jpg)
+[![Enable team discovery](https://assets.postman.com/postman-docs/team-discovery-enable-v9.7.jpg)](https://assets.postman.com/postman-docs/team-discovery-enable-v9.7.jpg)
 
 > Team admins will receive an email notification when team discovery is enabled.
 
 You can optionally add a question for pending team members to answer when they request to join your team. Enter your question and select **Update Question**. Anyone who requests to join the team will be prompted with the question. If you do not specify a question, team members can still add a note when they ask to join.
 
-You will receive a notification when anyone makes a request to join your team, including their answer to any question you set, or an optional note.
+You will be notified when someone makes a request to join your team, including their answer to any question you set, or an optional note.
 
-[![Team Request Approval](https://assets.postman.com/postman-docs/admin-team-join-requests.jpg)](https://assets.postman.com/postman-docs/admin-team-join-requests.jpg)
+[![Team Request Approval](https://assets.postman.com/postman-docs/admin-team-join-requests-v9.7.jpg)](https://assets.postman.com/postman-docs/admin-team-join-requests-v9.7.jpg)
 
 ## Collaborating in team workspaces
 
@@ -90,15 +83,15 @@ When you log in to the Postman web dashboard using a verified email address for 
 
 [![Choose Team](https://assets.postman.com/postman-docs/join-team-from-list.jpg)](https://assets.postman.com/postman-docs/join-team-from-list.jpg)
 
-You will see a list of the available teams within your organization. Select a team. Answer the question set by the team admin, if there is one. You can also add an optional note. Select **Request to join**. <!-- TODO: should these be groups -->
+You will see a list of the available teams within your organization. Select a team. Answer the question set by the team admin, if there is one. You can also add an optional note. Select **Request to join**.
 
-<img alt="Team Join Question" src="https://assets.postman.com/postman-docs/team-join-question-entry.jpg" width="400px"/>
+<img alt="Team Join Question" src="https://assets.postman.com/postman-docs/team-join-question-v9.7.jpg" width="400px"/>
 
 The team admin will receive a notification that you asked to join the team. Once they approve your request, you will be able to access the team and collaborate on API projects within it.
 
 ### Leaving a team
 
-You can leave a Postman team by navigating to your [Postman Dashboard](https://go.postman.co/home), selecting your avatar in the top-right corner, then **Account Settings**. Select **Team** on the left. You can then opt to **Leave Team**.
+You can leave a Postman team by navigating to your [Postman Dashboard](https://go.postman.co/home), selecting your avatar in the top right, then **Account Settings**. Select **Team** on the left. You can then opt to **Leave Team**.
 
 <img src="https://assets.postman.com/postman-docs/leave-team-v9.1.jpg" alt="Leave team"/>
 
@@ -121,7 +114,7 @@ The Postman usage menu allows you to review your team's limits for APIs, shared 
 
 For more details and to view your usage period, select **Resource Usage**.
 
-[![usage info](https://assets.postman.com/postman-docs/Screen%20Shot%202019-11-11%20at%205.38.16%20PM.png)](https://assets.postman.com/postman-docs/Screen%20Shot%202019-11-11%20at%205.38.16%20PM.png)
+![Usage limit information](https://assets.postman.com/postman-docs/team-resource-limits-v9.7.jpg)
 
 ### Recovering your archived collections
 


### PR DESCRIPTION
* Removes the [Archiving section](https://learning.postman.com/docs/collaborating-in-postman/collaboration-intro/#how-archiving-works) based on information in WORKSPACES-2084 and confirmed by Preetham.
* Updates screenshots as needed and removes all PNG files
* Removes content covered sufficiently elsewhere (https://learning.postman.com/docs/collaborating-in-postman/collaboration-intro/#how-archiving-works and https://learning.postman.com/docs/collaborating-in-postman/collaboration-intro/#creating-a-new-workspace-from-the-menu) and adds links to those other pages 
* Reorganizes content, general copyedits