### PR TITLE
TW 84 Use allowlist

### DIFF
--- a/src/pages/docs/integrations/available-integrations/github.md
+++ b/src/pages/docs/integrations/available-integrations/github.md
@@ -102,13 +102,13 @@ Backing up collection to GitHub with a custom domain name is similar to the abov
 
 ### Static IP Support
 
-If your network is behind a firewall that requires whitelisted IP addresses, you will need to use a static IP address to enable collection backups to GitHub on custom domains.
+If your network is behind a firewall that requires IP addresses from an allowlist, you will need to use a static IP address to enable collection backups to GitHub on custom domains.
 
-Contact your IT team to whitelist the following static IP in your firewall to enable collection backups to GitHub:
+Contact your IT team to allowlist the following static IP in your firewall to enable collection backups to GitHub:
 
 * US East: `3.212.102.200`
 
-Once you whitelist this IP address, calls for this integration will be able to connect to your network and allow the integration to work as expected.
+Once you allowlist this IP address, calls for this integration will be able to connect to your network and allow the integration to work as expected.
 
 ## Syncing your API schemas on GitHub
 

--- a/src/pages/docs/integrations/intro-integrations.md
+++ b/src/pages/docs/integrations/intro-integrations.md
@@ -45,13 +45,13 @@ Select __Add Integration__ to configure your integration. Enter the required inf
 
 ## Static IP support
 
-You can use static IP addresses to enable integrations and custom webhooks for Postman Collection backups that need to access hosted (private) networks behind firewalls that require whitelisted IP addresses.
+You can use static IP addresses to enable integrations and custom webhooks for Postman Collection backups that need to access hosted (private) networks behind firewalls that require IP addresses from an allowlist.
 
-Contact your IT team to whitelist the following static IP in your firewall to enable collection backup integrations and webhooks:
+Contact your IT team to allowlist the following static IP in your firewall to enable collection backup integrations and webhooks:
 
 * US East: `3.212.102.200`
 
-Once you whitelist this IP address, calls for the integrations and webhooks will be able to connect to your network and allow the integrations and webhooks to work as expected.
+Once you allowlist this IP address, calls for the integrations and webhooks will be able to connect to your network and allow the integrations and webhooks to work as expected.
 
 > DNS records should use the public IP address for instances which are behind a firewall or not accessible via the internet.
 

--- a/src/pages/docs/integrations/webhooks.md
+++ b/src/pages/docs/integrations/webhooks.md
@@ -37,13 +37,13 @@ You can configure a custom webhook with Postman to send events such as monitor r
 
 ## Static IP Support
 
-If your network is behind a firewall that requires whitelisted IP addresses, you will need to use a static IP address to enable collection backups to custom webhooks on custom domains.
+If your network is behind a firewall that requires IP addresses from an allowlist, you will need to use a static IP address to enable collection backups to custom webhooks on custom domains.
 
-Contact your IT team to whitelist the following static IP in your firewall to enable collection backups to webhooks:
+Contact your IT team to allowlist the following static IP in your firewall to enable collection backups to webhooks:
 
 * US East: `3.212.102.200`
 
-Once you whitelist this IP address, calls for the custom webhook will be able to connect to your network and allow the webhook to work as expected.
+Once you allowlist this IP address, calls for the custom webhook will be able to connect to your network and allow the webhook to work as expected.
 
 ## Configuring custom webhook URL
 

--- a/src/pages/docs/sending-requests/cookies.md
+++ b/src/pages/docs/sending-requests/cookies.md
@@ -90,9 +90,9 @@ To delete a domain and all cookies associated with it, select **X** next to the 
 
 You can also add or edit the cookies in a response with the [Set-Cookie header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie).
 
-## Whitelisting domains for programmatic access of cookies
+## Allowlisting domains for programmatic access of cookies
 
-Adding a domain to the whitelist allows cookies for that domain to be accessed in scripts. To whitelist a domain, select the **Cookies** link under the **Send** button and open the **Manage Cookies** dialog. Select **Whitelist Domains** in the bottom left and enter the list of domains to be whitelisted.
+Adding a domain to the allowlist allows cookies for that domain to be accessed in scripts. To allowlist a domain, select the **Cookies** link under the **Send** button and open the **Manage Cookies** dialog. Select **Whitelist Domains** in the bottom left and enter the list of domains to be allowlisted.
 
 ## Programmatic access of cookies
 

--- a/src/pages/docs/writing-scripts/script-references/postman-sandbox-api-reference.md
+++ b/src/pages/docs/writing-scripts/script-references/postman-sandbox-api-reference.md
@@ -509,7 +509,7 @@ pm.cookies.toObject():Function → Object
 
 You can also use `pm.cookies.jar` to specify a domain for access to request cookies.
 
-To enable programmatic access via the `pm.cookies.jar` methods, first [whitelist](/docs/sending-requests/cookies/) the cookie URL.
+To enable programmatic access via the `pm.cookies.jar` methods, first add the cookie URL to the [allowlist](/docs/sending-requests/cookies/).
 
 * Access the cookie jar object:
 


### PR DESCRIPTION
Based on the precedent set in TW-306, I used `allowlist` as a drop-in replacement for `whitelist`. There's [one remaining instance](https://github.com/postmanlabs/postman-docs/compare/tw-84-allowlist?expand=1#diff-e9b299aa8f1d236d9686af8300c111cca1173b23f75a5cd9d64d741a006862c9R95) that reflects the term's use in the Postman UI.  