### PR TITLE
TW 245 Refresh  /collaborating-in-postman/version-control-for-collections

### DIFF
--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -35,7 +35,6 @@ You can use version control with your Postman Collections by forking and merging
 * [Forking a collection](#forking-a-collection)
     * [Forking information](#forking-information)
     * [Forking to send requests](#forking-to-send-requests)
-    * [Watching a collection](#watching-a-collection)
 * [Forking an environment](#forking-an-environment)
 * [Creating pull requests](#creating-pull-requests)
     * [Pull request settings](#pull-request-settings)
@@ -88,26 +87,6 @@ Being a signed-in non-member, to send requests in a public workspace, fork the c
 <img src="https://assets.postman.com/postman-docs/visitor-fork-collection-v2.jpg" alt="Visitor creating a fork" height="400px"/>
 
 > Make sure your public profile is enabled before you fork a collection from a public workspace.
-
-### Watching a collection
-
-The watch option allows you to receive an email/in-app notification when one of your team member belonging to the same workspace modifies the collection. If you watch a collection, you will be notified of actions such as adding a new request, modifying the existing requests, adding or updating variables, editing pre-request scripts or tests, adding or deleting a folder and so on.
-
-Once you've created the collection, select __Watch__ to start watching the collection.
-
-![Collection watching](https://assets.postman.com/postman-docs/collection-watching-overview-v9.jpg)
-
-Select the bell icon <img alt="Changelog icon" src="https://assets.postman.com/postman-docs/icon-notification-bell-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> in the top right corner of Postman to view the notification. The popup will indicate further information about the change that was made to the collection.
-
-<img alt="Notification Collection Watching" src="https://assets.postman.com/postman-docs/collection-watch-notification-v8.jpg" width="500px"/>
-
-In addition to a notification, you will receive an email with the information regarding who has made the change, what the change was, and when it was made.
-
-![Watch Collection Email Notification](https://assets.postman.com/postman-docs/collection-watch-email-v8.jpg)
-
-Select __View changelog__ to access the full changelog in Postman.
-
-> If you created the collection and modified it from the same account, you will not receive email or in-app notifications for changes made.
 
 ## Forking an environment
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -53,19 +53,26 @@ You can fork Postman collections and environments. <!-- TODO: flesh this out a b
 
 ### Forking a collection
 
-> If you are not a member of a public workspace, you will not be able to send a request from a collection within the workspace. To send requests or make changes to a collection, you must fork the collection into a personal workspace or a team workspace that you belong to.
+> To fork a collection within a public workspace, you must enable your public profile in your [profile settings](https://go.postman.co/settings/me). For more information on making your profile public, see [Managing your account](/docs/getting-started/postman-account/#making-your-profile-public).
 
-To fork a collection in Postman, select the collection in the __Collections__ sidebar. Select <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px">  to view more actions, then select __Create a fork__. To provide a uniform forking experience, you can create a fork in a public workspace in three steps — log in to Postman, fill up fork details, and enable your public profile.
+When you fork a Postman collection, you create a copy of it in a different workspace. To fork a collection:
 
-<img src="https://assets.postman.com/postman-docs/collection-create-a-fork-v9.1.jpg" alt="Create fork selected in menu" width="300px"/>
+1. Select **Collections** in the left sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
+1. Select **Create a fork**.
 
-Enter a label for your fork, and select a workspace to save it to. Select __Fork Collection__.
+    <img src="https://assets.postman.com/postman-docs/collection-create-a-fork-v9.1.jpg" alt="Create fork selected in menu" width="300px"/>
 
-<img src="https://assets.postman.com/postman-docs/fork-collection-v9.1.jpg" alt="Create fork tab" width="400px"/>
+1. Enter a label for your fork, and select a workspace to save it to.
+1. Select **Fork Collection**.
+
+    <img src="https://assets.postman.com/postman-docs/fork-collection-v9.1.jpg" alt="Create fork tab" width="400px"/>
 
 Your fork will be created in the selected workspace.
 
-> If there are any mocks or monitors associated with a collection, they will not be available with the forked collection. You will need to create mocks and monitors specifically for the fork if you need them.
+If there are any [mocks](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/) or [monitors](/docs/monitoring-your-api/intro-monitors/) associated with a collection, they will not be available with the forked collection. You will need to create mocks and monitors specifically for the fork if you need them.
+
+> If you are not a member of a public workspace, you will not be able to send a request from a collection within the workspace. To send requests or make changes to a collection, fork the collection into a personal workspace or a team workspace that you belong to, and then make changes. Before forking the collection, you must be signed in to Postman.
 
 ### Forking an environment
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -66,7 +66,6 @@ To fork a collection:
 1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
 1. Select **Create a fork**.
 
-
     <img src="https://assets.postman.com/postman-docs/collection-create-a-fork-v9.1.jpg" alt="Create fork selected in menu" width="300px"/>
 
     > You can also fork a collection by selecting **Fork** on the collection overview tab.

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -52,7 +52,7 @@ Postman version control features provide a way for you and your team to collabor
 
 ## Forking Postman elements
 
-A _fork_ is a new instance of an element that you can modify without making any changes to the parent element. In Postman, you can fork [collections](#forking-a-collection) and [environments](#forking-an-environment). Forking also enables you to contribute to a collection or an environment without having edit access to that element.
+A _fork_ is a new instance of an element that you can modify without making any changes to the parent element. In Postman, you can fork [collections](#forking-a-collection) and [environments](#forking-an-environment). Forking also enables you to contribute to a collection or an environment without having Editor access to that element.
 
 ### Forking a collection
 
@@ -80,7 +80,7 @@ Your fork will be created in the selected workspace.
 
 If there are any [mocks](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/) or [monitors](/docs/monitoring-your-api/intro-monitors/) associated with a collection, they will not be available with the forked collection. You will need to create mocks and monitors specifically for the fork if you need them.
 
-> If you are not a member of a public workspace, you will not be able to send a request from a collection within the workspace. To send requests or make changes to a collection, fork the collection into a personal workspace or a team workspace that you belong to, and then make changes. Before forking the collection, you must be signed in to Postman.
+> If you are not a member of a public workspace, you will not be able to send a request from a collection within the workspace. To send requests or make changes to a collection, fork the collection into a personal workspace or a team workspace that you belong to. You must be signed in to Postman to fork a collection.
 
 ### Forking an environment
 
@@ -101,7 +101,7 @@ To fork an environment in Postman:
 
 Your forked environment will be created in the selected workspace. You will be able to view forked environments in **Environments** as well as under the environment dropdown on the right side of Postman.
 
-<img alt="Environment dropdown for forked environments" src="https://assets.postman.com/postman-docs/environment-dropdown-view-v9.12.jpg" height="200px"/>
+<img alt="Environment dropdown for forked environments" src="https://assets.postman.com/postman-docs/environment-dropdown-view-v9.12.jpg" width="300px"/>
 
 ### Viewing fork information
 
@@ -117,7 +117,8 @@ To see the list of forks for a collection:
 
 1. Select the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg" width="14px" style="vertical-align:middle;margin-bottom:5px"> from the context menu.
 1. Select the fork name under **Forks**.
-1. You can also select the user's avatar under **Forks** to view the user's public profile.
+
+    > You can also select the user's avatar under **Forks** to view the user's public profile.
 
     <img alt="View the list of forks" src="https://assets.postman.com/postman-docs/fork-information-list-v9.12.jpg" width="350px"/>
 
@@ -144,20 +145,16 @@ To create a pull request:
     * If there are any conflicts between the fork and the parent collection, they will be highlighted so that you can [resolve them](#resolving-conflicts).
 
 1. Select **Overview**.
-1. Enter a title and description for your pull request, and select up to 50 reviewers from the dropdown list. Reviewers must have edit access to the collection in order to merge your changes.
+1. Enter a title and description for your pull request, and select up to 50 reviewers from the dropdown list. Reviewers must have Editor access to the collection to merge your changes.
 1. Select **Create Pull Request**.
 
     <img alt="Create Pull Request" src="https://assets.postman.com/postman-docs/pull-request-overview.jpg" width="350px"/>
 
 The reviewers you selected will be notified about your pull request. You will receive a notification if the reviewers [comment on](#adding-comments), [approve](#approving-a-pull-request), or [merge](#merging-changes-from-a-pull-request) the pull request.
 
-The pull request reviewers and any users with [viewer or editor access](/docs/collaborating-in-postman/roles-and-permissions/) on the parent collection can do the following actions on a pull request:
-
-* [Update the title and description](#editing-or-declining-a-pull-request)
-* [Decline a pull request](#editing-or-declining-a-pull-request)
-* [Approve or unapprove a pull request](#approving-a-pull-request)
-* [Merge a pull request](#merging-changes)
-* [View or add pull request comments](#adding-comments)
+> A reviewer must have **Editor** access on the parent collection to merge changes. If a reviewer only has **Viewer** access to a collection, you will see a warning icon if you add them as reviewers for a pull request.
+>
+> <img alt="Reviewer permission" src="https://assets.postman.com/postman-docs/pull-request-reviewer-permission.jpg" width="350px"/>
 
 ### Creating public pull requests
 
@@ -185,14 +182,10 @@ Once you create the pull request, you will get a notification that it has been *
 
     <img alt="Collection Manage Roles" src="https://assets.postman.com/postman-docs/collection-manage-roles-v9.1.jpg" width="300px"/>
 
-1. Select **Editor** for the users you want to provide editor access to.
+1. Select **Editor** for the users you want to provide Editor access to.
 1. Select **Update Roles**.
 
     [![manage roles](https://assets.postman.com/postman-docs/manage-roles-collection-v9.12.jpg)](https://assets.postman.com/postman-docs/manage-roles-collection-v9.12.jpg)
-
-> A user must have **Editor** access on a collection to merge changes. If a user only has **Viewer** access to a collection, you will see a warning icon if you add them as reviewers for a pull request.
->
-> <img alt="Reviewer permission" src="https://assets.postman.com/postman-docs/pull-request-reviewer-permission.jpg" width="350px"/>
 
 #### Assign merge checks
 
@@ -257,15 +250,15 @@ Each item shows the pull request's status, which will be `OPEN` for any that hav
 
 ### Viewing the diff
 
-When you merge changes from a fork into its parent collection, you have a chance to review the difference between them, known as the _diff_, first.
+When you review a pull request, it's important to see the changes that the pull request would introduce into the parent collection. The difference between the fork and the parent collection is known as the _diff_.
 
-If you are [opening a new pull request](#creating-pull-requests), view the diff by selecting the **Changes** tab.
+To view the diff:
 
-<img alt="View diff when creating pull request" src="https://assets.postman.com/postman-docs/pull-request-create-view-diff-v9.12.jpg" width="300px"/>
-
-If you are reviewing a pull request, view the diff under the **Changes** heading.
+1. In the pull request, view the diff under the **Changes** heading.
 
 <img alt="View diff when reviewing pull request" src="https://assets.postman.com/postman-docs/pull-request-review-view-diff-v9.12.jpg" width="450px"/>
+
+The diff will tell you whether a change is an addition, a deletion, or a modification. You can use the **Jump to** pane on the right side of the pull request to navigate the folders and API requests included in the pull request.
 
 ### Adding comments
 
@@ -335,9 +328,9 @@ After a pull request is reviewed, it is ready to be merged into the parent colle
     > If the parent collection has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) before merging.
 
 1. Select one of the following merge options:
-    * **Merge changes**: Merge the changes into the parent collection. No changes are made to the forked collection. You must have editor access to the parent collection.
-    * **Merge changes and update source**: Merge the changes into the parent collection. Any differences in the parent collection are also made to the forked collection. You must have editor access to both the parent and forked collections.
-    * **Merge changes and delete source**: Merge the changes into the parent collection. After merging, the forked collection is deleted. You must have editor access to both the parent and forked collections.
+    * **Merge changes**: Merge the changes into the parent collection. No changes are made to the forked collection. You must have Editor access to the parent collection.
+    * **Merge changes and update source**: Merge the changes into the parent collection. Any differences in the parent collection are also made to the forked collection. You must have Editor access to both the parent and forked collections.
+    * **Merge changes and delete source**: Merge the changes into the parent collection. After merging, the forked collection is deleted. You must have Editor access to both the parent and forked collections.
 
     <img src="https://assets.postman.com/postman-docs/merge-fork-options-v9.12.jpg" alt="Merge Fork Options" width="400px"/>
 
@@ -345,13 +338,14 @@ After a pull request is reviewed, it is ready to be merged into the parent colle
 
 #### Merging changes from a forked collection
 
-If you have edit access to a collection, you can merge a fork into the parent collection without going through the [pull request process](#creating-pull-requests). For example, if you’re using forks in a personal workspace to organize your work, you can merge changes in a fork directly back into the parent collection. If you are collaborating with others, though, merging directly lacks the safeguards built into the pull request process, and many teams require pull requests as part of their version control workflow.
+If you have Editor access to a collection, you can merge a fork into the parent collection without going through the [pull request process](#creating-pull-requests). For example, if you’re using forks in a personal workspace to organize your work, you can merge changes in a fork directly back into the parent collection. If you are collaborating with others, though, merging directly lacks the safeguards built into the pull request process, and many teams require pull requests as part of their version control workflow.
 
 To merge changes from a fork without opening a pull request:
 
 1. Select the forked collection in the **Collections** sidebar.
 1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
 1. Select **Merge changes**.
+1. Review the diff and select **Merge all changes**.
 
     ![Merge Fork](https://assets.postman.com/postman-docs/merge-fork-collection-change-v2.jpg)
 
@@ -359,7 +353,7 @@ To merge changes from a fork without opening a pull request:
 
 ## Resolving conflicts
 
-A merge conflict happens when you try to merge changes into a parent collection that has changed since you updated your fork and Postman cannot automatically resolve the differences between the two collections. If you encounter a conflict when you try to merge a forked collection, you will need to decide how you want to resolve them before continuing.
+A merge conflict happens when you try to merge changes into an updated parent collection and Postman is not able to automatically resolve the differences between the two collections. If you encounter a conflict when you try to merge a forked collection, you will need to decide how you want to resolve them before continuing.
 
 > Merge conflicts can involve changes in multiple workspaces.
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -31,7 +31,7 @@ contextual_links:
 
 Postman version control features provide a way for you and your team to collaboratively build an API. You can fork a collection, make updates to the fork, make a pull request, and merge your changes into the parent collection.
 
-> Version control for collections is different than  API versioning. For information on managing multiple versions of APIs, see [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/).
+> Version control for collections is different from API versioning. For information on managing multiple versions of APIs, see [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/).
 
 * [Forking Postman elements](#forking-postman-elements)
     * [Forking a collection](#forking-a-collection)

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -312,16 +312,6 @@ After the pull request has been approved, you will see the status of the pull re
 
 <img src="https://assets.postman.com/postman-docs/pull-request-list-approved-v9.12.jpg" alt="Approved pull request" width="350px"/>
 
-### Viewing pull request details
-
-Once a pull request is merged, you cannot __edit__ or __decline__ it. You can check the merged pull request in the __Pull Requests__ panel.
-
-<img src="https://assets.postman.com/postman-docs/pull-request-list-v2.jpg" alt="Merged pull request" width="400px"/>
-
-You can view the detail on any merged pull request by selecting it.
-
-<img src="https://assets.postman.com/postman-docs/pull-request-details-v2.jpg" alt="Merge pull request Detail" width="300px"/>
-
 ### Pulling updates
 
 You can keep your forked collections up to date with any changes in the parent, for example if another team member has merged changes into the parent collection.
@@ -331,25 +321,38 @@ You can keep your forked collections up to date with any changes in the parent, 
 
 ![Pull recent changes](https://assets.postman.com/postman-docs/pr-pull-changes-v9.12.jpg)
 
-### Merging changes
-
-> If you have edit access to a collection, you can merge a fork into the parent collection without going through the [pull request process](#creating-pull-requests). However, the pull request process offers the most protection against introducing errors into your collections, and some teams require it.
+### Merging changes from a pull request
 
 After a pull request is reviewed, it is ready to be merged into the parent collection.
 
-Select __Merge changes__ on the fork in Postman.
+1. From the approved pull request, select **Merge**.
 
-Postman will display an overview of the changes you are attempting to merge.
+    ![Merge a pull request](https://assets.postman.com/postman-docs/pull-request-merge-fork-v9.12.jpg)
 
-![Merge Fork](https://assets.postman.com/postman-docs/merge-fork-collection-change-v2.jpg)
+    > If the parent collection has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) before merging.
 
-> If the parent collection has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) before merging.
+1. Select one of the following merge options:
+    * **Merge changes**: 
+    * **Merge changes and update source**:
+    * **Merge changes and delete source**:
 
-If there are no [conflicts](#resolving-conflicts) you can review the changes and select __Merge all changes__ when you are ready.
+    <img src="https://assets.postman.com/postman-docs/merge-fork-options-v9.12.jpg" alt="Merge Fork Options" width="400px"/>
 
-<img src="https://assets.postman.com/postman-docs/merge-fork-options.jpg" alt="Merge Fork Options" width="300px"/>
+1. Select **Merge**.
 
-You can merge all changes from the fork into the parent, merge into the parent and update the fork, or merge in the parent and delete the fork. Make a selection and select __Merge__.
+### Merging changes from a forked collection
+
+If you have edit access to a collection, you can merge a fork into the parent collection without going through the [pull request process](#creating-pull-requests). For example, if you’re using forks in a personal workspace to organize your work, you can merge changes in a fork directly back into the parent collection. If you are collaborating with others, though, merging directly lacks the safeguards built into the pull request process, and many teams require pull requests as part of their version control workflow.
+
+To merge changes from a fork without opening a pull request:
+
+1. Select the forked collection in the **Collections** sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
+1. Select **Merge changes**.
+
+    ![Merge Fork](https://assets.postman.com/postman-docs/merge-fork-collection-change-v2.jpg)
+
+1. Proceed with the merge process described in [Merging changes from a pull request](#merging-changes-from-a-pull-request).
 
 ## Resolving conflicts
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -29,7 +29,7 @@ contextual_links:
     url: "/docs/designing-and-developing-your-api/versioning-an-api/"
 ---
 
-You can use version control with your Postman Collections by forking and merging and utilizing a standard pull request process. Version control allows you to collaborate with teammates by working on different forks of the same collection, updating forks from the parent collection, and merging changes when you're ready. You can tag collaborators to review pull requests and resolve conflicts to manage collection versions.
+Postman version control features provide a way for you and your team to collaboratively build an API. You can fork a collection, make updates to the fork, make a pull request, and merge your changes into the parent collection.
 
 > Version control for collections is different than  API versioning. For information on managing multiple versions of APIs, see [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/).
 
@@ -49,13 +49,15 @@ You can use version control with your Postman Collections by forking and merging
 
 ## Forking Postman elements
 
-You can fork Postman collections and environments. <!-- TODO: flesh this out a bit and how it relates to version control -->
+A _fork_ is a new instance of an element that you can modify without making any changes to the parent element. In Postman, you can fork [collections](#forking-a-collection) and [environments](#forking-an-environment). Forking also enables you to contribute to a collection or an environment without having edit access to that element.
 
 ### Forking a collection
 
 > To fork a collection within a public workspace, you must enable your public profile in your [profile settings](https://go.postman.co/settings/me). For more information on making your profile public, see [Managing your account](/docs/getting-started/postman-account/#making-your-profile-public).
 
-When you fork a Postman collection, you create a copy of it in a different workspace. To fork a collection:
+When you fork a Postman collection, you create a copy of it in a different workspace.
+
+To fork a collection:
 
 1. Select **Collections** in the left sidebar.
 1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
@@ -120,9 +122,11 @@ To see the list of forks for a collection:
 
 > Pull requests are only available for collections.
 
-When you fork a collection, you can make changes to it. When you have made the changes that you want, you can create a _pull request_. Creating a pull request means that you want to merge the changes you made in the fork of the collection (the _source_) into the parent collection (the _destination_), requesting that reviewers look at your changes and decide to merge them.
+When you have made the changes that you want to a forked collection, you can create a _pull request_. Creating a pull request means that you want to merge the changes you made in the forked collection (the _source_) into the parent collection (the _destination_). As part of the pull request process, you will request that reviewers look at your changes. The reviewers can make comments on your changes and will decide whether to approve them and merge them into the parent collection.
 
-1. Select the collection in the **Collections** sidebar.
+To create a pull request:
+
+1. Select the forked collection in the **Collections** sidebar.
 1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
 1. Select **Create pull request**.
 
@@ -252,11 +256,24 @@ Each pull request includes status, which will be `OPEN` for any that have not be
 
 When you merge changes from a fork into its parent collection, you have a chance to review the difference between them, known as the _diff_, first. The diff navigation view enables you to review the changes made to a collection. The nested folder structure shows the requests present within the folders and improves navigation while working with forks and pull requests.
 
-To view the diff:
+To view the diff in a pull request:
 
 1. Select the __Changes__ tab.
 
-![Diff Navigation](https://assets.postman.com/postman-docs/diff-navigation-v2.jpg)
+![Diff Navigation](https://assets.postman.com/postman-docs/diff-navigation-v2.jpg) <!-- TODO: update image -->
+
+### Adding comments
+
+Adding comments as a reviewer is an important part of the pull request process, facilitating meaningful conversations and allowing stakeholders to have a voice in the process.
+
+To add a comment to a pull request:
+
+1. Select the comment icon <img alt="Changelog icon" src="https://assets.postman.com/postman-docs/icon-comments-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the change in the diff that you want to comment on.
+1. Once you've written your comment, select **Add Comment**.
+
+<img alt="Add a comment to a pull review" src="https://assets.postman.com/postman-docs/pr-add-comment-v9.12.jpg" width="450px"/>
+
+> To tag another user in your comment, use the `@` symbol before their username.
 
 ### Editing or declining a pull request
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -77,7 +77,7 @@ To fork a collection:
 
 Your fork will be created in the selected workspace.
 
-If there are any [mocks](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/) or [monitors](/docs/monitoring-your-api/intro-monitors/) associated with a collection, they will not be available with the forked collection. You will need to create mocks and monitors specifically for the fork if you need them.
+If there are any [mocks](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/) or [monitors](/docs/monitoring-your-api/intro-monitors/) associated with a collection, they will not be linked to the forked collection. You will need to create mocks and monitors specifically for the fork if you need them.
 
 > If you are not a member of a public workspace, you won't be able to send a request from a collection within the workspace. To send requests or make changes to a collection, fork the collection into a personal workspace or a team workspace that you belong to. You must be signed in to Postman to fork a collection.
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -102,7 +102,7 @@ Your forked environment will be created in the selected workspace. You will be a
 
 Fork information provides details about forks and the users who have created them. You will be able to identify the users who are actively consuming and contributing to your APIs.
 
-To see the list of users who have forked the collection:
+To see the list of users who have forked a collection or an environment:
 
 1. Select the number next to the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg" width="14px" style="vertical-align:middle;margin-bottom:5px"> to reveal the list of users who have active forks.
 
@@ -118,25 +118,31 @@ To see the list of forks for a collection:
 
 ## Creating pull requests
 
-You can merge changes from a collection fork (the _source_) into the parent (the _destination_) using a pull request process, by tagging reviewers who can comment on your changes and decide to merge them. In Postman, open the menu for a collection and select __Create Pull Request__.
+> Pull requests are not available for environments.
 
-<img alt="Create Pull Request" src="https://assets.postman.com/postman-docs/collection-create-pull-request-v9.1.jpg" width="250px"/>
+When you fork a collection, you can make changes to it. When you have made the changes that you want, you can create a _pull request_. Creating a pull request means that you want to merge the changes you made in the fork of the collection (the source) into the parent collection (the destination), requesting that reviewers look at your changes and decide to merge them.
 
-You can overview the source, destination, and changes that will be included in the pull request.
+1. Select the collection in the **Collections** sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
+1. Select **Create pull request**.
 
-![Pull Request Changes](https://assets.postman.com/postman-docs/pull-request-changes-v2.jpg)
+    <img alt="Create Pull Request" src="https://assets.postman.com/postman-docs/create-pull-request.jpg" width="250px"/>
 
-> If the parent collection has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) before merging.
+1. Select **Changes** to review the content changes that will be included in the pull request.
 
-If there are any conflicts, they will be highlighted so that you can [resolve them](#resolving-conflicts).
+    ![Pull Request Changes](https://assets.postman.com/postman-docs/pull-request-changes.jpg)
 
-![Resolve Conflicts](https://assets.postman.com/postman-docs/resolve-conflicts-v2.jpg)
+    * If the parent collection has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) before merging.
 
-If your pull request has no conflicts, you can go ahead and open it for review. Enter a title and description, and select up to three reviewers from the dropdown list. Reviewers will need edit access to the collection in order to merge your changes. Select __Create Pull Request__.
+    * If there are any conflicts, they will be highlighted so that you can [resolve them](#resolving-conflicts).
 
-<img alt="Create Pull Request" src="https://assets.postman.com/postman-docs/pull-request-overview-v2.jpg"/>
+1. Select **Overview**.
+1. Enter a title and description for your pull request, and select up to 50 reviewers from the dropdown list. Reviewers must have edit access to the collection in order to merge your changes.
+1. Select **Create Pull Request**.
 
-Reviewers can [comment on your pull request or decide to merge](#reviewing-pull-requests) your changes into the parent collection.
+    <img alt="Create Pull Request" src="https://assets.postman.com/postman-docs/pull-request-overview.jpg" width="350px"/>
+
+The reviewers you selected will be notified about your pull request. You will receive a notification if the reviewers comment on your pull request, approve your pull request, or merge the pull request. <!-- TODO: add links to other sections -->
 
 ### Pull request settings
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -238,21 +238,77 @@ To view notifications for a watched pull request:
 
 > If you create a pull request and modify it from the same account, you will not receive any notifications about changes made to the pull request.
 
-## Approving changes
+## Reviewing pull requests
 
-You can approve changes on a fork (the _source_) into the parent (the _destination_). Once the pull request is created, navigate to the collection in Postman and select the **Pull Requests** icon on the right panel.
+If you're tagged as a reviewer on a pull request, you can view the changes, comment, approve or decline the request, and merge the forked collection into the parent collection when you are ready.
 
-<img src="https://assets.postman.com/postman-docs/status-pull-request-v2.jpg" alt="Status Pull Request"/>
+You can see a list of pull request for any collection under the **Pull Requests** tab on the right panel in Postman.
 
-If you're tagged as a reviewer on a pull request, you can go ahead and approve the pull request. Upon approval, you will see the status of the pull request as **Approved**.
+<img src="https://assets.postman.com/postman-docs/open-pull-request-list-v2.jpg" alt="Open Pull Request" width="350px"/>
+
+Each pull request includes status, which will be `OPEN` for any that have not been merged or declined.
+
+### Viewing the diff
+
+When you merge changes from a fork into its parent collection, you have a chance to review the difference between them, known as the _diff_, first. The diff navigation view enables you to review the changes made to a collection. The nested folder structure shows the requests present within the folders and improves navigation while working with forks and pull requests.
+
+To view the diff:
+
+1. Select the __Changes__ tab.
+
+![Diff Navigation](https://assets.postman.com/postman-docs/diff-navigation-v2.jpg)
+
+### Editing or declining a pull request
+
+To edit or decline the pull request:
+
+You can choose to __Edit__ or __Decline__ the pull request.
+
+![Pull Request Options](https://assets.postman.com/postman-docs/edit-decline-pull-request-v2.jpg)
+
+### Approving a pull request
+
+If you're tagged as a reviewer on a pull request, you can approve the pull request.
+
+To approve a pull request:
+
+1. Navigate to the collection and select the **Pull Requests** icon <img alt="Pull request icon" src="https://assets.postman.com/postman-docs/icon-pull-request.jpg" width="16px" style="vertical-align:middle;margin-bottom:5px"> on the context menu.
+
+<img src="https://assets.postman.com/postman-docs/status-pull-request-v2.jpg" alt="Status Pull Request"/> <!-- TODO: update -->
+
+Upon approval, you will see the status of the pull request as **Approved**.
 
 <img src="https://assets.postman.com/postman-docs/approve-fork-v2.jpg" alt="Approve Fork"/>
 
-## Merging changes
+### Viewing pull request details
 
-You can merge changes on a fork (the _source_) into the parent fork (the _destination_). It is recommended that you use the [pull request process](#creating-pull-requests) instead of merging straight away—which you can only do if you have edit access to the original collection. If you do not have permissions to edit the parent collection, you will need to [open a pull request](#creating-pull-requests) so that someone with edit access can merge your changes.
+Once a pull request is merged, you cannot __edit__ or __decline__ it. You can check the merged pull request in the __Pull Requests__ panel.
 
-When you merge changes from a fork into its parent collection, you have a chance to review the "diff" first. Select __Merge changes__ on the fork in Postman.
+<img src="https://assets.postman.com/postman-docs/pull-request-list-v2.jpg" alt="Merged pull request" width="400px"/>
+
+You can view the detail on any merged pull request by selecting it.
+
+<img src="https://assets.postman.com/postman-docs/pull-request-details-v2.jpg" alt="Merge pull request Detail" width="300px"/>
+
+### Pulling updates
+
+You can keep your forked collections up to date with any changes in the parent, for example if another team member has merged changes into the parent collection.
+
+To compare your fork to its parent, choose __Merge changes__ in the forked collection in Postman.
+
+<img src="https://assets.postman.com/postman-docs/collection-fork-merge-changes-v9.1.jpg" alt="Merge Fork" width="300px"/>
+
+Postman will warn you before you attempt to merge a fork whose parent has changed since you last updated it. Select __Pull Changes__ to update your fork with the changes in the parent collection.
+
+![Update Fork](https://assets.postman.com/postman-docs/merge-changes-screen-v2.jpg)
+
+### Merging changes
+
+> If you have edit access to a collection, you can merge a fork into the parent collection without going through the [pull request process](#creating-pull-requests). However, the pull request process offers the most protection against introducing errors into your collections, and some teams require it.
+
+After a pull request is reviewed, it is ready to be merged into the parent collection.
+
+Select __Merge changes__ on the fork in Postman.
 
 Postman will display an overview of the changes you are attempting to merge.
 
@@ -265,46 +321,6 @@ If there are no [conflicts](#resolving-conflicts) you can review the changes and
 <img src="https://assets.postman.com/postman-docs/merge-fork-options.jpg" alt="Merge Fork Options" width="300px"/>
 
 You can merge all changes from the fork into the parent, merge into the parent and update the fork, or merge in the parent and delete the fork. Make a selection and select __Merge__.
-
-## Pulling updates
-
-You can keep your forked collections up to date with any changes in the parent, for example if another team member has merged changes into the parent collection.
-
-To compare your fork to its parent, choose __Merge changes__ in the forked collection in Postman.
-
-<img src="https://assets.postman.com/postman-docs/collection-fork-merge-changes-v9.1.jpg" alt="Merge Fork" width="300px"/>
-
-Postman will warn you before you attempt to merge a fork whose parent has changed since you last updated it. Select __Pull Changes__ to update your fork with the changes in the parent collection.
-
-![Update Fork](https://assets.postman.com/postman-docs/merge-changes-screen-v2.jpg)
-
-## Reviewing pull requests
-
-If you're tagged as a reviewer on a pull request, you can view the changes, comment, and merge the forked collection into the parent (or decline the pull request) when you are ready.
-
-You can see a list of pull request for any collection under the __Pull Requests__ tab on the right panel in Postman.
-
-<img src="https://assets.postman.com/postman-docs/open-pull-request-list-v2.jpg" alt="Open Pull Request" width="350px"/>
-
-Each pull request includes status, which will be `OPEN` for any that have not been merged or declined.
-
-You can choose to __Edit__ or __Decline__ the pull request.
-
-![Pull Request Options](https://assets.postman.com/postman-docs/edit-decline-pull-request-v2.jpg)
-
-To view the differences between the fork (the _source_) and the parent fork (the _destination_), select __Changes__ tab.
-
-![Diff Navigation](https://assets.postman.com/postman-docs/diff-navigation-v2.jpg)
-
-The diff navigation view enables you to review the changes made to a collection effortlessly. The nested folder structure shows the requests present within the folders and improves navigation while working with forks and pull requests.
-
-Once a pull request is merged, you cannot __edit__ or __decline__ it. You can check the merged pull request in the __Pull Requests__ panel.
-
-<img src="https://assets.postman.com/postman-docs/pull-request-list-v2.jpg" alt="Merged pull request" width="400px"/>
-
-You can view the detail on any merged pull request by selecting it.
-
-<img src="https://assets.postman.com/postman-docs/pull-request-details-v2.jpg" alt="Merge pull request Detail" width="300px"/>
 
 ## Resolving conflicts
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -38,9 +38,9 @@ You can use version control with your Postman Collections by forking and merging
     * [Forking an environment](#forking-an-environment)
     * [Viewing fork information](#viewing-fork-information)
 * [Creating pull requests](#creating-pull-requests)
-    * [Pull request settings](#pull-request-settings)
-    * [Creating public PRs](#creating-public-prs)
-    * [Watching a pull request](#watching-a-pull-request)
+    * [Creating public pull requests](#creating-public-pull-requests)
+* [Watching a pull request](#watching-a-pull-request)
+* [Pull request settings](#pull-request-settings)
 * [Approving changes](#approving-changes)
 * [Merging changes](#merging-changes)
 * [Pulling updates](#pulling-updates)
@@ -118,9 +118,9 @@ To see the list of forks for a collection:
 
 ## Creating pull requests
 
-> Pull requests are not available for environments.
+> Pull requests are only available for collections.
 
-When you fork a collection, you can make changes to it. When you have made the changes that you want, you can create a _pull request_. Creating a pull request means that you want to merge the changes you made in the fork of the collection (the source) into the parent collection (the destination), requesting that reviewers look at your changes and decide to merge them.
+When you fork a collection, you can make changes to it. When you have made the changes that you want, you can create a _pull request_. Creating a pull request means that you want to merge the changes you made in the fork of the collection (the _source_) into the parent collection (the _destination_), requesting that reviewers look at your changes and decide to merge them.
 
 1. Select the collection in the **Collections** sidebar.
 1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
@@ -132,9 +132,9 @@ When you fork a collection, you can make changes to it. When you have made the c
 
     ![Pull Request Changes](https://assets.postman.com/postman-docs/pull-request-changes.jpg)
 
-    * If the parent collection has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) before merging.
+    * If the parent collection has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) into your fork before merging.
 
-    * If there are any conflicts, they will be highlighted so that you can [resolve them](#resolving-conflicts).
+    * If there are any conflicts between the fork and the parent collection, they will be highlighted so that you can [resolve them](#resolving-conflicts).
 
 1. Select **Overview**.
 1. Enter a title and description for your pull request, and select up to 50 reviewers from the dropdown list. Reviewers must have edit access to the collection in order to merge your changes.
@@ -144,7 +144,31 @@ When you fork a collection, you can make changes to it. When you have made the c
 
 The reviewers you selected will be notified about your pull request. You will receive a notification if the reviewers comment on your pull request, approve your pull request, or merge the pull request. <!-- TODO: add links to other sections -->
 
-### Pull request settings
+### Pull request permissions
+
+The pull request author and any users with [viewer or editor access](/docs/collaborating-in-postman/roles-and-permissions/) on the parent collection can do the following actions on a pull request:
+
+* Update the title and description
+* Decline a pull request
+* Approve or unapprove a pull request
+* Merge a pull request
+* View or add pull request comments <!-- TODO: links to other sections -->
+
+### Creating public pull requests
+
+To create a pull request on a public collection, you must fork the parent collection into a public workspace so that the users you ask to [review it](#reviewing-pull-requests) have access to it.
+
+1. Begin the pull request process described in [Creating pull requests](#creating-pull-requests). You will see a note that tells you to move the source collection to a public workspace.
+1. Select a public workspace to which to move the collection.
+1. Select **Move Collection**.
+
+    <img src="https://assets.postman.com/postman-docs/make-source-collection-public-v9.jpg" alt="Make the source collection public" width="400px"/>
+
+1. After you move the collection to a public workspace, proceed with the workflow in [Creating pull requests](#creating-pull-requests).
+
+Once you create the pull request, you will get a notification that it has been **Shared to public workspace**.
+
+## Pull request settings
 
 Pull request settings are available on [Postman Professional and Enterprise plans](https://www.postman.com/pricing) in the __Manage Roles__ section of a collection.
 
@@ -174,26 +198,6 @@ If you do not have editor access to the collection, the option to __Merge__ will
 Select __View Merge Conditions__ to see the merge conditions to be met for the pull request.
 
 <img alt="Merge Condition" src="https://assets.postman.com/postman-docs/merge-conditions.jpg" width="400px"/>
-
-### Creating public PRs
-
-To create a pull request on a public collection, you must fork the collection to a public workspace and you should have either viewer or editor access on the source collection.
-
-The pull request author and users with viewer or editor access on the destination collection can do the following:
-
-* Edit the metadata (update the title and description)
-* Decline a pull request
-* Approve or unapprove a pull request
-* Merge a pull request
-* View or add pull request comments
-
-You can create a pull request on a fork (the _source_) into the parent (the _destination_). The parent collection resides in a public workspace whereas the forked collection is present in a team workspace. While creating a pull request, share the source collection to a public workspace so that the reviewers can access it while reviewing the pull request. Select the workspace and select __Create Pull Request__.
-
-<img src="https://assets.postman.com/postman-docs/make-source-collection-public-v2.jpg" alt="Source Collection Public" width="400px"/>
-
-Once you create the pull request, you will get a notification that it has been __Shared to public workspace__.
-
-<img src="https://assets.postman.com/postman-docs/source-collection-shared-v2.jpg" alt="Source Collection Shared"/>
 
 ### Watching a pull request
 
@@ -275,11 +279,11 @@ The diff navigation view enables you to review the changes made to a collection 
 
 Once a pull request is merged, you cannot __edit__ or __decline__ it. You can check the merged pull request in the __Pull Requests__ panel.
 
-<img src="https://assets.postman.com/postman-docs/pull-request-list-v2.jpg" alt="Merged PR" width="400px"/>
+<img src="https://assets.postman.com/postman-docs/pull-request-list-v2.jpg" alt="Merged pull request" width="400px"/>
 
 You can view the detail on any merged pull request by selecting it.
 
-<img src="https://assets.postman.com/postman-docs/pull-request-details-v2.jpg" alt="Merge PR Detail" width="300px"/>
+<img src="https://assets.postman.com/postman-docs/pull-request-details-v2.jpg" alt="Merge pull request Detail" width="300px"/>
 
 ## Resolving conflicts
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -32,9 +32,10 @@ You can use version control with your Postman Collections by forking and merging
 
 > Version control for collections is different than  API versioning. For information on managing multiple versions of APIs, see [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/).
 
-* [Forking a collection](#forking-a-collection)
-    * [Forking information](#forking-information)
-* [Forking an environment](#forking-an-environment)
+* [Forking Postman elements](#forking-postman-elements)
+    * [Forking a collection](#forking-a-collection)
+    * [Forking an environment](#forking-an-environment)
+    * [Viewing fork information](#viewing-fork-information)
 * [Creating pull requests](#creating-pull-requests)
     * [Pull request settings](#pull-request-settings)
     * [Creating public PRs](#creating-public-prs)
@@ -45,7 +46,11 @@ You can use version control with your Postman Collections by forking and merging
 * [Reviewing pull requests](#reviewing-pull-requests)
 * [Resolving conflicts](#resolving-conflicts)
 
-## Forking a collection
+## Forking Postman elements
+
+You can fork Postman collections and environments. <!-- TODO: flesh this out a bit -->
+
+### Forking a collection
 
 > If you are not a member of a public workspace, you will not be able to send a request from a collection within the workspace. To send requests or make changes to a collection, you must fork the collection into a personal workspace or a team workspace that you belong to.
 
@@ -61,19 +66,7 @@ Your fork will be created in the selected workspace.
 
 > If there are any mocks or monitors associated with a collection, they will not be available with the forked collection. You will need to create mocks and monitors specifically for the fork if you need them.
 
-### Forking information
-
-To fork a collection within a public workspace, you must enable your public profile. Navigate to your [profile settings](https://go.postman.co/settings/me). Select your avatar in the upper-right corner > **Account Settings**. Select the toggle next to **Make profile public**, then **Update Profile**.
-
-<img alt="Make profile public" src="https://assets.postman.com/postman-docs/make-profile-public-v9.jpg">
-
-Fork information provides details about forks and the users who have created them. You will be able to identify the users who are actively consuming and contributing to your APIs. Select the fork count to reveal the list of users who have active forks.
-
-[![Fork Information](https://assets.postman.com/postman-docs/fork-information-count.jpg)](https://assets.postman.com/postman-docs/fork-information-count.jpg)
-
-> You can select a user under __Forked by__ to view their public profile.
-
-## Forking an environment
+### Forking an environment
 
 To fork an environment in Postman, select the environment in the __Environments__ sidebar, then select <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> __> Create a fork__. You can also fork an environment by selecting __Fork__ on the environment overview tab.
 
@@ -94,6 +87,18 @@ The forks icon <img alt="Fork icon on context bar for v8" src="https://assets.po
 Select **View all forks** to reveal the detailed list of forks along with information about users who created them.
 
 <img alt="Fork overview details v8" src="https://assets.postman.com/postman-docs/fork-overview-details-v8.jpg"/>
+
+### Viewing fork information
+
+To fork a collection within a public workspace, you must enable your public profile. Navigate to your [profile settings](https://go.postman.co/settings/me). Select your avatar in the upper-right corner > **Account Settings**. Select the toggle next to **Make profile public**, then **Update Profile**.
+
+<img alt="Make profile public" src="https://assets.postman.com/postman-docs/make-profile-public-v9.jpg">
+
+Fork information provides details about forks and the users who have created them. You will be able to identify the users who are actively consuming and contributing to your APIs. Select the fork count to reveal the list of users who have active forks.
+
+[![Fork Information](https://assets.postman.com/postman-docs/fork-information-count.jpg)](https://assets.postman.com/postman-docs/fork-information-count.jpg)
+
+> You can select a user under __Forked by__ to view their public profile.
 
 ## Creating pull requests
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -29,7 +29,7 @@ contextual_links:
     url: "/docs/designing-and-developing-your-api/versioning-an-api/"
 ---
 
-Postman version control features provide a way for you and your team to collaboratively build an API. You can fork a collection, make updates to the fork, make a pull request, and merge your changes into the parent collection.
+Postman's version control features provide a way for you and your team to collaboratively build an API. You can fork a collection, make updates to the fork, create a pull request, and merge your changes into the parent collection.
 
 > Version control for collections is different from API versioning. For information on managing multiple versions of APIs, see [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/).
 
@@ -79,7 +79,7 @@ Your fork will be created in the selected workspace.
 
 If there are any [mocks](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/) or [monitors](/docs/monitoring-your-api/intro-monitors/) associated with a collection, they will not be available with the forked collection. You will need to create mocks and monitors specifically for the fork if you need them.
 
-> If you are not a member of a public workspace, you will not be able to send a request from a collection within the workspace. To send requests or make changes to a collection, fork the collection into a personal workspace or a team workspace that you belong to. You must be signed in to Postman to fork a collection.
+> If you are not a member of a public workspace, you won't be able to send a request from a collection within the workspace. To send requests or make changes to a collection, fork the collection into a personal workspace or a team workspace that you belong to. You must be signed in to Postman to fork a collection.
 
 ### Forking an environment
 
@@ -98,7 +98,7 @@ To fork an environment in Postman:
 
     <img src="https://assets.postman.com/postman-docs/fork-environment-v9.1.jpg" alt="Fork environment tab" width="400px"/>
 
-Your forked environment will be created in the selected workspace. You will be able to view forked environments in **Environments** as well as under the environment dropdown on the right side of Postman.
+Your forked environment will be created in the selected workspace. You will be able to view forked environments in **Environments** as well as under the environment dropdown list on the right side of Postman.
 
 <img alt="Environment dropdown for forked environments" src="https://assets.postman.com/postman-docs/environment-dropdown-view-v9.12.jpg" width="300px"/>
 
@@ -114,7 +114,7 @@ To see the list of users who have forked a collection or an environment:
 
 To see the list of forks for a collection:
 
-1. Select the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg" width="14px" style="vertical-align:middle;margin-bottom:5px"> from the context menu.
+1. Select the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg" width="14px" style="vertical-align:middle;margin-bottom:5px"> in the context bar.
 1. Select the fork name under **Forks**.
 
     > You can also select the user's avatar under **Forks** to view the user's public profile.
@@ -160,7 +160,7 @@ The reviewers you selected will be notified about your pull request. You will re
 To create a pull request on a public collection, you must fork the parent collection into a public workspace so that the users you ask to [review it](#reviewing-pull-requests) have access to it.
 
 1. Begin the pull request process described in [Creating pull requests](#creating-pull-requests). You will see a note that tells you to move the source collection to a public workspace.
-1. Select a public workspace to which to move the collection.
+1. Select the public workspace where you want to move the collection.
 1. Select **Move Collection**.
 
     <img src="https://assets.postman.com/postman-docs/make-source-collection-public-v9.jpg" alt="Make the source collection public" width="400px"/>
@@ -214,7 +214,7 @@ Select **View Merge Conditions** to see the merge conditions to be met for the p
 
 ## Watching a pull request
 
-The watch option allows you to receive an in-app notification when a team member modifies the pull request. If you watch a pull request, you will be notified of actions such as adding a new comment, approving or unapproving, merging, and editing or declining a pull request.
+The watch option enables you to receive an in-app notification when a team member modifies the pull request. If you watch a pull request, you will be notified of actions such as adding a new comment, approving or unapproving, merging, and editing or declining a pull request.
 
 To watch a pull request:
 
@@ -231,9 +231,9 @@ To change your watching notification settings:
 
 To view notifications for a watched pull request:
 
-1. Select the bell icon <img alt="Changelog icon" src="https://assets.postman.com/postman-docs/icon-notification-bell-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> in the top right corner of Postman. The popup will indicate further information about the change that was made to the pull request.
+1. Select the bell icon <img alt="Changelog icon" src="https://assets.postman.com/postman-docs/icon-notification-bell-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> in the top right corner of Postman. The popup indicates further information about the change that was made to the pull request.
 
-> If you create a pull request and modify it from the same account, you will not receive any notifications about changes made to the pull request.
+> If you create a pull request and modify it from the same Postman account, you will not receive any notifications about changes made to the pull request.
 
 ## Reviewing pull requests
 
@@ -241,15 +241,15 @@ If you're tagged as a reviewer on a pull request, you can view the changes, comm
 
 To see the list of pull requests for a collection:
 
-1. Navigate to the collection and select the **Pull Requests** icon <img alt="Pull request icon" src="https://assets.postman.com/postman-docs/icon-pull-request.jpg" width="16px" style="vertical-align:middle;margin-bottom:5px"> on the context menu.
+1. Navigate to the collection and select the **Pull Requests** icon <img alt="Pull request icon" src="https://assets.postman.com/postman-docs/icon-pull-request.jpg" width="16px" style="vertical-align:middle;margin-bottom:5px"> in the context bar.
 
 <img src="https://assets.postman.com/postman-docs/open-pull-request-list-v9.12.jpg" alt="Pull request list" width="350px"/>
 
-Each item shows the pull request's status, which will be `OPEN` for any that have not been merged or declined. Click on a pull request's name to open it.
+Each item shows the pull request's status, which will be `OPEN` for any that have not been merged or declined. Select a pull request's name to open it.
 
 ### Viewing the diff
 
-When you review a pull request, it's important to see the changes that the pull request would introduce into the parent collection. The difference between the fork and the parent collection is known as the _diff_.
+When you review a pull request, it's important to see the changes that the pull request will introduce into the parent collection. The difference between the fork and the parent collection is known as the _diff_.
 
 To view the diff:
 
@@ -270,7 +270,7 @@ To add a comment to a pull request:
 
 <img alt="Add a comment to a pull review" src="https://assets.postman.com/postman-docs/pr-add-comment-v9.12.jpg" width="450px"/>
 
-> To tag another user in your comment, use the `@` symbol before their username.
+> To tag another user in your comment, use the **@** symbol before their username.
 
 ### Editing or declining a pull request
 
@@ -282,7 +282,7 @@ To edit the pull request details:
 
 * Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> from the pull request's header bar.
 * Select **Edit**.
-* Make your changes to the pull request's title, description, and list of reviewers.
+* Make any changes to the pull request's title, description, and list of reviewers.
 * Select **Save Changes**.
 
 If you do not want to merge the pull request into the parent collection, you can decline it. Declined pull requests cannot be reopened, so if you want to request edits or offer feedback, [add a comment](#adding-comments) instead. To decline the pull request:

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -61,7 +61,10 @@ When you fork a Postman collection, you create a copy of it in a different works
 1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
 1. Select **Create a fork**.
 
+
     <img src="https://assets.postman.com/postman-docs/collection-create-a-fork-v9.1.jpg" alt="Create fork selected in menu" width="300px"/>
+
+    > You can also fork a collection by selecting **Fork** on the collection overview tab.
 
 1. Enter a label for your fork, and select a workspace to save it to.
 1. Select **Fork Collection**.
@@ -76,25 +79,24 @@ If there are any [mocks](/docs/designing-and-developing-your-api/mocking-data/se
 
 ### Forking an environment
 
-To fork an environment in Postman, select the environment in the __Environments__ sidebar, then select <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> __> Create a fork__. You can also fork an environment by selecting __Fork__ on the environment overview tab.
+To fork an environment in Postman:
 
-<img src="https://assets.postman.com/postman-docs/environment-create-a-fork-v9.1.jpg" alt="Create an Environment Fork" width="300px"/>
+1. Select **Environments** in the left sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the environment name.
+1. Select **Create a fork**.
 
-Enter a label for your fork, and select a workspace to save it to. Select __Fork Environment__.
+    <img src="https://assets.postman.com/postman-docs/environment-create-a-fork-v9.1.jpg" alt="Create an Environment Fork" width="300px"/>
 
-<img src="https://assets.postman.com/postman-docs/fork-environment-v9.1.jpg" alt="Fork environment tab" width="400px"/>
+    > You can also fork an environment by selecting **Fork** on the environment overview tab.
 
-Your forked environment will be created in the selected workspace. You will be able to view the forked environments in the sidebar on the left as well as under the environment dropdown on the right side of Postman.
+1. Enter a label for your fork, and select a workspace to save it to.
+1. Select **Fork Environment**.
 
-<img alt="Environment dropdown for forked environments" src="https://assets.postman.com/postman-docs/environment-dropdown-view-v8.jpg" height="200px"/>
+    <img src="https://assets.postman.com/postman-docs/fork-environment-v9.1.jpg" alt="Fork environment tab" width="400px"/>
 
-The forks icon <img alt="Fork icon on context bar for v8" src="https://assets.postman.com/postman-docs/fork-icon-right-panel-v8.jpg" height="30px"/> on the context bar provides details about the forks created.
+Your forked environment will be created in the selected workspace. You will be able to view forked environments in **Environments** as well as under the environment dropdown on the right side of Postman.
 
-<img alt="Fork icon overview for v8" src="https://assets.postman.com/postman-docs/fork-panel-overview-v8.jpg" height="300px"/>
-
-Select **View all forks** to reveal the detailed list of forks along with information about users who created them.
-
-<img alt="Fork overview details v8" src="https://assets.postman.com/postman-docs/fork-overview-details-v8.jpg"/>
+<img alt="Environment dropdown for forked environments" src="https://assets.postman.com/postman-docs/environment-dropdown-view-v9.12.jpg" height="200px"/>
 
 ### Viewing fork information
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -3,7 +3,7 @@ title: "Using version control"
 order: 75
 page_id: "version_control_for_collections"
 warning: false
-updated: 2022-02-15
+updated: 2022-02-17
 contextual_links:
   - type: section
     name: "Prerequisites"

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -170,32 +170,48 @@ Once you create the pull request, you will get a notification that it has been *
 
 ## Pull request settings
 
-Pull request settings are available on [Postman Professional and Enterprise plans](https://www.postman.com/pricing) in the __Manage Roles__ section of a collection.
+> Pull request settings are available on [Postman Professional and Enterprise plans](https://www.postman.com/pricing).
 
-<img alt="Collection Manage Roles" src="https://assets.postman.com/postman-docs/collection-manage-roles-v9.1.jpg" width="300px"/>
+### Manage reviewer permissions
 
-In Postman, select the collection in the __Collections__ sidebar and select <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px">. Select __Manage roles__, then select __Editor__ for the users you want to provide editor access to and **Update Roles**.
+1. Select the collection in the **Collections** sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
+1. Select **Manage roles**.
 
-[![manage roles](https://assets.postman.com/postman-docs/manage-roles-collection-v9.1.jpg)](https://assets.postman.com/postman-docs/manage-roles-collection-v9.1.jpg)
+    <img alt="Collection Manage Roles" src="https://assets.postman.com/postman-docs/collection-manage-roles-v9.1.jpg" width="300px"/>
 
-You must have __Editor__ access on a collection to merge changes. If you have __Viewer__ access to a collection, you will see a warning icon while adding reviewers to a pull request.
+1. Select **Editor** for the users you want to provide editor access to.
+1. Select **Update Roles**.
 
-<img alt="Reviewer permission" src="https://assets.postman.com/postman-docs/reviewer-permission-pull-request.jpg" width="400px"/>
+    [![manage roles](https://assets.postman.com/postman-docs/manage-roles-collection-v9.12.jpg)](https://assets.postman.com/postman-docs/manage-roles-collection-v9.12.jpg)
+
+> A user must have **Editor** access on a collection to merge changes. If a user only has **Viewer** access to a collection, you will see a warning icon if you add them as reviewers for a pull request.
+>
+> <img alt="Reviewer permission" src="https://assets.postman.com/postman-docs/pull-request-reviewer-permission.jpg" width="350px"/>
+
+### Assign merge checks
 
 Once you have created the pull request, you can assign merge checks before approving changes.
 
-<img alt="Merge Check" src="https://assets.postman.com/postman-docs/manage-roles-collection-v9.1.jpg"/>
-
 There are two different types of checks that you can enable for a pull request:
 
-* __Approved once__ : You need at least one approval to merge the pull request.
-* __Approved by a collection editor__ : You require the approval of a collection editor to merge the pull request.
+* **Approved once**: You need at least one approval to merge the pull request.
+* **Approved by a collection editor**: You need the approval of a collection editor to merge the pull request.
 
-If you do not have editor access to the collection, the option to __Merge__ will be disabled.
+To set merge checks for pull requests on a specific collection:
 
-<img alt="Merge Disabled" src="https://assets.postman.com/postman-docs/view-merge-conditions.jpg" width="400px"/>
+1. Select the collection in the **Collections** sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
+1. Select **Manage roles**.
+1. Select the merge checks that you want to set for the collection.
 
-Select __View Merge Conditions__ to see the merge conditions to be met for the pull request.
+<img alt="Merge Check" src="https://assets.postman.com/postman-docs/manage-roles-set-merge-checks.jpg" width="800px"/>
+
+If the merge conditions for a pull request are not met, the option to **Merge** will be disabled.
+
+<img alt="Merge Disabled" src="https://assets.postman.com/postman-docs/view-merge-conditions-v9.12.jpg" width="300px"/>
+
+Select **View Merge Conditions** to see the merge conditions to be met for the pull request.
 
 <img alt="Merge Condition" src="https://assets.postman.com/postman-docs/merge-conditions.jpg" width="400px"/>
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -260,11 +260,21 @@ To view the diff:
 
 ### Editing or declining a pull request
 
-To edit or decline the pull request:
+You can edit a pull request's details before approving it, or you can decline it.
 
-You can choose to __Edit__ or __Decline__ the pull request.
+<img alt="Refresh, edit, or decline a pull request" src="https://assets.postman.com/postman-docs/refresh-edit-decline-pull-request.jpg" width="350px"/>
 
-![Pull Request Options](https://assets.postman.com/postman-docs/edit-decline-pull-request-v2.jpg)
+To edit the pull request details:
+
+* Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> from the pull request's header bar.
+* Select **Edit**.
+* Make your changes to the pull request's title, description, and list of reviewers.
+* Select **Save Changes**.
+
+If you do not want to merge the pull request into the parent collection, you can decline it. Declined pull requests cannot be reopened, so if you want to request edits or feedback, add a comment instead. To decline the pull request:
+
+* Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> from the pull request's header bar.
+* Select **Decline**, then select **Decline Pull Request**.
 
 ### Approving a pull request
 
@@ -294,13 +304,10 @@ You can view the detail on any merged pull request by selecting it.
 
 You can keep your forked collections up to date with any changes in the parent, for example if another team member has merged changes into the parent collection.
 
-To compare your fork to its parent, choose __Merge changes__ in the forked collection in Postman.
+1. Open the pull request. Postman will warn you that the parent collection has changed since you last updated it.
+1. Select **Pull Changes** to update your fork with the changes in the parent collection.
 
-<img src="https://assets.postman.com/postman-docs/collection-fork-merge-changes-v9.1.jpg" alt="Merge Fork" width="300px"/>
-
-Postman will warn you before you attempt to merge a fork whose parent has changed since you last updated it. Select __Pull Changes__ to update your fork with the changes in the parent collection.
-
-![Update Fork](https://assets.postman.com/postman-docs/merge-changes-screen-v2.jpg)
+![Pull recent changes](https://assets.postman.com/postman-docs/pr-pull-changes-v9.12.jpg)
 
 ### Merging changes
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -39,12 +39,15 @@ Postman version control features provide a way for you and your team to collabor
     * [Viewing fork information](#viewing-fork-information)
 * [Creating pull requests](#creating-pull-requests)
     * [Creating public pull requests](#creating-public-pull-requests)
+    * [Pull request settings](#pull-request-settings)
 * [Watching a pull request](#watching-a-pull-request)
-* [Pull request settings](#pull-request-settings)
-* [Approving changes](#approving-changes)
-* [Merging changes](#merging-changes)
-* [Pulling updates](#pulling-updates)
 * [Reviewing pull requests](#reviewing-pull-requests)
+    * [Viewing the diff](#viewing-the-diff)
+    * [Adding comments](#adding-comments)
+    * [Editing or declining a pull request](#editing-or-declining-a-pull-request)
+    * [Approving a pull request](#approving-a-pull-request)
+    * [Pulling updates](#pulling-updates)
+    * [Merging changes](#merging-changes)
 * [Resolving conflicts](#resolving-conflicts)
 
 ## Forking Postman elements
@@ -148,8 +151,6 @@ To create a pull request:
 
 The reviewers you selected will be notified about your pull request. You will receive a notification if the reviewers [comment on](#adding-comments), [approve](#approving-a-pull-request), or [merge](#merging-changes-from-a-pull-request) the pull request.
 
-### Pull request permissions
-
 The pull request reviewers and any users with [viewer or editor access](/docs/collaborating-in-postman/roles-and-permissions/) on the parent collection can do the following actions on a pull request:
 
 * [Update the title and description](#editing-or-declining-a-pull-request)
@@ -172,11 +173,11 @@ To create a pull request on a public collection, you must fork the parent collec
 
 Once you create the pull request, you will get a notification that it has been **Shared to public workspace**.
 
-## Pull request settings
+### Pull request settings
 
 > Pull request settings are available on [Postman Professional and Enterprise plans](https://www.postman.com/pricing).
 
-### Manage reviewer permissions
+#### Manage reviewer permissions
 
 1. Select the collection in the **Collections** sidebar.
 1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
@@ -193,7 +194,7 @@ Once you create the pull request, you will get a notification that it has been *
 >
 > <img alt="Reviewer permission" src="https://assets.postman.com/postman-docs/pull-request-reviewer-permission.jpg" width="350px"/>
 
-### Assign merge checks
+#### Assign merge checks
 
 Once you have created the pull request, you can assign merge checks before approving changes.
 
@@ -219,7 +220,7 @@ Select **View Merge Conditions** to see the merge conditions to be met for the p
 
 <img alt="Merge Condition" src="https://assets.postman.com/postman-docs/merge-conditions.jpg" width="400px"/>
 
-### Watching a pull request
+## Watching a pull request
 
 The watch option allows you to receive an in-app notification when a team member modifies the pull request. If you watch a pull request, you will be notified of actions such as adding a new comment, approving or unapproving, merging, and editing or declining a pull request.
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -173,6 +173,8 @@ Once you create the pull request, you will get a notification that it has been *
 
 > Pull request settings are available on [Postman Professional and Enterprise plans](https://www.postman.com/pricing).
 
+Pull request settings let you manage permissions for reviewers and assign merge checks.
+
 #### Manage reviewer permissions
 
 1. Select the collection in the **Collections** sidebar.
@@ -204,9 +206,9 @@ To set merge checks for pull requests on a specific collection:
 
 <img alt="Merge Check" src="https://assets.postman.com/postman-docs/manage-roles-set-merge-checks.jpg" width="800px"/>
 
-If the merge conditions for a pull request are not met, the option to **Merge** it into the parent collection will be disabled.
+If the merge conditions for a pull request are not met, the option to **Merge** it into the parent collection will be active.
 
-<img alt="Merge Disabled" src="https://assets.postman.com/postman-docs/view-merge-conditions-v9.12.jpg" width="300px"/>
+<img alt="Merge option is not active" src="https://assets.postman.com/postman-docs/view-merge-conditions-v9.12.jpg" width="300px"/>
 
 Select **View Merge Conditions** to see the merge conditions to be met for the pull request.
 
@@ -280,15 +282,14 @@ You can edit a pull request's details before approving it, or you can decline it
 
 To edit the pull request details:
 
-* Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> from the pull request's header bar.
-* Select **Edit**.
-* Make any changes to the pull request's title, description, and list of reviewers.
-* Select **Save Changes**.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> at the upper right and select **Edit**.
+1. Make any changes to the pull request's title, description, and list of reviewers.
+1. Select **Save Changes**.
 
 If you do not want to merge the pull request into the parent collection, you can decline it. Declined pull requests cannot be reopened, so if you want to request edits or offer feedback, [add a comment](#adding-comments) instead. To decline the pull request:
 
-* Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> from the pull request's header bar.
-* Select **Decline**, then select **Decline Pull Request**.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> at the upper right and select **Decline**.
+1. Select **Decline Pull Request**.
 
 ### Approving a pull request
 
@@ -315,6 +316,8 @@ You can keep your forked collections up to date with any changes in the parent, 
 ![Pull recent changes](https://assets.postman.com/postman-docs/pr-pull-changes-v9.12.jpg)
 
 ### Merging changes
+
+When you are ready to add the changes from a pull request or forked collection into the parent collection, you will _merge_ them into the parent collection.
 
 #### Merging changes from a pull request
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -207,7 +207,7 @@ To set merge checks for pull requests on a specific collection:
 
 <img alt="Merge Check" src="https://assets.postman.com/postman-docs/manage-roles-set-merge-checks.jpg" width="800px"/>
 
-If the merge conditions for a pull request are not met, the option to **Merge** will be disabled.
+If the merge conditions for a pull request are not met, the option to **Merge** it into the parent collection will be disabled.
 
 <img alt="Merge Disabled" src="https://assets.postman.com/postman-docs/view-merge-conditions-v9.12.jpg" width="300px"/>
 
@@ -217,21 +217,26 @@ Select **View Merge Conditions** to see the merge conditions to be met for the p
 
 ### Watching a pull request
 
-The watch option allows you to receive an in-app notification when one of your team member belonging to the same workspace modifies the pull request. If you watch a pull request, you will be notified of actions such as adding a new comment, approving or unapproving, merging, editing or declining a pull request, and so on.
+The watch option allows you to receive an in-app notification when a team member modifies the pull request. If you watch a pull request, you will be notified of actions such as adding a new comment, approving or unapproving, merging, and editing or declining a pull request.
 
-Once you've created the pull request, select __Watch__ to start watching the pull request.
+To watch a pull request:
 
-![Pull request watching](https://assets.postman.com/postman-docs/watching-a-pull-request-v9.jpg)
+1. Select **Watch**.
 
-Once you have enabled watch, you will be able to view and modify the conditions for which notifications will be triggered.
+<img alt="Watch a pull request" src="https://assets.postman.com/postman-docs/watching-a-pull-request-v9.12.jpg" width="300px"/>
 
-<img alt="Conditions for watch notifications" src="https://assets.postman.com/postman-docs/watching-conditions-notifications-v9.jpg" height="424px"/>
+To change your watching notification settings:
 
-Select the bell icon <img alt="Changelog icon" src="https://assets.postman.com/postman-docs/icon-notification-bell-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> in the top right corner of Postman to view the notification. The popup will indicate further information about the change that was made to the pull request.
+1. Select **Watching**.
+1. Select or unselect the desired notification options.
 
-<img alt="Notification Pull Request Watching" src="https://assets.postman.com/postman-docs/pull-request-watch-notification-v8.jpg" width="500px"/>
+<img alt="Conditions for watch notifications" src="https://assets.postman.com/postman-docs/watching-conditions-notifications-v9.jpg" width="350px"/>
 
-> If you created the pull request and modified it from the same account, you will not receive any notifications for changes made.
+To view notifications for a watched pull request:
+
+1. Select the bell icon <img alt="Changelog icon" src="https://assets.postman.com/postman-docs/icon-notification-bell-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> in the top right corner of Postman. The popup will indicate further information about the change that was made to the pull request.
+
+> If you create a pull request and modify it from the same account, you will not receive any notifications about changes made to the pull request.
 
 ## Approving changes
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -30,6 +30,8 @@ contextual_links:
 
 You can use version control with your Postman Collections by forking and merging and utilizing a standard pull request process. Version control allows you to collaborate with teammates by working on different forks of the same collection, updating forks from the parent collection, and merging changes when you're ready. You can tag collaborators to review pull requests and resolve conflicts to manage collection versions.
 
+> Version control for collections is different than  API versioning. For information on managing multiple versions of APIs, see [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/).
+
 * [Forking a collection](#forking-a-collection)
     * [Forking information](#forking-information)
     * [Forking to send requests](#forking-to-send-requests)

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -146,17 +146,17 @@ To create a pull request:
 
     <img alt="Create Pull Request" src="https://assets.postman.com/postman-docs/pull-request-overview.jpg" width="350px"/>
 
-The reviewers you selected will be notified about your pull request. You will receive a notification if the reviewers comment on your pull request, approve your pull request, or merge the pull request. <!-- TODO: add links to other sections -->
+The reviewers you selected will be notified about your pull request. You will receive a notification if the reviewers [comment on](#adding-comments), [approve](#approving-a-pull-request), or [merge](#merging-changes-from-a-pull-request) the pull request.
 
 ### Pull request permissions
 
-The pull request author and any users with [viewer or editor access](/docs/collaborating-in-postman/roles-and-permissions/) on the parent collection can do the following actions on a pull request:
+The pull request reviewers and any users with [viewer or editor access](/docs/collaborating-in-postman/roles-and-permissions/) on the parent collection can do the following actions on a pull request:
 
-* Update the title and description
-* Decline a pull request
-* Approve or unapprove a pull request
-* Merge a pull request
-* View or add pull request comments <!-- TODO: links to other sections -->
+* [Update the title and description](#editing-or-declining-a-pull-request)
+* [Decline a pull request](#editing-or-declining-a-pull-request)
+* [Approve or unapprove a pull request](#approving-a-pull-request)
+* [Merge a pull request](#merging-changes)
+* [View or add pull request comments](#adding-comments)
 
 ### Creating public pull requests
 
@@ -321,7 +321,9 @@ You can keep your forked collections up to date with any changes in the parent, 
 
 ![Pull recent changes](https://assets.postman.com/postman-docs/pr-pull-changes-v9.12.jpg)
 
-### Merging changes from a pull request
+### Merging changes
+
+#### Merging changes from a pull request
 
 After a pull request is reviewed, it is ready to be merged into the parent collection.
 
@@ -332,15 +334,15 @@ After a pull request is reviewed, it is ready to be merged into the parent colle
     > If the parent collection has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) before merging.
 
 1. Select one of the following merge options:
-    * **Merge changes**: 
-    * **Merge changes and update source**:
-    * **Merge changes and delete source**:
+    * **Merge changes**: Merge the changes into the parent collection. No changes are made to the forked collection. You must have editor access to the parent collection.
+    * **Merge changes and update source**: Merge the changes into the parent collection. Any differences in the parent collection are also made to the forked collection. You must have editor access to both the parent and forked collections.
+    * **Merge changes and delete source**: Merge the changes into the parent collection. After merging, the forked collection is deleted. You must have editor access to both the parent and forked collections.
 
     <img src="https://assets.postman.com/postman-docs/merge-fork-options-v9.12.jpg" alt="Merge Fork Options" width="400px"/>
 
 1. Select **Merge**.
 
-### Merging changes from a forked collection
+#### Merging changes from a forked collection
 
 If you have edit access to a collection, you can merge a fork into the parent collection without going through the [pull request process](#creating-pull-requests). For example, if you’re using forks in a personal workspace to organize your work, you can merge changes in a fork directly back into the parent collection. If you are collaborating with others, though, merging directly lacks the safeguards built into the pull request process, and many teams require pull requests as part of their version control workflow.
 
@@ -356,13 +358,18 @@ To merge changes from a fork without opening a pull request:
 
 ## Resolving conflicts
 
-If you encounter conflicts when you attempt to merge a forked collection, you will need to decide how you want to resolve them before continuing. A conflict will occur when you are attempting to merge changes into a request, folder, or example that has changed since you updated your fork.
+A merge conflict happens when you try to merge changes into a parent collection that has changed since you updated your fork and Postman cannot automatically resolve the differences between the two collections. If you encounter a conflict when you try to merge a forked collection, you will need to decide how you want to resolve them before continuing.
 
 > Merge conflicts can involve changes in multiple workspaces.
 
+To resolve a merge conflict:
+
+1. Look at the differences between the two collections. The **Source** line shows the changes on your fork, and the **Destination** line shows the changes on the parent collection.
+1. Select **Use this** next to the version you want to include when you merge.
+
 <img src="https://assets.postman.com/postman-docs/conflicts-pull-changes-v2.jpg" alt="Pull Changes" width="450px"/>
 
-The __Source__ will indicate the changes on your fork, with the __Destination__ representing the changes on the parent branch. Select __Use this__ next to the version you want to include when you merge. When conflicts are resolved, the __Pull changes__ button will be enabled and you can [pull updates](#pulling-updates).
+After you resolve the conflicts, the **Pull changes** button will be enabled and you can [pull updates](#pulling-updates).
 
 ## Next steps
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -34,7 +34,6 @@ You can use version control with your Postman Collections by forking and merging
 
 * [Forking a collection](#forking-a-collection)
     * [Forking information](#forking-information)
-    * [Forking to send requests](#forking-to-send-requests)
 * [Forking an environment](#forking-an-environment)
 * [Creating pull requests](#creating-pull-requests)
     * [Pull request settings](#pull-request-settings)
@@ -47,6 +46,8 @@ You can use version control with your Postman Collections by forking and merging
 * [Resolving conflicts](#resolving-conflicts)
 
 ## Forking a collection
+
+> If you are not a member of a public workspace, you will not be able to send a request from a collection within the workspace. To send requests or make changes to a collection, you must fork the collection into a personal workspace or a team workspace that you belong to.
 
 To fork a collection in Postman, select the collection in the __Collections__ sidebar. Select <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px">  to view more actions, then select __Create a fork__. To provide a uniform forking experience, you can create a fork in a public workspace in three steps — log in to Postman, fill up fork details, and enable your public profile.
 
@@ -71,22 +72,6 @@ Fork information provides details about forks and the users who have created the
 [![Fork Information](https://assets.postman.com/postman-docs/fork-information-count.jpg)](https://assets.postman.com/postman-docs/fork-information-count.jpg)
 
 > You can select a user under __Forked by__ to view their public profile.
-
-### Forking to send requests
-
-If you are a visitor who does not belong to any public workspace, to send requests from a collection in a public workspace, log in to Postman with your credentials. Select __Sign in__.
-
-[![Visitor accessing public workspace](https://assets.postman.com/postman-docs/visitor-public-workspace.jpg)](https://assets.postman.com/postman-docs/visitor-public-workspace.jpg)
-
-Postman will prompt a login screen, you can either create a free account or sign in to get started.
-
-<img src="https://assets.postman.com/postman-docs/sign-in-v2.jpg" alt="Visitor Sign in" height="400px"/>
-
-Being a signed-in non-member, to send requests in a public workspace, fork the collection into a workspace that you belong to (either team or personal whichever you choose during fork creation) and then make changes.
-
-<img src="https://assets.postman.com/postman-docs/visitor-fork-collection-v2.jpg" alt="Visitor creating a fork" height="400px"/>
-
-> Make sure your public profile is enabled before you fork a collection from a public workspace.
 
 ## Forking an environment
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -246,21 +246,25 @@ To view notifications for a watched pull request:
 
 If you're tagged as a reviewer on a pull request, you can view the changes, comment, approve or decline the request, and merge the forked collection into the parent collection when you are ready.
 
-You can see a list of pull request for any collection under the **Pull Requests** tab on the right panel in Postman.
+To see the list of pull requests for a collection:
 
-<img src="https://assets.postman.com/postman-docs/open-pull-request-list-v2.jpg" alt="Open Pull Request" width="350px"/>
+1. Navigate to the collection and select the **Pull Requests** icon <img alt="Pull request icon" src="https://assets.postman.com/postman-docs/icon-pull-request.jpg" width="16px" style="vertical-align:middle;margin-bottom:5px"> on the context menu.
 
-Each pull request includes status, which will be `OPEN` for any that have not been merged or declined.
+<img src="https://assets.postman.com/postman-docs/open-pull-request-list-v9.12.jpg" alt="Pull request list" width="350px"/>
+
+Each item shows the pull request's status, which will be `OPEN` for any that have not been merged or declined. Click on a pull request's name to open it.
 
 ### Viewing the diff
 
-When you merge changes from a fork into its parent collection, you have a chance to review the difference between them, known as the _diff_, first. The diff navigation view enables you to review the changes made to a collection. The nested folder structure shows the requests present within the folders and improves navigation while working with forks and pull requests.
+When you merge changes from a fork into its parent collection, you have a chance to review the difference between them, known as the _diff_, first.
 
-To view the diff in a pull request:
+If you are [opening a new pull request](#creating-pull-requests), view the diff by selecting the **Changes** tab.
 
-1. Select the __Changes__ tab.
+<img alt="View diff when creating pull request" src="https://assets.postman.com/postman-docs/pull-request-create-view-diff-v9.12.jpg" width="300px"/>
 
-![Diff Navigation](https://assets.postman.com/postman-docs/diff-navigation-v2.jpg) <!-- TODO: update image -->
+If you are reviewing a pull request, view the diff under the **Changes** heading.
+
+<img alt="View diff when reviewing pull request" src="https://assets.postman.com/postman-docs/pull-request-review-view-diff-v9.12.jpg" width="450px"/>
 
 ### Adding comments
 
@@ -268,7 +272,7 @@ Adding comments as a reviewer is an important part of the pull request process, 
 
 To add a comment to a pull request:
 
-1. Select the comment icon <img alt="Changelog icon" src="https://assets.postman.com/postman-docs/icon-comments-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the change in the diff that you want to comment on.
+1. Select the comment icon <img alt="Changelog icon" src="https://assets.postman.com/postman-docs/icon-comments-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the change that you want to comment on.
 1. Once you've written your comment, select **Add Comment**.
 
 <img alt="Add a comment to a pull review" src="https://assets.postman.com/postman-docs/pr-add-comment-v9.12.jpg" width="450px"/>
@@ -288,24 +292,25 @@ To edit the pull request details:
 * Make your changes to the pull request's title, description, and list of reviewers.
 * Select **Save Changes**.
 
-If you do not want to merge the pull request into the parent collection, you can decline it. Declined pull requests cannot be reopened, so if you want to request edits or feedback, add a comment instead. To decline the pull request:
+If you do not want to merge the pull request into the parent collection, you can decline it. Declined pull requests cannot be reopened, so if you want to request edits or offer feedback, [add a comment](#adding-comments) instead. To decline the pull request:
 
 * Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> from the pull request's header bar.
 * Select **Decline**, then select **Decline Pull Request**.
 
 ### Approving a pull request
 
-If you're tagged as a reviewer on a pull request, you can approve the pull request.
+If you're tagged as a reviewer on a pull request you can approve the pull request.
 
 To approve a pull request:
 
-1. Navigate to the collection and select the **Pull Requests** icon <img alt="Pull request icon" src="https://assets.postman.com/postman-docs/icon-pull-request.jpg" width="16px" style="vertical-align:middle;margin-bottom:5px"> on the context menu.
+1. Select **Approve**.
+1. The button text now says **Unapprove**. If you need to revoke your approval, select the button again.
 
-<img src="https://assets.postman.com/postman-docs/status-pull-request-v2.jpg" alt="Status Pull Request"/> <!-- TODO: update -->
+<img alt="Approve a pull request" src="https://assets.postman.com/postman-docs/pull-request-approve-v9.12.jpg" width="300px"/>
 
-Upon approval, you will see the status of the pull request as **Approved**.
+After the pull request has been approved, you will see the status of the pull request as **Approved** in the collection's list of pull requests.
 
-<img src="https://assets.postman.com/postman-docs/approve-fork-v2.jpg" alt="Approve Fork"/>
+<img src="https://assets.postman.com/postman-docs/pull-request-list-approved-v9.12.jpg" alt="Approved pull request" width="350px"/>
 
 ### Viewing pull request details
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -3,6 +3,7 @@ title: "Using version control"
 order: 75
 page_id: "version_control_for_collections"
 warning: false
+updated: 2022-02-15
 contextual_links:
   - type: section
     name: "Prerequisites"

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -48,7 +48,7 @@ You can use version control with your Postman Collections by forking and merging
 
 ## Forking Postman elements
 
-You can fork Postman collections and environments. <!-- TODO: flesh this out a bit -->
+You can fork Postman collections and environments. <!-- TODO: flesh this out a bit and how it relates to version control -->
 
 ### Forking a collection
 
@@ -90,15 +90,21 @@ Select **View all forks** to reveal the detailed list of forks along with inform
 
 ### Viewing fork information
 
-To fork a collection within a public workspace, you must enable your public profile. Navigate to your [profile settings](https://go.postman.co/settings/me). Select your avatar in the upper-right corner > **Account Settings**. Select the toggle next to **Make profile public**, then **Update Profile**.
+Fork information provides details about forks and the users who have created them. You will be able to identify the users who are actively consuming and contributing to your APIs.
 
-<img alt="Make profile public" src="https://assets.postman.com/postman-docs/make-profile-public-v9.jpg">
+To see the list of users who have forked the collection:
 
-Fork information provides details about forks and the users who have created them. You will be able to identify the users who are actively consuming and contributing to your APIs. Select the fork count to reveal the list of users who have active forks.
+1. Select the number next to the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg" width="14px" style="vertical-align:middle;margin-bottom:5px"> to reveal the list of users who have active forks.
 
-[![Fork Information](https://assets.postman.com/postman-docs/fork-information-count.jpg)](https://assets.postman.com/postman-docs/fork-information-count.jpg)
+    <img alt="View the fork information count" src="https://assets.postman.com/postman-docs/fork-information-count-v9.12.jpg" width="400px"/>
 
-> You can select a user under __Forked by__ to view their public profile.
+To see the list of forks for a collection:
+
+1. Select the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg" width="14px" style="vertical-align:middle;margin-bottom:5px"> from the context menu.
+1. Select the fork name under **Forks**.
+1. You can also select the user's avatar under **Forks** to view the user's public profile.
+
+    <img alt="View the list of forks" src="https://assets.postman.com/postman-docs/fork-information-list-v9.12.jpg" width="350px"/>
 
 ## Creating pull requests
 

--- a/src/pages/docs/sending-requests/intro-to-collections.md
+++ b/src/pages/docs/sending-requests/intro-to-collections.md
@@ -214,7 +214,7 @@ To view notifications about what has changed in a collection you watch:
 
 1. You will also receive an email with the information regarding who made the change, what the change was, and when it was made. Select **View changelog** in the email to access the full changelog in Postman.
 
-> If you create a collection and modify it from the same account, you will not receive notifications for any changes you make to that collection.
+> If you create a collection and modify it from the same Postman account, you will not receive notifications for any changes you make to that collection.
 
 ### Forking a collection
 

--- a/src/pages/docs/sending-requests/intro-to-collections.md
+++ b/src/pages/docs/sending-requests/intro-to-collections.md
@@ -54,6 +54,7 @@ Select **Collections** in the left sidebar of Postman to see the list of collect
     * [Deleting a collection](#deleting-a-collection)
     * [Recovering a deleted collection](#recovering-a-deleted-collection)
     * [Sharing a collection](#sharing-a-collection)
+    * [Watching a collection](#watching-a-collection)
     * [Forking a collection](#forking-a-collection)
     * [Adding comments to a collection](#adding-comments-to-a-collection)
     * [Reverting collection changes](#reverting-collection-changes)
@@ -194,6 +195,26 @@ To share your collections with other users, you can:
 * Publish a [Run in Postman](/docs/publishing-your-api/run-in-postman/creating-run-button/) button.
 * Invite others to collaborate by selecting the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name, then selecting **Share**. Learn more about [sharing elements in Postman](/docs/collaborating-in-postman/sharing/#sharing-postman-entities).
 * Move the collection to a shared workspace by selecting the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name, then selecting **Move**. Learn more about [moving Postman elements](/docs/collaborating-in-postman/sharing/#moving-postman-entities-to-collaborative-workspaces).
+
+### Watching a collection
+
+When you watch a collection, Postman notifies you when a workspace team member makes changes to the collection, including adding a new request, modifying the existing requests, adding or updating variables, editing pre-request scripts or tests, and adding or deleting a folder. You can watch a collection that you own, as well as collections in any public workspace.
+
+To watch a collection:
+
+1. Select the watch icon <img alt="External link icon" src="https://assets.postman.com/postman-docs/eye.jpg" width="24px" style="vertical-align:middle;margin-bottom:5px"> to start watching the collection.
+
+![Collection watching](https://assets.postman.com/postman-docs/collection-watching-overview-v9.12.jpg)
+
+To view notifications about what has changed in a collection you watch:
+
+1. Select the bell icon <img alt="Changelog icon" src="https://assets.postman.com/postman-docs/icon-notification-bell-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> in the top right corner of Postman to view the notification. Select **View changelog** to view the collection's changelog.
+
+    <img alt="Notification Collection Watching" src="https://assets.postman.com/postman-docs/collection-watch-notification-v9.jpg" width="500px"/>
+
+1. You will also receive an email with the information regarding who made the change, what the change was, and when it was made. Select **View changelog** in the email to access the full changelog in Postman.
+
+> If you create a collection and modify it from the same account, you will not receive notifications for any changes you make to that collection.
 
 ### Forking a collection
 


### PR DESCRIPTION
- Updates screenshots
- Reorganizes content 
- Reformats instructions into numbered lists

(Follow-up work is necessary for the [Resolving conflicts](https://learning.postman.com/docs/collaborating-in-postman/version-control-for-collections/#resolving-conflicts) section and to document the use of **Refresh**, new ticket is TW 371)