### PR TITLE
[MARKENG-1212] Improved navigation for "Previous" and "Next" links for Docs 

### DIFF
--- a/src/components/LeftNav/LeftNav.jsx
+++ b/src/components/LeftNav/LeftNav.jsx
@@ -8,10 +8,9 @@ const sectionHandler = (e) => {
   document.location.href = e.target.getAttribute('data-section');
 };
 
-const renderTwoLevelList = (item, runtime,) => {
+const renderTwoLevelList = (item, runtime) => {
   if (typeof document !== 'undefined') {
     const active = runtime ? document.location.pathname.match(item.parentSlug) : '';
-  
     return (
       <ul key={uuidv4()}>
         <li className="parent">
@@ -86,16 +85,15 @@ const renderTwoLevelList = (item, runtime,) => {
 }
 
 function LeftNav(props) {
-  const [useProp, setProps] = useState({ props })
+  const [{ leftNavItems = [] }, setProps] = useState({ ...props })
   const [runtime, setRuntime] = useState(true)
   const isRuntime = typeof document === 'object';
-  const { leftNavItems = [] } = props;
   useEffect(() => {
-    setProps(leftNavItems);
+    setProps(props);
     setRuntime(isRuntime)
   }, []);
   return (
-    leftNavItems.map((item) => renderTwoLevelList(item, runtime, useProp))
+    leftNavItems.map((item) => renderTwoLevelList(item, runtime))
   )
 }
 

--- a/src/components/LeftNav/LeftNav.jsx
+++ b/src/components/LeftNav/LeftNav.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect }  from 'react';
 import { Link } from 'gatsby';
 import './LeftNav.scss';
 
@@ -85,27 +85,18 @@ const renderTwoLevelList = (item, runtime,) => {
   }
 }
 
-class LeftNav extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      props,
-      runtime: true
-    }
-  }
-  componentDidMount() {
-    const isRuntime = typeof document === 'object';
-    this.setState({
-      runtime: isRuntime,
-    })
-  }
-  render() {
-    const { props, runtime } = this.state;
-    const { leftNavItems = [] } = props;
-    return (
-      leftNavItems.map((item) => renderTwoLevelList(item, runtime))
-    )
-  }
+function LeftNav(props) {
+  const [useProp, setProps] = useState({ props })
+  const [runtime, setRuntime] = useState(true)
+  const isRuntime = typeof document === 'object';
+  const { leftNavItems = [] } = props;
+  useEffect(() => {
+    setProps(leftNavItems);
+    setRuntime(isRuntime)
+  }, []);
+  return (
+    leftNavItems.map((item) => renderTwoLevelList(item, runtime, useProp))
+  )
 }
 
 export default LeftNav;

--- a/src/components/modules/PreviousAndNextLinks.jsx
+++ b/src/components/modules/PreviousAndNextLinks.jsx
@@ -1,135 +1,127 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { leftNavItems } from '../LeftNav/LeftNavItems';
 import { handleKeyboard, handleSwipe } from './handlePagination'
