### PR TITLE
TW 386 Update instructions for Scratch Pad export

### DIFF
--- a/src/pages/docs/getting-started/importing-and-exporting-data.md
+++ b/src/pages/docs/getting-started/importing-and-exporting-data.md
@@ -2,7 +2,7 @@
 title: 'Importing and exporting data'
 order: 8.2
 page_id: 'importing_and_exporting_data'
-updated: 2022-2-16
+updated: 2022-03-01
 contextual_links:
   - type: section
     name: "Additional Resources"

--- a/src/pages/docs/getting-started/importing-and-exporting-data.md
+++ b/src/pages/docs/getting-started/importing-and-exporting-data.md
@@ -16,7 +16,7 @@ contextual_links:
     url: "https://youtu.be/gljWt9tDKOY"
   - type: link
     name: "Postman Level Up | Import a HAR file in Postman"
-    url: "https://youtu.be/E3uo-oQ9WtE"    
+    url: "https://youtu.be/E3uo-oQ9WtE"
   - type: subtitle
     name: "Related Blog Posts"
   - type: link
@@ -237,6 +237,8 @@ The [Export page](http://go.postman.co/me/export) shows information about your e
 * **Download**: The zipped file is ready to be downloaded.
 
 When the export is ready, you will receive an email with link to download a zipped file with the data dump. You can also download the file using the **Download** button on the Export page.
+
+> Data exports from the Scratch Pad are downloaded directly instead of being emailed to you. See [Exporting data from the Scratch Pad](/docs/getting-started/using-scratch-pad/#exporting-data-from-the-scratch-pad) for more details.
 
 ## Next steps
 

--- a/src/pages/docs/getting-started/using-scratch-pad.md
+++ b/src/pages/docs/getting-started/using-scratch-pad.md
@@ -41,22 +41,22 @@ To leave the Scratch Pad:
 
 ## Exporting data from the Scratch Pad
 
-When you leave the Scratch Pad, your data remains there; you won't see it in your workspace. But you can export the data from the Scratch Pad, then import it to a workspace.
+When you leave the Scratch Pad, your data remains there; you won't see it in your workspace. But you can export the data from the Scratch Pad as JSON, then import it to a workspace.
 
-To export all Scratch Pad data:
+To export saved Scratch Pad data:
 
 1. Go to the Scratch Pad.
 1. Select the gear icon in the upper-right corner to open **Settings**, and select the **Data** tab.
 1. Click **Export Data**.
-1. This opens the **Export data** page in your web browser. Click **Export Data**.
-1. Select **Collections**, **Environments**, or both, and select **Request Data Export**.
-1. You'll get an email with a link to download the data dump, which is a single JSON file containing your data.
+1. In the save dialog, choose a directory in which to save the file, then select **Save**.
 
-You can also export a single collection or an environment. For more information, see [Exporting Postman data](/docs/getting-started/importing-and-exporting-data/#exporting-postman-data)
+You can also export a single collection or an environment. For more information, see [Exporting Postman data](/docs/getting-started/importing-and-exporting-data/#exporting-postman-data).
 
-To import Scratch Pad data:
+## Importing data from the Scratch Pad
 
-1. Log in and switch to a workspace using the **Workspaces** menu at the top of Postman. For more information, see [Using and managing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/)
+When you log back in to Postman, you can import your Scratch Pad data:
+
+1. Log in and switch to a workspace using the **Workspaces** menu at the top of Postman. For more information, see [Using and managing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/).
 1. Click **Import** in the upper-left corner.
 1. Drag and drop your exported data dump, collection, or environment and click **Import**.
 

--- a/src/pages/docs/getting-started/using-scratch-pad.md
+++ b/src/pages/docs/getting-started/using-scratch-pad.md
@@ -15,7 +15,7 @@ If you're logged out or your connection to Postman is broken, you'll see a globa
 
 <img alt="Scratch Pad global banner" src="https://assets.postman.com/postman-docs/scratch-pad-notice.jpg" width="350px" />
 
-If you are logged in and want to go to the Scratch Pad, click the gear icon to the right side of the header toolbar and select **Scratch Pad**.
+If you are logged in and want to go to the Scratch Pad, select the gear icon <img alt="Settings icon" src="https://assets.postman.com/postman-docs/icon-gear-outline-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> to the right side of the header toolbar and select **Scratch Pad**.
 
 <img alt="Enter Scratch Pad" src="https://assets.postman.com/postman-docs/scratch-pad-enter.jpg" width="200px" />
 
@@ -47,8 +47,8 @@ To export saved Scratch Pad data:
 
 1. Go to the Scratch Pad.
 1. Select the gear icon in the upper-right corner to open **Settings**, and select the **Data** tab.
-1. Click **Export Data**.
-1. In the save dialog, choose a directory in which to save the file, then select **Save**.
+1. Select **Export Data**.
+1. Choose a directory in which to save the file, then select **Save**.
 
 You can also export a single collection or an environment. For more information, see [Exporting Postman data](/docs/getting-started/importing-and-exporting-data/#exporting-postman-data).
 
@@ -57,7 +57,7 @@ You can also export a single collection or an environment. For more information,
 When you log back in to Postman, you can import your Scratch Pad data:
 
 1. Log in and switch to a workspace using the **Workspaces** menu at the top of Postman. For more information, see [Using and managing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/).
-1. Click **Import** in the upper-left corner.
-1. Drag and drop your exported data dump, collection, or environment and click **Import**.
+1. Select **Import** in the upper-left corner.
+1. Drag and drop your exported data dump, collection, or environment and select **Import**.
 
 For more information on importing, see [Importing data into Postman](/docs/getting-started/importing-and-exporting-data/#importing-data-into-postman).

--- a/src/pages/docs/getting-started/using-scratch-pad.md
+++ b/src/pages/docs/getting-started/using-scratch-pad.md
@@ -2,6 +2,7 @@
 title: "Using the Scratch Pad"
 order: 7.1
 page_id: "using-the-scratch-pad"
+updated: 2022-03-01
 warning: false
 ---
 


### PR DESCRIPTION
* Updates instructions for exporting Scratch Pad data - since users are logged out, data dumps are downloaded directly rather than being emailed to them. 