### PR TITLE
Markeng 1227 - Point gatsby-config to use env vars when generating  site map url

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
         RELIC_PRODUCTION_AGENT_ID: ${{ secrets.RELIC_PRODUCTION_AGENT_ID }}
         RELIC_PRODUCTION_APPLICATION_ID: ${{ secrets.RELIC_PRODUCTION_APPLICATION_ID }}
         PM_TECH: ${{secrets.PM_TECH}}
+        SITE_URL: ${{secrets.SITE_URL_BETA}}
 
       run: |
         npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -33,6 +33,7 @@ jobs:
         RELIC_PRODUCTION_AGENT_ID: ${{ secrets.RELIC_PRODUCTION_AGENT_ID }}
         RELIC_PRODUCTION_APPLICATION_ID: ${{ secrets.RELIC_PRODUCTION_APPLICATION_ID }}
         PM_TECH: ${{secrets.PM_TECH}}
+        SITE_URL: ${{secrets.SITE_URL_PROD}}
 
       run: |
         npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,12 +8,14 @@ require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
 });
 
+const siteUrl = process.env.SITE_URL ? process.env.SITE_URL : 'https://learning.postman.com'
+
 module.exports = {
   siteMetadata: {
     title: 'Postman Learning Center',
     description: '',
     author: 'Postman',
-    siteUrl: 'https://learning.postman.com',
+    siteUrl: siteUrl,
   },
   plugins: [
     {
@@ -102,8 +104,8 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-robots-txt',
       options: {
-        host: 'https://learning.postman-beta.com',
-        sitemap: 'https://learning.postman-beta.com/sitemap/sitemap-index.xml',
+        host: siteUrl,
+        sitemap:`${siteUrl}/sitemap/sitemap-index.xml`,
         resolveEnv: () => process.env.GATSBY_ACTIVE_ENV,
         env: {
           development: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -102,8 +102,8 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-robots-txt',
       options: {
-        host: 'https://learning.postman.com',
-        sitemap: 'https://learning.postman.com/sitemap/sitemap-index.xml',
+        host: 'https://learning.postman-beta.com',
+        sitemap: 'https://learning.postman-beta.com/sitemap/sitemap-index.xml',
         resolveEnv: () => process.env.GATSBY_ACTIVE_ENV,
         env: {
           development: {


### PR DESCRIPTION
Right now, Beta's site map uses `postman.com` when it should be `postman-beta`.  This PR makes the config file grab  the URL from the env vars, which I added in GH secrets and set to beta and prod respectively./