### PR TITLE
added #icon to add CSS hook for inline icons

### DIFF
--- a/src/pages/docs/administration/managing-your-team/user-groups.md
+++ b/src/pages/docs/administration/managing-your-team/user-groups.md
@@ -94,7 +94,7 @@ Select the team roles you would like to assign to the group, or deselect team ro
 
 You can control a group's access to individual workspaces, collections, APIs, environments, mock servers, and monitors. For more information on managing workspaces, see [Sharing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#sharing-workspaces).
 
-For collections, APIs, environments, mock servers, and monitors, navigate to the entity in Postman. In the left sidebar, select <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> to view more actions, then select **Manage roles**.
+For collections, APIs, environments, mock servers, and monitors, navigate to the entity in Postman. In the left sidebar, select <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg#icon" width="18px"> to view more actions, then select **Manage roles**.
 
 <img alt="Invite group to collection" src="https://assets.postman.com/postman-docs/manage-roles-collection-with-user-group-v9.1.jpg"/>
 

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -23,6 +23,9 @@ h2, h3, h4 {
     height: auto;
     image-rendering: -webkit-optimize-contrast;
   }
+  img[src$='#icon'] {
+    margin-bottom: 0;
+  }
 
   // WIP - need to get ul li markers to move away from text
   ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* Adding support support for appending inline icons with `#icon` as a CSS hook to help style them to be more inline with text.
* updated one page's icon to show as an example.
<img width="897" alt="Screen Shot 2022-03-22 at 14 46 36" src="https://user-images.githubusercontent.com/4358288/159581641-2643f909-116a-4935-9589-74e33614bdf9.png">

