### PR TITLE
TW 424 Add link to status page

### DIFF
--- a/src/pages/docs/getting-started/troubleshooting-inapp.md
+++ b/src/pages/docs/getting-started/troubleshooting-inapp.md
@@ -3,18 +3,26 @@ title: "Troubleshooting app issues"
 order: 9
 page_id: "troubleshooting_in_app"
 warning: false
-updated: 2021-12-22
+updated: 2022-03-29
 ---
 
-Postman automatically captures log messages in the event something goes wrong in the Postman app. The logs include information about recent activity in the app and can be helpful when troubleshooting issues.
+Sometimes things go wrong! If you're having trouble with the Postman app, there are several resources that can help you diagnose and fix the problem.
 
-> **Have questions about Postman?** Check out [Postman's Help Center](https://support.postman.com/hc/en-us) for answers to [frequently asked questions about the Postman app](https://support.postman.com/hc/en-us/categories/115000609125-Postman-App).
+If you have questions about Postman beyond what's covered in this guide, see [Postman's Help Center](https://support.postman.com/hc/en-us) for answers to [frequently asked questions about the Postman app](https://support.postman.com/hc/en-us/categories/115000609125-Postman-App).
+
+> This guide specifically discusses troubleshooting issues with the Postman app. To troubleshoot issues with Postman requests, see [Troubleshooting requests](/docs/sending-requests/troubleshooting-api-requests/). To troubleshoot issues with Postman monitors, see [Troubleshooting monitors](/docs/monitoring-your-api/troubleshooting-monitors/).
+
+## Checking Postman's status
+
+Wondering if Postman is experiencing issues? Check the [Postman Status page](https://status.postman.com/), which lets you know if Postman is experiencing degraded performance, outages, or is undergoing maintenance.
 
 ## Contacting Postman product support
 
 You can contact Postman product support if you need help resolving any issues you find in Postman. Go to the [Postman Support Center](https://www.postman.com/support/) and select **Submit a Request**.
 
 ## Locating Postman logs
+
+Postman automatically captures log messages in the event something goes wrong in the Postman app. The logs include information about recent activity in the app and can be helpful when troubleshooting issues.
 
 Use the instructions below to locate the Postman logs on your macOS, Windows, or Linux system. Attach the log files to your support request to help the support team troubleshoot your issue.
 

--- a/src/pages/docs/getting-started/troubleshooting-inapp.md
+++ b/src/pages/docs/getting-started/troubleshooting-inapp.md
@@ -12,10 +12,6 @@ If you have questions about Postman beyond what's covered in this guide, see [Po
 
 > This guide specifically discusses troubleshooting issues with the Postman app. To troubleshoot issues with Postman requests, see [Troubleshooting requests](/docs/sending-requests/troubleshooting-api-requests/). To troubleshoot issues with Postman monitors, see [Troubleshooting monitors](/docs/monitoring-your-api/troubleshooting-monitors/).
 
-## Checking Postman's status
-
-Wondering if Postman is experiencing issues? Check the [Postman Status page](https://status.postman.com/), which lets you know if Postman is experiencing degraded performance, outages, or is undergoing maintenance.
-
 ## Contacting Postman product support
 
 You can contact Postman product support if you need help resolving any issues you find in Postman. Go to the [Postman Support Center](https://www.postman.com/support/) and select **Submit a Request**.
@@ -45,3 +41,7 @@ To locate the logs in Linux, open the Postman app and go to **View > Developer >
 The DevTools console provides internal debugging entries for Postman that may be useful in troubleshooting problems with the app.
 
 To access the DevTools console logs, go to **View > Developer > Show DevTools (current view)**. In the DevTools window, select __Console__ to see the app debug logs.
+
+## Checking Postman's status
+
+Wondering if Postman is experiencing issues? Check the [Postman Status page](https://status.postman.com/), which lets you know if Postman is experiencing degraded performance, outages, or is undergoing maintenance.


### PR DESCRIPTION
- Adds a link to https://status.postman.com/ from https://learning.postman.com/docs/getting-started/troubleshooting-inapp/
- Adds a new introduction and a note about the type of troubleshooting page this is