### PR TITLE
Update edge case bug for "Last modified" date

### DIFF
--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -35,7 +35,9 @@ const DocPage = ({ data }) => {
               <main className="col-sm-12 col-md-12 col-lg-9 offset-lg-0 col-xl-7 doc-page ml-xl-5">
                 <h1>{post.frontmatter.title}</h1>
                 <span dangerouslySetInnerHTML={{ __html: post.html }} />
-                <small className="font-italic">Last modified: {date}</small>
+                <p>
+                  <small className="font-italic">Last modified: {date}</small>
+                </p>
               </main>
               <aside className="col-sm-12 col-md-12 col-lg-3 offset-lg-0 col-xl-3 offset-xl-1 right-column">
                 <hr className="d-block d-lg-none" />


### PR DESCRIPTION
http://localhost:8000/docs/designing-and-developing-your-api/the-api-workflow/
https://learning.postman.com/docs/designing-and-developing-your-api/the-api-workflow/

This adds a p tag to the text element and allows it to render below an image instead of the side.
![Screen Shot 2022-01-11 at 2 48 53 PM](https://user-images.githubusercontent.com/42796716/149033879-1ab0bde7-2eb5-4468-8f02-55d713380b0b.png)

