### PR TITLE
Updated footer links to point to new Trust Center; updated doc links for /security/ also

### DIFF
--- a/src/components/Footer/Footer.data.json
+++ b/src/components/Footer/Footer.data.json
@@ -132,17 +132,17 @@
     },
     {
       "title": "Security and Legal",
-      "arialabelledby": "security-and-terms",
+      "arialabelledby": "security-and-legal",
       "category": "global-footer",
-      "label": "security-and-terms",
-      "id": "security-and-terms",
+      "label": "security-and-legal",
+      "id": "security-and-legal",
       "items": [
         {
-          "title": "Security",
-          "url": "https://www.postman.com/security/",
+          "title": "Trust and Security",
+          "url": "https://www.postman.com/trust/",
           "category": "global-footer",
-          "label": "security",
-          "id": "security",
+          "label": "trust-and-security",
+          "id": "trust-and-security",
           "target":"" 
         },
         {

--- a/src/components/MarketingPages/Line.scss
+++ b/src/components/MarketingPages/Line.scss
@@ -14,7 +14,6 @@
   padding:0 30px; 
   font-weight: 500;
   font-size: 28px;
-  text-rendering: optimizeLegibility;
   letter-spacing: .8px;
  }
 }

--- a/src/pages/docs/administration/onboarding-checklist.md
+++ b/src/pages/docs/administration/onboarding-checklist.md
@@ -8,7 +8,7 @@ contextual_links:
     name: "Additional Resources"
   - type: link
     name: "Security and Compliance: A Shared Responsibility Model"
-    url: "https://www.postman.com/security/shared-responsibility/"
+    url: "https://www.postman.com/trust/shared-responsibility/"
   - type: link
     name: "Managing your team"
     url: "/docs/administration/managing-your-team/managing-your-team/"

--- a/src/pages/docs/getting-started/syncing.md
+++ b/src/pages/docs/getting-started/syncing.md
@@ -101,7 +101,7 @@ If you or your organization have a requirement to prevent your data from being s
 
 You can delete already synced data by [deleting your account](#deleting-your-postman-account). Note that if you are a part of a Postman team, you must first [leave the team](/docs/collaborating-in-postman/collaboration-intro/#leaving-a-team) in order to delete your account.
 
-> Learn more about [Security at Postman](https://www.postman.com/security/).
+> Learn more about [Security at Postman](https://www.postman.com/trust/security/).
 
 ## Deleting your Postman account
 

--- a/src/pages/docs/monitoring-your-api/faqs-monitors.md
+++ b/src/pages/docs/monitoring-your-api/faqs-monitors.md
@@ -64,7 +64,7 @@ You can delete a monitor at any time. Once deleted, all run history for the moni
 
 ### Where do Monitors run?
 
-Monitors run on Postman's cloud infrastructure, which is hosted by Amazon Web Services (AWS). More information about the cloud infrastructure is available on the [Security overview](https://www.postman.com/security).
+Monitors run on Postman's cloud infrastructure, which is hosted by Amazon Web Services (AWS). More information about the cloud infrastructure is available on the [Security overview](https://www.postman.com/trust/security/).
 
 ### Can Monitors access private networks?
 


### PR DESCRIPTION
changelog:
- updated links to Security pages in docs to use new Trust Center 
- updated footer to use new Trust Center label and link