### PR TITLE
[339] Resolve LC cookie notice scroll issue + clear errors on homepage

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,6 +35,12 @@ module.exports = {
       },
     },
     {
+      resolve: `gatsby-plugin-catch-links`,
+      options: {
+        excludePattern: /(excluded-link|external)/,
+      },
+    },
+    {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
         id: 'GTM-M42M5N',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9069,6 +9069,15 @@
         "lodash.chunk": "^4.2.0"
       }
     },
+    "gatsby-plugin-catch-links": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-4.6.0.tgz",
+      "integrity": "sha512-/FXReA80nyWtk2KM9dn4Epo7DftTLyW6UKNuKtndAh9tDMLqiXwqmUCYhcRc750auN8O8hN7ddCIxUgD5vGp7g==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
     "gatsby-plugin-env-variables": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-env-variables/-/gatsby-plugin-env-variables-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gatsby": "4.3.0",
     "gatsby-cli": "4.3.0",
     "gatsby-plugin-algolia": "0.24.0",
+    "gatsby-plugin-catch-links": "^4.6.0",
     "gatsby-plugin-env-variables": "2.2.0",
     "gatsby-plugin-gdpr-cookies": "2.0.8",
     "gatsby-plugin-google-analytics": "4.3.0",

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -618,7 +618,7 @@ class Header extends React.Component {
                 aria-expanded="false"
               >
                 <svg id="navbar-chevron-icons" width="20" height="11" viewBox="0 0 20 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M1 1L10 10L19 1" stroke="#6B6B6B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                  <path d="M1 1L10 10L19 1" stroke="#6B6B6B" strokwidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               </div>
             </span>


### PR DESCRIPTION
1. To resolve external a links from scrolling after click, I installed https://www.gatsbyjs.com/plugins/gatsby-plugin-catch-links/
This will need to be tested in beta since localhost does not automatically scroll. I suspect the upgrade to Gatsby V4 could  be the reason as our other platforms don't have this scroll issue.

2. Cleared up SVG errors on homepage
![Screen Shot 2022-01-27 at 11 47 18 AM](https://user-images.githubusercontent.com/42796716/151435590-a8fc1b94-2d28-4ebe-994a-a2c32d7776e3.png)

