### PR TITLE
[TW-314] Doc Azure on-prem git integration

### DIFF
--- a/src/pages/docs/designing-and-developing-your-api/versioning-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/versioning-an-api.md
@@ -44,7 +44,7 @@ contextual_links:
     url: "/docs/designing-and-developing-your-api/validating-elements-against-schema/"
 ---
 
-> __[GitHub Enterprise Server and GitLab Self-Managed integrations are only available on Postman Enterprise plans.](https://www.postman.com/pricing)__
+> __[GitHub Enterprise Server, GitLab Self-Managed, and Azure DevOps Server (hosted on-premises) integrations are only available on Postman Enterprise plans.](https://www.postman.com/pricing)__
 
 You can manage multiple versions of any APIs you create in Postman. You can then associate mocks, monitors, and documentation to specific versions of APIs.
 

--- a/src/pages/docs/integrations/available-integrations/azure-devops.md
+++ b/src/pages/docs/integrations/available-integrations/azure-devops.md
@@ -12,6 +12,8 @@ contextual_links:
     url: "/docs/sending-requests/intro-to-collections/"
 ---
 
+> __[Azure DevOps Server (hosted on-premises) integrations are only available on Postman Enterprise plans.](https://www.postman.com/pricing)__
+
 Postman enables you to sync your Postman APIs to Microsoft Azure DevOps, an open-source Git repository manager, with the Postman to Azure DevOps integration.
 
 Setting up an Azure DevOps integration requires you to authenticate with Azure Devops and configure how you would like to back up your collections.


### PR DESCRIPTION
Added note that Azure on-prem integration requires an Enterprise plan:
/docs/designing-and-developing-your-api/versioning-an-api/
/docs/integrations/available-integrations/azure-devops/