### PR TITLE
Updated print.css styles to target #icon and keep them from becoming block-level

### DIFF
--- a/styles/config/print.css
+++ b/styles/config/print.css
@@ -111,6 +111,12 @@
         height: auto;
         display: block;
     }
+    img[src$='#icon'] {
+        margin-bottom: 0;
+        display: inline;
+        width: 18pt;
+        height: auto;
+      }
         
     /* Adding custom messages before and after the content */
     .entry:after {


### PR DESCRIPTION
* icons would blow up to block-level size on print 
* targeting #icon, we can now keep them inline and 18pt width

BEFORE:
<img width="1005" alt="Screen Shot 2022-03-22 at 16 22 19" src="https://user-images.githubusercontent.com/4358288/159592695-7341a7de-0b3d-4543-ba1c-f10b5078e8af.png">

AFTER:
<img width="1005" alt="Screen Shot 2022-03-22 at 16 25 03" src="https://user-images.githubusercontent.com/4358288/159592699-83a0f4c2-58f4-4d42-a852-a1ecb81faa73.png">

