### PR TITLE
gatsby-react-router-scroll added back to develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8262,6 +8262,7 @@
         "gatsby-plugin-page-creator": "^4.3.0",
         "gatsby-plugin-typescript": "^4.3.0",
         "gatsby-plugin-utils": "^2.3.0",
+        "gatsby-react-router-scroll": "^5.3.0",
         "gatsby-telemetry": "^3.3.0",
         "gatsby-worker": "^1.3.0",
         "glob": "^7.2.0",


### PR DESCRIPTION
Missing Gatsby package isn't in develop and causing develop build to break.