### PR TITLE
[MARKENG-1081] Breadcrumbs Navigation Links

### DIFF
--- a/src/components/modules/BreadCrumbsLinks.jsx
+++ b/src/components/modules/BreadCrumbsLinks.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import './BreadCrumbsLinks.scss';
 import { leftNavItems } from '../LeftNav/LeftNavItems';
 
 // Example: Home > Getting Started >
@@ -41,22 +42,23 @@ class BreadCrumbsLinks extends React.Component {
   render() {
     const { parentLink, subParentLink } = this.state;
     return (
-      <div className="mb-5">
-        <a href="/">Home</a>
-        <span> &#62; </span>
-        {JSON.stringify(subParentLink) !== '{}' ? (
-          <>
-          <a href={parentLink.url}>{parentLink.name}</a>
-          <span> &#62; </span>
-            <a href={subParentLink.slug}>{subParentLink.name}</a>
-          </>
-        ) : (
+      <nav className="breadcrumb-wrapper" aria-label="You are here:">
+        <div  className="mb-3">
+          <a href="/" className="small breadcrumb-home-link">Home</a>
+          <span className="small"> / </span>
+          {JSON.stringify(subParentLink) !== '{}' ? (
             <>
-          <a href={parentLink.url}>{parentLink.name}</a>
-          <span> &#62; </span>
-        </>
-        )}
-      </div>
+            <a href={parentLink.url} className="small breadcrumb-parent-link">{parentLink.name}</a>
+            <span className="small"> / </span>
+              <a href={subParentLink.slug} className="small breadcrumb-subparent-link">{subParentLink.name}</a>
+            </>
+          ) : (
+              <>
+            <a href={parentLink.url} className="small breadcrumb-parent-link">{parentLink.name}</a>
+          </>
+          )}
+        </div>
+      </nav>
     )
   }
 }

--- a/src/components/modules/BreadCrumbsLinks.jsx
+++ b/src/components/modules/BreadCrumbsLinks.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { leftNavItems } from '../LeftNav/LeftNavItems';
+
+// Example: Home > Getting Started >
+// a list of links separated by > to aid in navigation
+class BreadCrumbsLinks extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      parentLink: {},
+      subParentLink: {},
+
+    }
+  }
+  componentDidMount() {
+    let location;
+    if (typeof window !== 'undefined') {
+      location = window.location.pathname;
+    }
+    /* Loop over LeftNavItems.jsx */
+    for (let index = 0; index < leftNavItems.length; index++) {
+      /* First Menu: If matching URL, use the parent data for breadcrumb */
+      leftNavItems[index].subMenuItems1.map((subMenuItem1, index2) => {
+        if (subMenuItem1.url === location) {
+          this.setState({
+            parentLink: leftNavItems[index],
+          })
+        }
+        /* Second Menu: If matching URL, use the parent AND subparent data for breadcrumb */
+        subMenuItem1.subMenuItems2 && subMenuItem1.subMenuItems2.map(subMenuItem2 => {
+          if (subMenuItem2.url === location) {
+            this.setState({
+              parentLink: leftNavItems[index],
+              subParentLink: leftNavItems[index].subMenuItems1[index2],
+            })
+          }
+        })
+      })
+    }
+  }
+  render() {
+    const { parentLink, subParentLink } = this.state;
+    return (
+      <div className="mb-5">
+        <a href="/">Home</a>
+        <span> &#62; </span>
+        {JSON.stringify(subParentLink) !== '{}' ? (
+          <>
+          <a href={parentLink.url}>{parentLink.name}</a>
+          <span> &#62; </span>
+            <a href={subParentLink.slug}>{subParentLink.name}</a>
+          </>
+        ) : (
+            <>
+          <a href={parentLink.url}>{parentLink.name}</a>
+          <span> &#62; </span>
+        </>
+        )}
+      </div>
+    )
+  }
+}
+
+export default BreadCrumbsLinks;

--- a/src/components/modules/BreadCrumbsLinks.scss
+++ b/src/components/modules/BreadCrumbsLinks.scss
@@ -1,0 +1,17 @@
+@import '../Shared/_variables.scss';
+.breadcrumb-wrapper {
+    & a:link,
+    a:visited,
+    span {
+        color: $grey_50;
+        transition: all 0.2s ease-in-out;
+        border-bottom: 1px transparent;
+    }
+    & a:hover,
+    a:active {
+        transition: all 0.2s ease-in-out;
+        text-decoration: none;
+        color: $blue_60;
+        border-bottom: 1px solid;
+    }
+}

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -10,18 +10,22 @@ import SEO from '../components/seo';
 import './doc.scss';
 import 'prismjs/themes/prism-tomorrow.css';
 import pose from '../assets/pose-learning-center.svg';
-import PreviousAndNextLinks  from '../components/modules/PreviousAndNextLinks';
+import PreviousAndNextLinks from '../components/modules/PreviousAndNextLinks';
+import BreadCrumbsLinks  from '../components/modules/BreadCrumbsLinks';
 const { v4: uuidv4 } = require('uuid');
 
 const DocPage = ({ data }) => {
-  /* Returns last modified date */
+  /* Last modified date */
   const date = data.markdownRemark.fields.lastModifiedDate;
-  /* Returns single post */
+  /* Single post data */
   const post = data.markdownRemark;
   let contextualLinks;
   if (post.frontmatter.contextual_links) {
     contextualLinks = <ContextualLinks key={uuidv4()} links={post.frontmatter.contextual_links} />;
   }
+  /* Breadcrumbs (Top of page) */
+  const { parentLink, subParentLink } = data;
+  /* Previous and Next Links (Bottom of page) */
   const { previous, next } = data;
   return (
     <Layout>
@@ -34,6 +38,7 @@ const DocPage = ({ data }) => {
           <div className="col">
             <div className="row row-eq-height">
               <main className="col-sm-12 col-md-12 col-lg-9 offset-lg-0 col-xl-7 doc-page ml-xl-5">
+                <BreadCrumbsLinks data={{parentLink, subParentLink}} />
                 <h1>{post.frontmatter.title}</h1>
                 <span dangerouslySetInnerHTML={{ __html: post.html }} />
                 <p>

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -179,7 +179,7 @@ blockquote code.language-text {
   padding-left: 40px !important;
 
   @media (min-width:992px) {
-    margin-top: 136px;
+    margin-top: 119px;
     padding-right: 24px;
     padding-left: 0px !important;
   }


### PR DESCRIPTION
This adds Breadcrumbs functionality to Breadcrumbs docs

- Broke out component into /components/modules folder
- Uses LeftNavLinks as a single source of truth for our navigation links
- Keeps docs.jsx clean by separating the feature components 
- added a11y
- pmTech-ready

Ex: Home / Sending Requests / Supported API Frameworks