-class PreviousAndNextLinks extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      prevLink: {},
-      nextLink: {}
-    }
-  }
-  componentDidMount() {
-    let location;
-    if (typeof window !== 'undefined') {
-      location = window.location.pathname;
-    }
-    // 1. Filter data  / data reference: LeftNavItems.jsx
-    const parentLinks = [];
-    leftNavItems.forEach((leftNavItem) => {
-      leftNavItem.subMenuItems1.map((subMenuItem1, index) => {
-        // parent - if url matches window.location, push item to array
-        leftNavItem.subMenuItems1[index].url === location && parentLinks.push(leftNavItem.subMenuItems1)
-        // subparent - same logic as above but a level deeper
-        subMenuItem1.subMenuItems2 && subMenuItem1.subMenuItems2.filter(subMenuItem2 =>
-          // push three arrays to parentLinks[last item in previous section, current items, first item in next section]
-          subMenuItem2.url === location && parentLinks.push(
-            [leftNavItem.subMenuItems1[index - 1]],
-            subMenuItem1.subMenuItems2,
-            [leftNavItem.subMenuItems1[index + 1]]
-          )
-         )
-        }
-      )
-      return parentLinks;
-    })
-    // 2. Invoke function based on array length and which page the user is on
-    let previous;
-    let next;
-    let subParentLinks;
-    if (parentLinks.length > 1) {
-      // merge three arrays to one [last item in previous section, current items, first item in next section]
-      subParentLinks = parentLinks[0].concat(parentLinks[1], parentLinks[2]);
-      // remove first and last element if undefined
-      subParentLinks[0] === undefined ? subParentLinks.shift() : subParentLinks;
-      subParentLinks[subParentLinks.length + -1] === undefined ? subParentLinks.pop() : subParentLinks;
-      handleSubMenu(subParentLinks);
-    } else {
-      handleParentMenu(parentLinks);
-    }
 
-    function handleSubMenu(links) {
-      for (let i = 0; i < links.length; i++) {
-        if (links[i].url === location) {
-          let prevIndex = links[i + -1];
-          let nextIndex = links[i + 1];
-          previous = prevIndex && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;
-          next = nextIndex  ? nextIndex : nextIndex;
-        }
+function PreviousAndNextLinks() {
+  const [prevLink, setPrevious] = useState({ previous } || {})
+  const [nextLink, setNext] = useState({ next } || {})
+
+  let location;
+  if (typeof window !== 'undefined') {
+    location = window.location.pathname;
+  }
+  // 1. Filter data  / data reference: LeftNavItems.jsx
+  const parentLinks = [];
+  leftNavItems.forEach((leftNavItem) => {
+    leftNavItem.subMenuItems1.map((subMenuItem1, index) => {
+      // parent - if url matches window.location, push item to array
+      leftNavItem.subMenuItems1[index].url === location && parentLinks.push(leftNavItem.subMenuItems1)
+      // subparent - same logic as above but a level deeper
+      subMenuItem1.subMenuItems2 && subMenuItem1.subMenuItems2.filter(subMenuItem2 =>
+        // push three arrays to parentLinks[last item in previous section, current items, first item in next section]
+        subMenuItem2.url === location && parentLinks.push(
+          [leftNavItem.subMenuItems1[index - 1]],
+          subMenuItem1.subMenuItems2,
+          [leftNavItem.subMenuItems1[index + 1]]
+        )
+      )
+    }
+    )
+    return parentLinks;
+  })
+  // 2. Invoke function based on array length and which page the user is on
+  let previous;
+  let next;
+  let subParentLinks;
+  if (parentLinks.length > 1) {
+    // merge three arrays to one [last item in previous section, current items, first item in next section]
+    subParentLinks = parentLinks[0].concat(parentLinks[1], parentLinks[2]);
+    // remove first and last element if undefined
+    subParentLinks[0] === undefined ? subParentLinks.shift() : subParentLinks;
+    subParentLinks[subParentLinks.length + -1] === undefined ? subParentLinks.pop() : subParentLinks;
+    handleSubMenu(subParentLinks);
+  } else {
+    handleParentMenu(parentLinks);
+  }
+
+  function handleSubMenu(links) {
+    for (let i = 0; i < links.length; i++) {
+      if (links[i].url === location) {
+        let prevIndex = links[i + -1];
+        let nextIndex = links[i + 1];
+        previous = prevIndex && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;
+        next = nextIndex ? nextIndex : nextIndex;
       }
     }
-    function handleParentMenu(links) {
-      links.map(link => {
-        for (let i = 0; i < link.length; i++) {
-          if (link[i].url === location) {
-            let prevIndex = link[i + -1];
-            let nextIndex = link[i + 1];
-            // if previous section is submenu, use last item of previous section
-            // Ex: /docs/designing-and-developing-your-api/view-and-analyze-api-reports/
-            previous = prevIndex && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;
-            next = nextIndex  ? nextIndex : nextIndex;
-          }
+  }
+  function handleParentMenu(links) {
+    links.map(link => {
+      for (let i = 0; i < link.length; i++) {
+        if (link[i].url === location) {
+          let prevIndex = link[i + -1];
+          let nextIndex = link[i + 1];
+          // if previous section is submenu, use last item of previous section
+          // Ex: /docs/designing-and-developing-your-api/view-and-analyze-api-reports/
+          previous = prevIndex && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;
+          next = nextIndex ? nextIndex : nextIndex;
         }
-      })
-    }
-    this.setState({
-      prevLink: previous,
-      nextLink: next
+      }
     })
-    /* arrow key and swipe functionality */
+  }
+  
+  useEffect(() => {
+    setPrevious(previous);
+    setNext(next);
     handleKeyboard();
     handleSwipe();
-  }
+  }, []);
 
-  render() {
-    const { nextLink, prevLink } = this.state;
-    console.log(prevLink, nextLink)
-    return (
-      <>
-        <hr />
-        <div id="previousNextLinks" className="d-flex flex-row mt-3 pagination" role="navigation">
-          {prevLink && (
-            <div className="mr-auto">
-              <span
-                className="font-weight-bold mr-3"
-                aria-hidden="true"
-              >
-                &#171;
-              </span>
-              <a
-                className="prevDoc"
-                rel="prev"
-                href={prevLink.slug || prevLink.url}
-                title={`Go to the previous page: ${prevLink.name}`}
-                aria-label={`Go to the previous page: ${prevLink.name}`}
-              >
-                {prevLink.name}
-              </a>
-            </div>
-          )}
-          {nextLink && (
-            <div className="ml-auto">
-              <a
-                className="nextDoc"
-                rel="next"
-                href={nextLink.slug || nextLink.url}
-                title={`Go to the next page: ${nextLink.name}`}
-                aria-label={`Go to the next page: ${nextLink.name}`}
-              >
-                {nextLink.name}
-              </a>
-              <span
-                className="font-weight-bold ml-3"
-                aria-hidden="true"
-              >
-                &#187;
-              </span>
-            </div>
-          )}
-        </div>
-      </>
-    )
-  }
+
+  return (
+    <>
+      <hr />
+      <div id="previousNextLinks" className="d-flex flex-row mt-3 pagination" role="navigation">
+        {prevLink && (
+          <div className="mr-auto">
+            <span
+              className="font-weight-bold mr-3"
+              aria-hidden="true"
+            >
+              &#171;
+            </span>
+            <a
+              className="prevDoc"
+              rel="prev"
+              href={prevLink.slug || prevLink.url}
+              title={`Go to the previous page: ${prevLink.name}`}
+              aria-label={`Go to the previous page: ${prevLink.name}`}
+            >
+              {prevLink.name}
+            </a>
+          </div>
+        )}
+        {nextLink && (
+          <div className="ml-auto">
+            <a
+              className="nextDoc"
+              rel="next"
+              href={nextLink.slug || nextLink.url}
+              title={`Go to the next page: ${nextLink.name}`}
+              aria-label={`Go to the next page: ${nextLink.name}`}
+            >
+              {nextLink.name}
+            </a>
+            <span
+              className="font-weight-bold ml-3"
+              aria-hidden="true"
+            >
+              &#187;
+            </span>
+          </div>
+        )}
+      </div>
+    </>
+  )
 }
 
 export default PreviousAndNextLinks;

--- a/src/components/modules/PreviousAndNextLinks.jsx
+++ b/src/components/modules/PreviousAndNextLinks.jsx
@@ -3,8 +3,8 @@ import { leftNavItems } from '../LeftNav/LeftNavItems';
 import { handleKeyboard, handleSwipe } from './handlePagination'
 
 function PreviousAndNextLinks() {
-  const [prevLink, setPrevious] = useState({ previous } || {})
-  const [nextLink, setNext] = useState({ next } || {})
+  const [prevLink, setPrevious] = useState({})
+  const [nextLink, setNext] = useState({})
 
   let location;
   if (typeof window !== 'undefined') {
@@ -68,7 +68,7 @@ function PreviousAndNextLinks() {
       }
     })
   }
-  
+
   useEffect(() => {
     setPrevious(previous);
     setNext(next);

--- a/src/components/modules/PreviousAndNextLinks.jsx
+++ b/src/components/modules/PreviousAndNextLinks.jsx
@@ -59,7 +59,7 @@ class PreviousAndNextLinks extends React.Component {
         for (let i = 0; i < link.length; i++) {
           if (link[i].url === location) {
             let prevIndex = link[i + -1];
-            let nextIndex = link[i + 1]
+            let nextIndex = link[i + 1];
             // edge case: if previous section is a submenu, traverse to the last index to grab data
             // Ex: /docs/designing-and-developing-your-api/view-and-analyze-api-reports/
             previous = prevIndex && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;

--- a/src/components/modules/PreviousAndNextLinks.jsx
+++ b/src/components/modules/PreviousAndNextLinks.jsx
@@ -14,26 +14,25 @@ class PreviousAndNextLinks extends React.Component {
     if (typeof window !== 'undefined') {
       location = window.location.pathname;
     }
-    // 1. filter data 
-    // Reference file: LeftNavItems.jsx
+    // 1. filter data  / reference file: LeftNavItems.jsx
     const parentLinks = [];
-      // for every nav item, map over
     leftNavItems.forEach((leftNavItem) => {
-      // parent menu - if url matches window.location, push the item into array
+      // parent menu - if url matches window.location, push the item (subMenuItem1) into array
       leftNavItem.subMenuItems1.map((subMenuItem1, index) => {
         leftNavItem.subMenuItems1[index].url === location && parentLinks.push(leftNavItem.subMenuItems1)
-        // subparent menu - same logic applies but another level deeper in the object
+        // subparent menu - same logic applies but a level deeper in the obj (subMenuItem2)
         subMenuItem1.subMenuItems2 && subMenuItem1.subMenuItems2.filter(subMenuItem2 =>
           subMenuItem2.url === location && parentLinks
-            // pushes three items into parentLinks array [last item in previous section, current items, first item in next section]
+            // push three items into parentLinks array [last item in previous section, current items, first item in next section]
             .push([leftNavItem.subMenuItems1[index - 1]], subMenuItem1.subMenuItems2, [leftNavItem.subMenuItems1[index + 1]]))
       })
+      return parentLinks;
     })
     // 2. initiate handleSubMenu or handleParentMenu functions based on active link
     let previous;
     let next;
     let subParentLinks;
-    // length will be more than one if there is a parent or subparent node above/below the folder
+    // length will be more than one if parent or subparent menus between sections exist
     if (parentLinks.length > 1) {
       // merge three arrays into one [last item in previous section, current items, first item in next section]
       subParentLinks = parentLinks[0].concat(parentLinks[1], parentLinks[2]);
@@ -41,17 +40,14 @@ class PreviousAndNextLinks extends React.Component {
       subParentLinks[0] === undefined ? subParentLinks.shift() : subParentLinks;
       // remove last element if undefined
       subParentLinks[subParentLinks.length + -1] === undefined ? subParentLinks.pop() : subParentLinks;
-      console.log('foo')
       handleSubMenu(subParentLinks);
     } else {
-      console.log('bar')
       handleParentMenu(parentLinks);
     }
     function handleSubMenu(links) {
       for (let i = 0; i < links.length; i++) {
         if (links[i].url === location) {
           let prevIndex = links[i + -1];
-          console.log(prevIndex)
           let nextIndex = links[i + 1];
           previous = prevIndex && prevIndex.slug && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;
           next = nextIndex && nextIndex.slug ? nextIndex : nextIndex;

--- a/src/components/modules/PreviousAndNextLinks.jsx
+++ b/src/components/modules/PreviousAndNextLinks.jsx
@@ -41,16 +41,19 @@ class PreviousAndNextLinks extends React.Component {
       subParentLinks[0] === undefined ? subParentLinks.shift() : subParentLinks;
       // remove last element if undefined
       subParentLinks[subParentLinks.length + -1] === undefined ? subParentLinks.pop() : subParentLinks;
+      console.log('foo')
       handleSubMenu(subParentLinks);
     } else {
+      console.log('bar')
       handleParentMenu(parentLinks);
     }
     function handleSubMenu(links) {
       for (let i = 0; i < links.length; i++) {
         if (links[i].url === location) {
           let prevIndex = links[i + -1];
+          console.log(prevIndex)
           let nextIndex = links[i + 1];
-          previous = prevIndex && prevIndex.slug ? prevIndex : prevIndex;
+          previous = prevIndex && prevIndex.slug && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;
           next = nextIndex && nextIndex.slug ? nextIndex : nextIndex;
         }
       }

--- a/src/components/modules/PreviousAndNextLinks.jsx
+++ b/src/components/modules/PreviousAndNextLinks.jsx
@@ -22,20 +22,20 @@ class PreviousAndNextLinks extends React.Component {
       // parent menu - if url matches window.location, push the item into array
       leftNavItem.subMenuItems1.map((subMenuItem1, index) => {
         leftNavItem.subMenuItems1[index].url === location && parentLinks.push(leftNavItem.subMenuItems1)
-        // subparent menu - same logic applies above, but at a deeper level in the object
+        // subparent menu - same logic applies but another level deeper in the object
         subMenuItem1.subMenuItems2 && subMenuItem1.subMenuItems2.filter(subMenuItem2 =>
           subMenuItem2.url === location && parentLinks
-            // pushes three items [last item in previous section, current items in active section, first item in next section]
+            // pushes three items into parentLinks array [last item in previous section, current items, first item in next section]
             .push([leftNavItem.subMenuItems1[index - 1]], subMenuItem1.subMenuItems2, [leftNavItem.subMenuItems1[index + 1]]))
       })
     })
-    // 2. initiate function depending if user is on parent or subparent menu
+    // 2. initiate handleSubMenu or handleParentMenu functions based on active link
     let previous;
     let next;
     let subParentLinks;
-    // if user is currently in submenu of parent, length will be more than 1
+    // length will be more than one if there is a parent or subparent node above/below the folder
     if (parentLinks.length > 1) {
-      // combine three arrays
+      // merge three arrays into one [last item in previous section, current items, first item in next section]
       subParentLinks = parentLinks[0].concat(parentLinks[1], parentLinks[2]);
       // remove first element if undefined
       subParentLinks[0] === undefined ? subParentLinks.shift() : subParentLinks;
@@ -61,7 +61,7 @@ class PreviousAndNextLinks extends React.Component {
           if (link[i].url === location) {
             let prevIndex = link[i + -1];
             let nextIndex = link[i + 1]
-            // edge case: if previous parent section is a submenu, traverse to that arrays last index
+            // edge case: if previous section is a submenu, traverse to the last index to grab data
             // Ex: /docs/designing-and-developing-your-api/view-and-analyze-api-reports/
             previous = prevIndex && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;
             next = nextIndex && nextIndex.slug ? nextIndex : nextIndex;

--- a/src/components/modules/PreviousAndNextLinks.jsx
+++ b/src/components/modules/PreviousAndNextLinks.jsx
@@ -14,43 +14,47 @@ class PreviousAndNextLinks extends React.Component {
     if (typeof window !== 'undefined') {
       location = window.location.pathname;
     }
-    // 1. filter data  / reference file: LeftNavItems.jsx
+    // 1. Filter data  / data reference: LeftNavItems.jsx
     const parentLinks = [];
     leftNavItems.forEach((leftNavItem) => {
-      // parent menu - if url matches window.location, push the item (subMenuItem1) into array
       leftNavItem.subMenuItems1.map((subMenuItem1, index) => {
+        // parent - if url matches window.location, push item to array
         leftNavItem.subMenuItems1[index].url === location && parentLinks.push(leftNavItem.subMenuItems1)
-        // subparent menu - same logic applies but a level deeper in the obj (subMenuItem2)
+        // subparent - same logic as above but a level deeper
         subMenuItem1.subMenuItems2 && subMenuItem1.subMenuItems2.filter(subMenuItem2 =>
-          subMenuItem2.url === location && parentLinks
-            // push three items into parentLinks array [last item in previous section, current items, first item in next section]
-            .push([leftNavItem.subMenuItems1[index - 1]], subMenuItem1.subMenuItems2, [leftNavItem.subMenuItems1[index + 1]]))
-      })
+          // push three arrays to parentLinks[last item in previous section, current items, first item in next section]
+          subMenuItem2.url === location && parentLinks.push(
+            [leftNavItem.subMenuItems1[index - 1]],
+            subMenuItem1.subMenuItems2,
+            [leftNavItem.subMenuItems1[index + 1]]
+          )
+         )
+        }
+      )
       return parentLinks;
     })
-    // 2. initiate handleSubMenu or handleParentMenu functions based on active link
+    // 2. Invoke function based on array length and which page the user is on
     let previous;
     let next;
     let subParentLinks;
-    // length will be more than one if parent or subparent menus between sections exist
     if (parentLinks.length > 1) {
-      // merge three arrays into one [last item in previous section, current items, first item in next section]
+      // merge three arrays to one [last item in previous section, current items, first item in next section]
       subParentLinks = parentLinks[0].concat(parentLinks[1], parentLinks[2]);
-      // remove first element if undefined
+      // remove first and last element if undefined
       subParentLinks[0] === undefined ? subParentLinks.shift() : subParentLinks;
-      // remove last element if undefined
       subParentLinks[subParentLinks.length + -1] === undefined ? subParentLinks.pop() : subParentLinks;
       handleSubMenu(subParentLinks);
     } else {
       handleParentMenu(parentLinks);
     }
+
     function handleSubMenu(links) {
       for (let i = 0; i < links.length; i++) {
         if (links[i].url === location) {
           let prevIndex = links[i + -1];
           let nextIndex = links[i + 1];
-          previous = prevIndex && prevIndex.slug && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;
-          next = nextIndex && nextIndex.slug ? nextIndex : nextIndex;
+          previous = prevIndex && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;
+          next = nextIndex  ? nextIndex : nextIndex;
         }
       }
     }
@@ -60,20 +64,18 @@ class PreviousAndNextLinks extends React.Component {
           if (link[i].url === location) {
             let prevIndex = link[i + -1];
             let nextIndex = link[i + 1];
-            // edge case: if previous section is a submenu, traverse to the last index to grab data
+            // if previous section is submenu, use last item of previous section
             // Ex: /docs/designing-and-developing-your-api/view-and-analyze-api-reports/
             previous = prevIndex && prevIndex.subMenuItems2 ? prevIndex.subMenuItems2[prevIndex.subMenuItems2.length + -1] : prevIndex;
-            next = nextIndex && nextIndex.slug ? nextIndex : nextIndex;
+            next = nextIndex  ? nextIndex : nextIndex;
           }
         }
       })
     }
-    // 3. set previous and next links
     this.setState({
       prevLink: previous,
       nextLink: next
     })
-
     /* arrow key and swipe functionality */
     handleKeyboard();
     handleSwipe();
@@ -81,6 +83,7 @@ class PreviousAndNextLinks extends React.Component {
 
   render() {
     const { nextLink, prevLink } = this.state;
+    console.log(prevLink, nextLink)
     return (
       <>
         <hr />
@@ -109,7 +112,7 @@ class PreviousAndNextLinks extends React.Component {
               <a
                 className="nextDoc"
                 rel="next"
-                href={nextLink.url || nextLink.slug}
+                href={nextLink.slug || nextLink.url}
                 title={`Go to the next page: ${nextLink.name}`}
                 aria-label={`Go to the next page: ${nextLink.name}`}
               >

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -26,7 +26,6 @@ import './index.scss';
 
 
 const heroBackground = {
-  // grey_10
   backgroundColor: '#f9f9f9',
   padding: '48px 80px',
 };


### PR DESCRIPTION
**Bug/Issue:** Previous and Next links are hitting a dead end when navigating between a second level folder above or below the section causing the UI to feel broken. Current logic does not support this case.

**Solution:** 
I updated the logic into two parts. The first part filters out the left nav data depending on window location. The second part checks which active  link the user is on then pushes items into an array based on index and availability [last item from previous section, current items in active section, first item in next section]
- Added React Hooks useState and useEffect. Cleaner imo.

**Expected functionality:**
- Adds the ability to navigate docs another level deeper using "Previous" or "Next" methods (mouseclick, arrow keys on web or swipe on mobile)
- Example: Designing and Developing your API <-> Mocking Data <-> Analyzing Reports

✅

![Screen Shot 2022-02-01 at 7 17 32 PM](https://user-images.githubusercontent.com/42796716/152087948-ab9f17a7-3267-437f-a93e-7caa80da36be.png)


- Does not apply between sections 
- Ex: Getting Started <-> Sending Requests

 ❌

![Screen Shot 2022-02-01 at 8 11 28 PM](https://user-images.githubusercontent.com/42796716/152091927-ee34cab7-8ab7-456c-945a-f0c547c359b0.png)




**Other:**
- Updated comments
- Swipe and arrow key functionality still working
