### PR TITLE
refactored Breadcrumbs to use <ol> making it more accessible and semantic

### DIFF
--- a/src/components/modules/BreadCrumbsLinks.jsx
+++ b/src/components/modules/BreadCrumbsLinks.jsx
@@ -42,22 +42,30 @@ class BreadCrumbsLinks extends React.Component {
   render() {
     const { parentLink, subParentLink } = this.state;
     return (
-      <nav className="breadcrumb-wrapper" aria-label="You are here:">
-        <div  className="mb-3">
-          <a href="/" className="small breadcrumb-home-link">Home</a>
-          <span className="small"> / </span>
+      <nav className="breadcrumb-wrapper mb-3" aria-label="breadcrumbs">
+        <ol className="lc-breadcrumbs">
+          <li>
+            <a href="/" className="small breadcrumb-home-link" title="Learning Center">Home</a>
+            <span className="small" aria-hidden="true"> / </span>
+          </li>
           {JSON.stringify(subParentLink) !== '{}' ? (
             <>
-            <a href={parentLink.url} className="small breadcrumb-parent-link">{parentLink.name}</a>
-            <span className="small"> / </span>
+            <li>
+              <a href={parentLink.url} className="small breadcrumb-parent-link">{parentLink.name}</a>
+              <span className="small" aria-hidden="true"> / </span>
+            </li>
+            <li>
               <a href={subParentLink.slug} className="small breadcrumb-subparent-link">{subParentLink.name}</a>
+            </li>
             </>
           ) : (
-              <>
-            <a href={parentLink.url} className="small breadcrumb-parent-link">{parentLink.name}</a>
-          </>
+            <>
+            <li>
+              <a href={parentLink.url} className="small breadcrumb-parent-link">{parentLink.name}</a>
+            </li>
+            </>
           )}
-        </div>
+        </ol>
       </nav>
     )
   }

--- a/src/components/modules/BreadCrumbsLinks.scss
+++ b/src/components/modules/BreadCrumbsLinks.scss
@@ -15,3 +15,11 @@
         border-bottom: 1px solid;
     }
 }
+ol.lc-breadcrumbs {
+    margin: 0;
+    li {
+        list-style-type: none;
+        display: inline;
+        padding-left: 0;
+    }
+}

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -74,7 +74,7 @@ h2, h3, h4 {
 
   ol {
     li {
-      padding-left: 10px !important;
+      padding-left: 10px;
       margin-bottom: 8px;
     }
     li::marker {


### PR DESCRIPTION
* refactored how we build the breadcrumb to use <ol>, which is preferred for a11y to show hierarchy
* applying `aria-hidden` to separators to hide from screenreaders
* added `title` to "Home" link to explore how this affects the SEO preview card on LinkedIn (which currently prints "Home" instead of "Learning Center")
<img width="305" alt="Screen Shot 2022-03-17 at 10 48 53" src="https://user-images.githubusercontent.com/4358288/158864203-cbf86b0b-b8be-401f-bbd2-be179f363aa0.png">

