### PR TITLE
[TW-191] Update references to types of API tests

### DIFF
--- a/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
+++ b/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
@@ -173,7 +173,7 @@ The following roles control access at an API level:
 | View reports for APIs |   &#x2714;  | &#x2714;   |
 | Add and remove API environments |   &#x2714;  | &#x2714;   |
 | Add and remove API documentation |   &#x2714;  | &#x2714;   |
-| Add and remove API test suites, integration tests, and contract tests |   &#x2714;  | &#x2714;   |
+| Add and remove API tests |   &#x2714;  | &#x2714;   |
 | Add and remove API monitors |   &#x2714;  | &#x2714;   |
 | Add and remove API mock servers |   &#x2714;  | &#x2714;   |
 

--- a/src/pages/docs/designing-and-developing-your-api/testing-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/testing-an-api.md
@@ -40,7 +40,7 @@ contextual_links:
     url: "/docs/integrations/ci-integrations/"
 ---
 
-You can create collections to use as test suites, integration tests, or contract tests for your API. These collections can be linked to a specific version of your API. You can also integrate your API with supported Continuous Integration (CI) tools.
+Testing is a critical part of the API development process. You can create a collection that contains your API tests and link it to a specific versions of your API. You can also integrate your API with supported Continuous Integration (CI) tools.
 
 * [Adding tests](#adding-tests)
 * [Adding CI integration](#adding-ci-integration)

--- a/src/pages/docs/monitoring-your-api/faqs-monitors.md
+++ b/src/pages/docs/monitoring-your-api/faqs-monitors.md
@@ -10,7 +10,7 @@ warning: false
 
 ### What can I test with Monitors?
 
-You can use Postman Monitors for simple uptime monitoring to ensure your servers are online or for performance monitoring to ensure your servers are responding promptly. You also can write detailed [test suites](/docs/writing-scripts/test-scripts/) to check monitors for proper behavior, business logic, error handling, and so on.
+You can use Postman Monitors for simple uptime monitoring to ensure your servers are online or for performance monitoring to ensure your servers are responding promptly. You also can [write tests](/docs/writing-scripts/test-scripts/) to check monitors for proper behavior, business logic, error handling, and so on.
 
 ### What restrictions apply?
 

--- a/src/pages/docs/monitoring-your-api/monitoring-apis-websites.md
+++ b/src/pages/docs/monitoring-your-api/monitoring-apis-websites.md
@@ -20,7 +20,7 @@ contextual_links:
     name: "Public Workspaces"
   - type: link
     name: "Postman API Monitoring Examples"
-    url:  "https://www.postman.com/postman/workspace/e348c5a0-2965-44cc-87ed-7b316516f38d"  
+    url:  "https://www.postman.com/postman/workspace/e348c5a0-2965-44cc-87ed-7b316516f38d"
   - type: subtitle
     name: "Related Blog Posts"
   - type: link
@@ -50,7 +50,7 @@ To monitor a specific endpoint, create a collection with different variants of t
 
 This is similar in approach to monitoring a specific endpoint, with the subtle difference of storing the common API host in an environment variable, such that the requests across different API endpoints differ in their path, among other request parameters. Such a sequence also makes it possible to chain data across requests, which allows testing an entire API as a whole.
 
-### Running an API test suite
+### Running API tests
 
 In an API where various endpoints are interlinked, precise knowledge about their functioning is crucial. In cases where data is passed from one request to another, the entire response, or a part of it, can be saved as an environment variable. Additional care should be taken while setting non-atomic values (objects, arrays, etc), as the original value will be lost. Instead, such complex objects and arrays can be handled via:
 

--- a/src/pages/docs/sending-requests/intro-to-collections.md
+++ b/src/pages/docs/sending-requests/intro-to-collections.md
@@ -33,7 +33,7 @@ contextual_links:
 warning: false
 ---
 
-You can group your Postman requests and examples into collections to keep your workspace organized, to collaborate with teammates, to generate API documentation and test suites, and to automate request runs.
+You can group your Postman requests and examples into collections to keep your workspace organized, to collaborate with teammates, to generate API documentation and API tests, and to automate request runs.
 
 Select **Collections** in the left sidebar of Postman to see the list of collections in a workspace.
 

--- a/src/pages/docs/writing-scripts/intro-to-scripts.md
+++ b/src/pages/docs/writing-scripts/intro-to-scripts.md
@@ -43,7 +43,7 @@ warning: false
 
 ## Scripts in Postman
 
-Postman contains a powerful runtime based on Node.js that allows you to add dynamic behavior to requests and collections. This allows you to write test suites, build requests that can contain dynamic parameters, pass data between requests, and a lot more. You can add JavaScript code to execute during 2 events in the flow:
+Postman contains a powerful runtime based on Node.js that allows you to add dynamic behavior to requests and collections. This allows you to write API tests, build requests that can contain dynamic parameters, pass data between requests, and a lot more. You can add JavaScript code to execute during 2 events in the flow:
 
   1. Before a request is sent to the server, as a [pre-request script](/docs/writing-scripts/pre-request-scripts/) under the **Pre-request Script** tab.
   1. After a response is received, as a [test script](/docs/writing-scripts/test-scripts/) under the **Tests** tab.
@@ -84,7 +84,7 @@ If you created log statements in the pre-request and test script sections for th
 
 ### How does this work?
 
-Is this magic? No, it's the [Postman Sandbox](/docs/writing-scripts/script-references/postman-sandbox-api-reference/). The Postman Sandbox is a JavaScript execution environment that is available to you while writing pre-request and test scripts for requests (both in Postman and Newman). Whatever code you write in these sections is executed in this sandbox.  
+Is this magic? No, it's the [Postman Sandbox](/docs/writing-scripts/script-references/postman-sandbox-api-reference/). The Postman Sandbox is a JavaScript execution environment that is available to you while writing pre-request and test scripts for requests (both in Postman and Newman). Whatever code you write in these sections is executed in this sandbox.
 
 ## Debugging scripts
 


### PR DESCRIPTION
Changed references to "test suites", "integration tests", and "contract tests" to refer simply to "API tests" per the Tests tab in the API Builder in v9.0 later