### PR TITLE
Modify the installation docs to stop mentioning about any sudo privileges

### DIFF
--- a/src/pages/docs/getting-started/installation-and-updates.md
+++ b/src/pages/docs/getting-started/installation-and-updates.md
@@ -234,6 +234,9 @@ Open the DevTools using __View__ &gt; __Developer__ &gt; __Show DevTools (Curren
 
 ![Multiple Updates Running Issue in DevTools](https://assets.postman.com/postman-docs/multiple-updates-running.png)
 
+* __Error message:__ `EACCES: permission denied, open '/opt/Postman/Postman-1620288011421.tar.gz`
+    * This error means that the app user does not have write permission in the directory where Postman is installed. To resolve the problem, move Postman to a directory where the user has write permissions, for example the `home` directory for Linux.
+
 ### Update button not available
 
 If you are using Postman for Linux, and installed the app with the Ubuntu Software Center or Snap Store, you may not see a __Check for updates__ button. This is because the updates are handled by the store, which should automatically update Postman on a regular cadence.

--- a/src/pages/docs/getting-started/installation-and-updates.md
+++ b/src/pages/docs/getting-started/installation-and-updates.md
@@ -84,7 +84,7 @@ Postman is available for Windows 7 and later.
 
 You can install Postman on Linux by manually downloading it, using the [Snap](https://snapcraft.io/postman) store link, or with the command `snap install postman`.
 
-To install manually, [download](https://www.postman.com/downloads/) and unzip the app, for example into the `opt` directory. You will need `sudo` privileges.
+To install manually, [download](https://www.postman.com/downloads/) and unzip the app, for example into the `Downloads` directory.
 
 To start the app from a launcher icon, create a desktop file, naming it `Postman.desktop` and saving it in the following location:
 
@@ -92,14 +92,14 @@ To start the app from a launcher icon, create a desktop file, naming it `Postman
 ~/.local/share/applications/Postman.desktop
 ```
 
-Enter the following content in the file, replacing `opt` if you extracted the file somewhere else, and save it:
+Enter the following content in the file, replacing `/path/to/Downloads` if you extracted the file somewhere else, and save it:
 
 ```shell
 [Desktop Entry]
 Encoding=UTF-8
 Name=Postman
-Exec=/opt/Postman/app/Postman %U
-Icon=/opt/Postman/app/resources/app/assets/icon.png
+Exec=/path/to/Downloads/Postman/app/Postman %U
+Icon=/path/to/Downloads/Postman/app/resources/app/assets/icon.png
 Terminal=false
 Type=Application
 Categories=Development;

--- a/src/pages/docs/getting-started/installation-and-updates.md
+++ b/src/pages/docs/getting-started/installation-and-updates.md
@@ -222,17 +222,15 @@ If you see an __Update Failed__ notification in Postman, you can use the DevTool
 
 ![update-error-dialog](https://assets.postman.com/postman-docs/update-error-dialog.png)
 
-Open the DevTools using __View__ &gt; __Developer__ &gt; __Show DevTools (Current View)__. Some known errors are as follows:
+Open the DevTools using __View__ &gt; __Developer__ &gt; __Show DevTools (Current View)__.
+
+Some known errors are as follows:
 
 * __Error message:__ `Cannot update while running on a read-only volume`
     * This error means that the app user does not have write permission in the directory where Postman is installed. To resolve the problem, move Postman to a directory where the user has write permissions, for example the `/Application` directory for Mac, and to the `home` directory for Linux.
 
-![Write Permission Issue in DevTools](https://assets.postman.com/postman-docs/write-permission-issue.png)
-
 * __Error message:__ `Code signature at URL file:///... did not pass validation: code object is not signed at all`
     * This error means that there are multiple updates running at the same time. This can happen when the app is opened before the previous update could finish. To resolve the problem, quit and reopen the app.
-
-![Multiple Updates Running Issue in DevTools](https://assets.postman.com/postman-docs/multiple-updates-running.png)
 
 * __Error message:__ `EACCES: permission denied, open '/opt/Postman/Postman-1620288011421.tar.gz`
     * This error means that the app user does not have write permission in the directory where Postman is installed. To resolve the problem, move Postman to a directory where the user has write permissions, for example the `home` directory for Linux.

--- a/src/pages/docs/getting-started/installation-and-updates.md
+++ b/src/pages/docs/getting-started/installation-and-updates.md
@@ -92,7 +92,7 @@ To start the app from a launcher icon, create a desktop file, naming it `Postman
 ~/.local/share/applications/Postman.desktop
 ```
 
-Enter the following content in the file, replacing `/path/to/Downloads` if you extracted the file somewhere else, and save it:
+Enter the following content in the file, replacing `/path/to/Downloads` with the location of the file, and save it:
 
 ```shell
 [Desktop Entry]


### PR DESCRIPTION
Postman Linux application doesn't require any special privilege to launch the application on the Linux platform. The example shared on the installation docs might make users think that a sudo privilege is needed to run the postman application. The example mentioned should be very simple where the user generally ends up downloading the application and extract it inside the `Downloads` directory