### PR TITLE
[MARKENG-339] Remove scroll packages; not working in develop / production

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,12 +35,6 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-plugin-catch-links`,
-      options: {
-        excludePattern: /(excluded-link|external)/,
-      },
-    },
-    {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
         id: 'GTM-M42M5N',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8262,7 +8262,6 @@
         "gatsby-plugin-page-creator": "^4.3.0",
         "gatsby-plugin-typescript": "^4.3.0",
         "gatsby-plugin-utils": "^2.3.0",
-        "gatsby-react-router-scroll": "^5.3.0",
         "gatsby-telemetry": "^3.3.0",
         "gatsby-worker": "^1.3.0",
         "glob": "^7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9069,15 +9069,6 @@
         "lodash.chunk": "^4.2.0"
       }
     },
-    "gatsby-plugin-catch-links": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-4.6.0.tgz",
-      "integrity": "sha512-/FXReA80nyWtk2KM9dn4Epo7DftTLyW6UKNuKtndAh9tDMLqiXwqmUCYhcRc750auN8O8hN7ddCIxUgD5vGp7g==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "escape-string-regexp": "^1.0.5"
-      }
-    },
     "gatsby-plugin-env-variables": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-env-variables/-/gatsby-plugin-env-variables-2.2.0.tgz",
@@ -9443,11 +9434,12 @@
       }
     },
     "gatsby-react-router-scroll": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-5.3.0.tgz",
-      "integrity": "sha512-5OnkXwDJqCIXwp3BZmZ3byclfK7kDQEp8Fe+nj2AeAPP4NC5TH68v1OfEK/MwblJgzRzOHlhoeeM9BtMS1O/8Q==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-5.6.0.tgz",
+      "integrity": "sha512-n8wO0xeRxvBkJXrH2DAuLKCiHQRgFn/9Ytqb3Uz19fWd5q+jpOlD/qjorkeWl2cqo8oNb83ku8D6dF3qr8OT5g==",
       "requires": {
-        "@babel/runtime": "^7.15.4"
+        "@babel/runtime": "^7.15.4",
+        "prop-types": "^15.7.2"
       }
     },
     "gatsby-recipes": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "gatsby": "4.3.0",
     "gatsby-cli": "4.3.0",
     "gatsby-plugin-algolia": "0.24.0",
-    "gatsby-plugin-catch-links": "^4.6.0",
     "gatsby-plugin-env-variables": "2.2.0",
     "gatsby-plugin-gdpr-cookies": "2.0.8",
     "gatsby-plugin-google-analytics": "4.3.0",


### PR DESCRIPTION
Removed gatsby-plugin-catch-links package. Issue for scroll top for One Trust cookie still remainds.
The issue is that locally, the page does not scroll to the top when compared to beta which does scroll. I suspect this could be coming from an update in Gatsby V4 as the issue does not persist on WWW which is on V2.