### PR TITLE
[MARKENG-1293] Fixed scroll issue when navigation to previous page

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -7,7 +7,7 @@ import './styles/config/print.css'
 import $ from 'jquery';
 import 'jquery.scrollto';
 
-export const onClientEntry = () => {
+export function onClientEntry(){
   if (!window.location.hash) {
     window.scrollTo(0, 0);
   } else {
@@ -19,3 +19,12 @@ export const onClientEntry = () => {
     }, 1000)
   }
 }
+// Scroll to top of page if user revisits page
+export function shouldUpdateScroll({ routerProps: { location } }) {
+  const { pathname } = location;
+  if (pathname && !window.location.hash) {
+    window.scrollTo(0, 0);
+  }
+  return false;
+}
+


### PR DESCRIPTION
This fixes the issue when a navigation to a previous page. Page will begin at the top instead of remembering previous scroll position.

To test:
- Navigate to any doc page and scroll all the way down
- Click any page
- Click <- icon in the browser and page should start at the top