### PR TITLE
[TW-341] Updates for Environment Merging and PRs

### DIFF
--- a/src/pages/docs/collaborating-in-postman/public-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/public-workspaces.md
@@ -154,7 +154,7 @@ Select **X** next to the team member you want to remove from the public workspac
 
 To collaborate on entities within a public workspace, open the workspace menu and select the workspace.
 
-For collections and environments, [create a fork](/docs/collaborating-in-postman/version-control-for-collections/#forking-a-collection) and request to merge changes using a [pull request](/docs/collaborating-in-postman/version-control-for-collections/#creating-pull-requests).
+For collections and environments, [create a fork](/docs/collaborating-in-postman/version-control-for-collections/#creating-a-fork) and request to merge changes using a [pull request](/docs/collaborating-in-postman/version-control-for-collections/#creating-pull-requests).
 
 For APIs, navigate to the API and version. Select **Definition** > **Request Access** to request an editor role.
 

--- a/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
+++ b/src/pages/docs/collaborating-in-postman/version-control-for-collections.md
@@ -3,7 +3,7 @@ title: "Using version control"
 order: 75
 page_id: "version_control_for_collections"
 warning: false
-updated: 2022-02-17
+updated: 2022-03-23
 contextual_links:
   - type: section
     name: "Prerequisites"
@@ -29,13 +29,12 @@ contextual_links:
     url: "/docs/designing-and-developing-your-api/versioning-an-api/"
 ---
 
-Postman's version control features provide a way for you and your team to collaboratively build an API. You can fork a collection, make updates to the fork, create a pull request, and merge your changes into the parent collection.
+Postman's version control features provide a way for you and your team to collaboratively build an API. You can fork a collection or environment, make updates to the fork, create a pull request, and merge your changes into the parent entity.
 
-> Version control for collections is different from API versioning. For information on managing multiple versions of APIs, see [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/).
+> Version control for collections and environments is different from API versioning. For information on managing multiple versions of APIs, see [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/).
 
-* [Forking Postman elements](#forking-postman-elements)
-    * [Forking a collection](#forking-a-collection)
-    * [Forking an environment](#forking-an-environment)
+* [Forking Postman entities](#forking-postman-entities)
+    * [Creating a fork](#creating-a-fork)
     * [Viewing fork information](#viewing-fork-information)
 * [Creating pull requests](#creating-pull-requests)
     * [Creating public pull requests](#creating-public-pull-requests)
@@ -50,69 +49,48 @@ Postman's version control features provide a way for you and your team to collab
     * [Merging changes](#merging-changes)
 * [Resolving conflicts](#resolving-conflicts)
 
-## Forking Postman elements
+## Forking Postman entities
 
-A _fork_ is a new instance of an element that you can modify without making any changes to the parent element. In Postman, you can fork [collections](#forking-a-collection) and [environments](#forking-an-environment). Forking also enables you to contribute to a collection or an environment without having Editor access to that element.
+A _fork_ is a new instance of an element that you can modify without making any changes to the parent element. In Postman, you can fork [collections](#forking-a-collection) and [environments](#forking-an-environment). Forking also enables you to contribute to a collection or an environment without having [editor access](/docs/collaborating-in-postman/roles-and-permissions/#element-based-roles) to that element.
 
-### Forking a collection
+### Creating a fork
 
-> To fork a collection within a public workspace, you must enable your public profile in your [profile settings](https://go.postman.co/settings/me). For more information on making your profile public, see [Managing your account](/docs/getting-started/postman-account/#making-your-profile-public).
+> To fork a collection or environment within a public workspace, you must enable your public profile in your [profile settings](https://go.postman.co/settings/me). For more information on making your profile public, see [Managing your account](/docs/getting-started/postman-account/#making-your-profile-public).
 
-When you fork a Postman collection, you create a copy of it in a different workspace.
+When you fork a Postman collection or environment, you create a copy of it in a different workspace. You must be signed in create a fork.
 
-To fork a collection:
+To fork a collection or environment:
 
-1. Select **Collections** in the left sidebar.
-1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
+1. Hover over the entity in the left sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> that appear next to its name.
 1. Select **Create a fork**.
 
     <img src="https://assets.postman.com/postman-docs/collection-create-a-fork-v9.1.jpg" alt="Create fork selected in menu" width="300px"/>
 
-    > You can also fork a collection by selecting **Fork** on the collection overview tab.
+    > You can also create a fork by selecting **Fork** <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg#icon" width="14px"> in the overview tab.
 
 1. Enter a label for your fork, and select a workspace to save it to.
-1. Select **Fork Collection**.
+1. Select **Fork Collection** or **Fork Environment**.
 
     <img src="https://assets.postman.com/postman-docs/fork-collection-v9.1.jpg" alt="Create fork tab" width="400px"/>
 
 Your fork will be created in the selected workspace.
 
-If there are any [mocks](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/) or [monitors](/docs/monitoring-your-api/intro-monitors/) associated with a collection, they will not be linked to the forked collection. You will need to create mocks and monitors specifically for the fork if you need them.
+If there are any [mocks](/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/) or [monitors](/docs/monitoring-your-api/intro-monitors/) associated with the collection or environment, they won't be linked to the forked entity. You will need to create mocks and monitors specifically for the fork if you need them.
 
-> If you are not a member of a public workspace, you won't be able to send a request from a collection within the workspace. To send requests or make changes to a collection, fork the collection into a personal workspace or a team workspace that you belong to. You must be signed in to Postman to fork a collection.
-
-### Forking an environment
-
-To fork an environment in Postman:
-
-1. Select **Environments** in the left sidebar.
-1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the environment name.
-1. Select **Create a fork**.
-
-    <img src="https://assets.postman.com/postman-docs/environment-create-a-fork-v9.1.jpg" alt="Create an Environment Fork" width="300px"/>
-
-    > You can also fork an environment by selecting **Fork** on the environment overview tab.
-
-1. Enter a label for your fork, and select a workspace to save it to.
-1. Select **Fork Environment**.
-
-    <img src="https://assets.postman.com/postman-docs/fork-environment-v9.1.jpg" alt="Fork environment tab" width="400px"/>
-
-Your forked environment will be created in the selected workspace. You will be able to view forked environments in **Environments** as well as under the environment dropdown list on the right side of Postman.
-
-<img alt="Environment dropdown for forked environments" src="https://assets.postman.com/postman-docs/environment-dropdown-view-v9.12.jpg" width="300px"/>
+> If a collection resides in a public workspace that you aren't a member of, you won't be able to send a request within that workspace. You must fork the collection into a personal workspace or a team workspace that you belong to in order to send requests or make changes to that collection.
 
 ### Viewing fork information
 
 Fork information provides details about forks and the users who have created them. You will be able to identify the users who are actively consuming and contributing to your APIs.
 
-To see the list of users who have forked a collection or an environment:
+To see the list of users who have forked a collection or environment:
 
 1. Select the number next to the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg" width="14px" style="vertical-align:middle;margin-bottom:5px"> to reveal the list of users who have active forks.
 
     <img alt="View the fork information count" src="https://assets.postman.com/postman-docs/fork-information-count-v9.12.jpg" width="400px"/>
 
-To see the list of forks for a collection:
+To see the list of forks for a collection or environment:
 
 1. Select the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg" width="14px" style="vertical-align:middle;margin-bottom:5px"> in the context bar.
 1. Select the fork name under **Forks**.
@@ -123,49 +101,48 @@ To see the list of forks for a collection:
 
 ## Creating pull requests
 
-> Pull requests are only available for collections.
-
-When you have made the changes that you want to a forked collection, you can create a _pull request_. Creating a pull request means that you want to merge the changes you made in the forked collection (the _source_) into the parent collection (the _destination_). As part of the pull request process, you will request that reviewers look at your changes. The reviewers can make comments on your changes and will decide whether to approve them and merge them into the parent collection.
+When you have made the changes that you want to a forked collection or environment, you can create a _pull request_. Creating a pull request means that you want to merge the changes you made in the forked entity (the _source_) into the parent entity (the _destination_). As part of the pull request process, you will request that reviewers look at your changes. Reviewers can make comments on your changes and will decide whether to approve them and merge them into the parent entity.
 
 To create a pull request:
 
-1. Select the forked collection in the **Collections** sidebar.
-1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
+1. Hover over the entity in the left sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> that appear next to its name.
+
 1. Select **Create pull request**.
 
     <img alt="Create Pull Request" src="https://assets.postman.com/postman-docs/create-pull-request.jpg" width="250px"/>
 
-1. Select **Changes** to review the content changes that will be included in the pull request.
+1. Select **Changes** to review the changes that will be included in the pull request.
 
     ![Pull Request Changes](https://assets.postman.com/postman-docs/pull-request-changes.jpg)
 
-    * If the parent collection has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) into your fork before merging.
+    * If the parent entity has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) into your fork before merging.
 
-    * If there are any conflicts between the fork and the parent collection, they will be highlighted so that you can [resolve them](#resolving-conflicts).
+    * If there are any conflicts between the fork and the parent entity, they will be highlighted so that you can [resolve them](#resolving-conflicts).
 
 1. Select **Overview**.
-1. Enter a title and description for your pull request, and select up to 50 reviewers from the dropdown list. Reviewers must have Editor access to the collection to merge your changes.
+1. Enter a title and description for your pull request, and select up to 50 reviewers from the dropdown list. Reviewers must have [editor access](/docs/collaborating-in-postman/roles-and-permissions/#element-based-roles) on the entity to merge your changes.
 1. Select **Create Pull Request**.
 
     <img alt="Create Pull Request" src="https://assets.postman.com/postman-docs/pull-request-overview.jpg" width="350px"/>
 
 The reviewers you selected will be notified about your pull request. You will receive a notification if the reviewers [comment on](#adding-comments), [approve](#approving-a-pull-request), or [merge](#merging-changes-from-a-pull-request) the pull request.
 
-> A reviewer must have **Editor** access on the parent collection to merge changes. If a reviewer only has **Viewer** access to a collection, you will see a warning icon if you add them as reviewers for a pull request.
+> A reviewer must have **Editor** access on the entity to merge changes. If a reviewer only has **Viewer** access, you will see a warning icon when you add them as reviewers for a pull request.
 >
 > <img alt="Reviewer permission" src="https://assets.postman.com/postman-docs/pull-request-reviewer-permission.jpg" width="350px"/>
 
 ### Creating public pull requests
 
-To create a pull request on a public collection, you must fork the parent collection into a public workspace so that the users you ask to [review it](#reviewing-pull-requests) have access to it.
+To create a pull request on a public collection or environment, you must fork the parent entity into a public workspace so that the users you ask to [review it](#reviewing-pull-requests) have access to it.
 
-1. Begin the pull request process described in [Creating pull requests](#creating-pull-requests). You will see a note that tells you to move the source collection to a public workspace.
-1. Select the public workspace where you want to move the collection.
-1. Select **Move Collection**.
+1. Begin the pull request process described in [Creating pull requests](#creating-pull-requests). You will see a note that tells you to move the source entity to a public workspace.
+1. Select the public workspace where you want to move the entity.
+1. Select **Move Collection** or **Move Environment**.
 
     <img src="https://assets.postman.com/postman-docs/make-source-collection-public-v9.jpg" alt="Make the source collection public" width="400px"/>
 
-1. After you move the collection to a public workspace, proceed with the workflow in [Creating pull requests](#creating-pull-requests).
+1. After you move the fork to a public workspace, proceed with the workflow in [Creating pull requests](#creating-pull-requests).
 
 Once you create the pull request, you will get a notification that it has been **Shared to public workspace**.
 
@@ -177,8 +154,8 @@ Pull request settings let you manage permissions for reviewers and assign merge 
 
 #### Manage reviewer permissions
 
-1. Select the collection in the **Collections** sidebar.
-1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
+1. Hover over the entity in the left sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> that appear next to its name.
 1. Select **Manage roles**.
 
     <img alt="Collection Manage Roles" src="https://assets.postman.com/postman-docs/collection-manage-roles-v9.1.jpg" width="300px"/>
@@ -190,7 +167,7 @@ Pull request settings let you manage permissions for reviewers and assign merge 
 
 #### Assign merge checks
 
-Once you have created the pull request, you can assign merge checks before approving changes.
+For collections, you can assign merge checks before approving changes.
 
 There are two different types of checks that you can enable for a pull request:
 
@@ -199,16 +176,16 @@ There are two different types of checks that you can enable for a pull request:
 
 To set merge checks for pull requests on a specific collection:
 
-1. Select the collection in the **Collections** sidebar.
-1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
+1. Hover over the entity in the left sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> that appear next to its name.
 1. Select **Manage roles**.
 1. Select the merge checks that you want to set for the collection.
 
 <img alt="Merge Check" src="https://assets.postman.com/postman-docs/manage-roles-set-merge-checks.jpg" width="800px"/>
 
-If the merge conditions for a pull request are not met, the option to **Merge** it into the parent collection will be active.
+If the merge conditions for a pull request aren't met, the option to **Merge** it into the parent collection will be active.
 
-<img alt="Merge option is not active" src="https://assets.postman.com/postman-docs/view-merge-conditions-v9.12.jpg" width="300px"/>
+<img alt="Merge option isn't active" src="https://assets.postman.com/postman-docs/view-merge-conditions-v9.12.jpg" width="300px"/>
 
 Select **View Merge Conditions** to see the merge conditions to be met for the pull request.
 
@@ -235,23 +212,23 @@ To view notifications for a watched pull request:
 
 1. Select the bell icon <img alt="Changelog icon" src="https://assets.postman.com/postman-docs/icon-notification-bell-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> in the top right corner of Postman. The popup indicates further information about the change that was made to the pull request.
 
-> If you create a pull request and modify it from the same Postman account, you will not receive any notifications about changes made to the pull request.
+> If you create a pull request and modify it from the same Postman account, you won't receive any notifications about changes made to the pull request.
 
 ## Reviewing pull requests
 
-If you're tagged as a reviewer on a pull request, you can view the changes, comment, approve or decline the request, and merge the forked collection into the parent collection when you are ready.
+If you're tagged as a reviewer on a pull request, you can view the changes, comment, approve or decline the request, and merge the forked collection or environment into the parent entity when you are ready.
 
-To see the list of pull requests for a collection:
+To see the list of pull requests:
 
-1. Navigate to the collection and select the **Pull Requests** icon <img alt="Pull request icon" src="https://assets.postman.com/postman-docs/icon-pull-request.jpg" width="16px" style="vertical-align:middle;margin-bottom:5px"> in the context bar.
+1. Navigate to the entity and select the **Pull Requests** icon <img alt="Pull request icon" src="https://assets.postman.com/postman-docs/icon-pull-request.jpg" width="16px" style="vertical-align:middle;margin-bottom:5px"> in the context bar.
 
 <img src="https://assets.postman.com/postman-docs/open-pull-request-list-v9.12.jpg" alt="Pull request list" width="350px"/>
 
-Each item shows the pull request's status, which will be `OPEN` for any that have not been merged or declined. Select a pull request's name to open it.
+Each item shows the pull request's status, which will be `OPEN` for any that haven't been merged or declined. Select a pull request's name to open it.
 
 ### Viewing the diff
 
-When you review a pull request, it's important to see the changes that the pull request will introduce into the parent collection. The difference between the fork and the parent collection is known as the _diff_.
+When you review a pull request, it's important to see the changes that the pull request will introduce into the parent collection or environment. The difference between the fork and the parent entity is known as the _diff_.
 
 To view the diff:
 
@@ -286,7 +263,7 @@ To edit the pull request details:
 1. Make any changes to the pull request's title, description, and list of reviewers.
 1. Select **Save Changes**.
 
-If you do not want to merge the pull request into the parent collection, you can decline it. Declined pull requests cannot be reopened, so if you want to request edits or offer feedback, [add a comment](#adding-comments) instead. To decline the pull request:
+If you don't want to merge the pull request into the parent entity, you can decline it. Declined pull requests can't be reopened, so if you want to request edits or offer feedback, [add a comment](#adding-comments) instead. To decline the pull request:
 
 1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> at the upper right and select **Decline**.
 1. Select **Decline Pull Request**.
@@ -302,50 +279,51 @@ To approve a pull request:
 
 <img alt="Approve a pull request" src="https://assets.postman.com/postman-docs/pull-request-approve-v9.12.jpg" width="300px"/>
 
-After the pull request has been approved, you will see the status of the pull request as **Approved** in the collection's list of pull requests.
+After the pull request has been approved, you will see the status of the pull request as **Approved** in the list of pull requests.
 
 <img src="https://assets.postman.com/postman-docs/pull-request-list-approved-v9.12.jpg" alt="Approved pull request" width="350px"/>
 
 ### Pulling updates
 
-You can keep your forked collections up to date with any changes in the parent, for example if another team member has merged changes into the parent collection.
+You can keep your forked collections and environments up to date with any changes to the parent entity, for example if another team member has merged changes into the parent entity.
 
-1. Open the pull request. Postman will warn you that the parent collection has changed since you last updated it.
-1. Select **Pull Changes** to update your fork with the changes in the parent collection.
+1. Open the pull request. Postman will warn you that the parent entity has changed since you last updated it.
+1. Select **Pull Changes** to update your fork with the changes to the parent entity.
 
 ![Pull recent changes](https://assets.postman.com/postman-docs/pr-pull-changes-v9.12.jpg)
 
 ### Merging changes
 
-When you are ready to add the changes from a pull request or forked collection into the parent collection, you will _merge_ them into the parent collection.
+When you are ready to add the changes from a pull request or fork, you will _merge_ them into the parent collection or environment.
 
 #### Merging changes from a pull request
 
-After a pull request is reviewed, it's ready to be merged into the parent collection.
+After a pull request is reviewed, it's ready to be merged into the parent entity.
 
 1. From the approved pull request, select **Merge**.
 
     ![Merge a pull request](https://assets.postman.com/postman-docs/pull-request-merge-fork-v9.12.jpg)
 
-    > If the parent collection has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) before merging.
+    > If the parent entity has any changes since you last updated your fork, you can [pull those changes](#pulling-updates) before merging.
 
 1. Select one of the following merge options:
-    * **Merge changes**: Merge the changes into the parent collection. No changes are made to the forked collection. You must have Editor access to the parent collection.
-    * **Merge changes and update source**: Merge the changes into the parent collection. Any differences in the parent collection are also made to the forked collection. You must have Editor access to both the parent and forked collections.
-    * **Merge changes and delete source**: Merge the changes into the parent collection. After merging, the forked collection is deleted. You must have Editor access to both the parent and forked collections.
+    * **Merge changes**: Merge the changes into the parent entity. No changes are made to the fork. You must have Editor access to the parent entity.
+    * **Merge changes and update source**: Merge the changes into the parent entity. Any differences in the parent entity are also made to the fork. You must have Editor access to both the parent and forked entities.
+    * **Merge changes and delete source**: Merge the changes into the parent entity. After merging, the fork is deleted. You must have Editor access to both the parent and forked entities.
 
     <img src="https://assets.postman.com/postman-docs/merge-fork-options-v9.12.jpg" alt="Merge Fork Options" width="400px"/>
 
 1. Select **Merge**.
 
-#### Merging changes from a forked collection
+#### Merging changes from a fork
 
-If you have Editor access to a collection, you can merge a fork into the parent collection without going through the [pull request process](#creating-pull-requests). For example, if you’re using forks in a personal workspace to organize your work, you can merge changes in a fork directly back into the parent collection. If you are collaborating with others, though, merging directly lacks the safeguards built into the pull request process, and many teams require pull requests as part of their version control workflow.
+If you have Editor access on the entity, you can merge a fork into the parent entity without going through the [pull request process](#creating-pull-requests). For example, if you’re using forks in a personal workspace to organize your work, you can merge changes in a fork directly back into the parent entity. If you are collaborating with others, though, merging directly lacks the safeguards built into the pull request process, and many teams require pull requests as part of their version control workflow.
 
 To merge changes from a fork without opening a pull request:
 
-1. Select the forked collection in the **Collections** sidebar.
-1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> next to the collection name.
+1. Hover over the fork in the left sidebar.
+1. Select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg" width="18px" style="vertical-align:middle;margin-bottom:5px"> that appear next to its name.
+
 1. Select **Merge changes**.
 1. Review the diff and select **Merge all changes**.
 
@@ -355,13 +333,13 @@ To merge changes from a fork without opening a pull request:
 
 ## Resolving conflicts
 
-A merge conflict happens when you try to merge changes into an updated parent collection and Postman is not able to automatically resolve the differences between the two collections. If you encounter a conflict when you try to merge a forked collection, you will need to decide how you want to resolve them before continuing.
+A merge conflict happens when you try to merge changes into an updated parent entity and Postman isn't able to automatically resolve the differences between the two. If you encounter a conflict when you try to merge a fork, you will need to decide how you want to resolve them before continuing.
 
 > Merge conflicts can involve changes in multiple workspaces.
 
 To resolve a merge conflict:
 
-1. Look at the differences between the two collections. The **Source** line shows the changes on your fork, and the **Destination** line shows the changes on the parent collection.
+1. Look at the differences between the two entities. The **Source** line shows the changes on your fork, and the **Destination** line shows the changes on the parent entity.
 1. Select **Use this** next to the version you want to include when you merge.
 
 <img src="https://assets.postman.com/postman-docs/conflicts-pull-changes-v2.jpg" alt="Pull Changes" width="450px"/>

--- a/src/pages/docs/getting-started/exploring-public-api-network.md
+++ b/src/pages/docs/getting-started/exploring-public-api-network.md
@@ -45,7 +45,7 @@ There are a variety of ways to find APIs, workspaces, teams, and collections:
 * Under **Browse**, you can select to view **Teams**, **Workspaces**, **APIs**, and **Collections**. You can sort results using the **Featured**, **Most Viewed**, and **Latest** tabs just below the header.
     * You can also sort Collections and Workspaces by category using the filters below the header.
 
-To import a collection from a public workspace to your workspace, create a fork of it. See [forking a collection](/docs/collaborating-in-postman/version-control-for-collections/#forking-a-collection).
+To import a collection from a public workspace to your workspace, create a fork of it. See [creating a fork](/docs/collaborating-in-postman/version-control-for-collections/#creating-a-fork).
 
 Check out some useful collections for getting started learning about APIs, requests, and Postman:
 

--- a/src/pages/docs/monitoring-your-api/intro-monitors.md
+++ b/src/pages/docs/monitoring-your-api/intro-monitors.md
@@ -86,7 +86,7 @@ Because they run Postman requests and scripts, collection-based monitors can be 
 * **Monitor the security of your endpoints.** Continuously test APIs for known security vulnerabilities.
 * **Visualize results on the monitor dashboard.** Get better visibility into API performance over time and identify trends.
 
-> **Want to see Postman Monitors in action?** Visit the [Postman API Monitoring Examples public workspace](https://www.postman.com/postman/workspace/postman-api-monitoring-examples/overview) to find example collections for some common monitoring use cases. You can collaborate on the collections in the workspace by [creating a fork](/docs/collaborating-in-postman/version-control-for-collections/#forking-a-collection), or modify the collections for your team's use by [exporting and importing them into your team workspace](/docs/getting-started/importing-and-exporting-data/#exporting-collections).
+> **Want to see Postman Monitors in action?** Visit the [Postman API Monitoring Examples public workspace](https://www.postman.com/postman/workspace/postman-api-monitoring-examples/overview) to find example collections for some common monitoring use cases. You can collaborate on the collections in the workspace by [creating a fork](/docs/collaborating-in-postman/version-control-for-collections/#creating-a-fork), or modify the collections for your team's use by [exporting and importing them into your team workspace](/docs/getting-started/importing-and-exporting-data/#exporting-collections).
 
 ## Next steps
 

--- a/src/pages/docs/sending-requests/managing-environments.md
+++ b/src/pages/docs/sending-requests/managing-environments.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing environments"
 order: 25
-updated: 2021-10-06
+updated: 2022-03-23
 page_id: "managing-environments"
 search_keyword: "pm.globals.set, globals.set, pm.environment.set, environment.set, pm.variables.get, variables.get, pm.globals.get, globals.get, pm.environment.get, environment.get"
 contextual_links:
@@ -59,6 +59,8 @@ An environment is a set of [variables](/docs/sending-requests/variables/) you ca
     * [Using an environment in viewer role](#using-an-environment-in-viewer-role)
         * [Requesting environment access](#requesting-environment-access)
     * [Using an environment in editor role](#using-an-environment-in-editor-role)
+    * [Forking environments](#forking-environments)
+    * [Viewing pull requests, forks, and environment details](#viewing-pull-requests-forks-and-environment-details)
 
 ## Creating environments
 
@@ -251,7 +253,28 @@ When you edit the initial value of a shared environment variable, your updated v
 
 > If you uncheck (deselect) a variable in your environment, it will only be available to collaborators who also have edit access to the environment. They will also be able to see if the variable is active or not. Anyone with the viewer role for the environment won't see the unchecked variable. </br></br> ![Turn off environment variable](https://assets.postman.com/postman-docs/environment-editor-unchecked-var-v9.13.jpg)
 
-With the editor role, you can [configure access for other team members](#managing-environment-roles). If you need to specify access but do not have the editor role, you can [request access](#requesting-environment-access).
+With the editor role, you can [configure access for other team members](#managing-environment-roles). If you need to specify access but don't have the editor role, you can [request access](#requesting-environment-access).
+
+### Forking environments
+
+You can fork environments to change them without impacting their base versions, or to contribute to their development without having editor access. To fork an environment:
+
+1. Hover over the environment in the left sidebar and select the three dots <img alt="Three dots icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg#icon" width="18px"> that appear to the right of the environment's name.
+2. Select **Create a Fork**.
+
+> You can also fork an environment by selecting **Fork** <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg#icon" width="14px"> in the environment overview tab.
+
+You can edit your environment fork and use it as needed, or you can [create a pull request](/docs/collaborating-in-postman/version-control-for-collections/#creating-pull-requests) to update the original environment.
+
+### Viewing pull requests, forks, and environment details
+
+You can view all pull requests, forks, and details about an environment from the right sidebar:
+
+* To view pull requests, select the pull request icon <img alt="Pull request icon" src="https://assets.postman.com/postman-docs/icon-pull-request.jpg" width="16px" style="vertical-align:middle;margin-bottom:5px">
+* To view forks, select the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg" width="16px" style="vertical-align:middle;margin-bottom:5px">
+* To view additional information about the environment, including its ID, author, and any mock servers or monitors that use it, select the info icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg" width="16px" style="vertical-align:middle;margin-bottom:5px">
+
+If you have [editor access](/docs/collaborating-in-postman/roles-and-permissions/#environment-roles) on the environment, you can [review pull requests](/docs/collaborating-in-postman/version-control-for-collections/#reviewing-pull-requests) and [merge changes into the parent environment](/docs/collaborating-in-postman/version-control-for-collections/#merging-changes).
 
 ## Next steps
 

--- a/src/pages/docs/writing-scripts/test-with-monitors.md
+++ b/src/pages/docs/writing-scripts/test-with-monitors.md
@@ -40,7 +40,7 @@ Postman Monitors provide a way to automatically run test scripts and perform oth
 
 Below are some ways you can use collection-based monitors to test your APIs and ensure they're functioning correctly.
 
-> **Want to see Postman Monitors in action?** Visit the [Postman API Monitoring Examples public workspace](https://www.postman.com/postman/workspace/postman-api-monitoring-examples/overview) to find example collections for some common monitoring use cases. You can collaborate on the collections in the workspace by [creating a fork](/docs/collaborating-in-postman/version-control-for-collections/#forking-a-collection), or modify the collections for your team's use by [exporting and importing them into your team workspace](/docs/getting-started/importing-and-exporting-data/#exporting-collections).
+> **Want to see Postman Monitors in action?** Visit the [Postman API Monitoring Examples public workspace](https://www.postman.com/postman/workspace/postman-api-monitoring-examples/overview) to find example collections for some common monitoring use cases. You can collaborate on the collections in the workspace by [creating a fork](/docs/collaborating-in-postman/version-control-for-collections/#creating-a-fork), or modify the collections for your team's use by [exporting and importing them into your team workspace](/docs/getting-started/importing-and-exporting-data/#exporting-collections).
 
 ## Monitoring an API endpoint
 


### PR DESCRIPTION
* Adds brief sections to /docs/sending-requests/managing-environments/ (based on /docs/sending-requests/intro-to-collections/)
* Updates /docs/collaborating-in-postman/version-control-for-collections/ to account for environments having a similar fork/PR/merge experience
* Maintaining diff for review, but planning to update the page URL to remove "for collections"



It seems too wordy to say "collection or environment" everywhere, hence the frequent use of "entity"—thoughts?