### PR TITLE
moving polyfill script to bottom to keep from being a render-blocking file

### DIFF
--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -103,9 +103,6 @@
        {/* Algolia Instantsearch IE11 support v4 */}
        <link rel="dns-prefetch" href="https://polyfill.io" />
        <link crossOrigin rel="preconnect" href="https://polyfill.io" />
-       <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries" />
- 
- 
      </Helmet>
    );
  }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -37,6 +37,12 @@ class IndexPage extends React.Component {
     pix.src = '//pixel.mathtag.com/event/js?mt_id=1538259&mt_adid=244742&mt_exem=&mt_excl=&v1=&v2=&v3=&s1=&s2=&s3=';
     pix.async = true;
     document.body.appendChild(pix);
+    
+    const polyfill = document.createElement('script');
+    polyfill.language = 'JavaScript1.1';
+    polyfill.src = '//polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries';
+    polyfill.async = true;
+    document.body.appendChild(polyfill);
   }
 
   render() {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -37,12 +37,16 @@ class IndexPage extends React.Component {
     pix.src = '//pixel.mathtag.com/event/js?mt_id=1538259&mt_adid=244742&mt_exem=&mt_excl=&v1=&v2=&v3=&s1=&s2=&s3=';
     pix.async = true;
     document.body.appendChild(pix);
-    
-    const polyfill = document.createElement('script');
-    polyfill.language = 'JavaScript1.1';
-    polyfill.src = '//polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries';
-    polyfill.async = true;
-    document.body.appendChild(polyfill);
+
+    const id = 'Polyfill';
+    if (!document.getElementById(id)) {
+      const polyfill = document.createElement('script');
+      polyfill.id = id;
+      polyfill.language = 'JavaScript1.1';
+      polyfill.src = '//polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries';
+      polyfill.async = true;
+      document.body.appendChild(polyfill);
+    }
   }
 
   render() {


### PR DESCRIPTION
* using waterfaller.dev, we found that "polyfill.min.js is blocking the render of your page wasting 230ms"
* using same pattern as `math` script, I moved the polyfill script to bottom of page
* removed from SEO.jsx (head)
* will retest in https://waterfaller.dev/ when on BETA