### PR TITLE
[MARKENG-1338] additional header for node fetching of bff content

### DIFF
--- a/scripts/fetchBlogPosts.js
+++ b/scripts/fetchBlogPosts.js
@@ -1,6 +1,13 @@
 const fs = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
+const requestOptions = {
+  method: 'GET',
+  headers: {
+    bff: 'e2e'
+  },
+  redirect: 'follow'
+};
 
 require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
@@ -10,7 +17,7 @@ const host = process.env.BFF_BLOG_URL || ''
 
 function fetchBlogPosts() {
   if (host) {
-    return fetch(host)
+    return fetch(host, requestOptions)
     .then(
       (res) => {
         res.text()

--- a/scripts/fetchEvents.js
+++ b/scripts/fetchEvents.js
@@ -1,6 +1,13 @@
 const fs = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
+const requestOptions = {
+  method: 'GET',
+  headers: {
+    bff: 'e2e'
+  },
+  redirect: 'follow'
+};
 
 require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
@@ -10,7 +17,7 @@ const host = process.env.BFF_EVENTS_URL || ''
 
 function fetchEvents() {
   if (host) {
-    return fetch(host)
+    return fetch(host, requestOptions)
     .then(
       (res) => {
         res.text()

--- a/scripts/fetchPmTech.js
+++ b/scripts/fetchPmTech.js
@@ -4,6 +4,13 @@ const path = require('path');
 const fetch = require('node-fetch');
 const sh = require('shelljs');
 const { minify } = require('terser');
+const requestOptions = {
+  method: 'GET',
+  headers: {
+    bff: 'e2e'
+  },
+  redirect: 'follow'
+};
 
 async function compress(t) {
   const result = await minify(t, {});
@@ -14,7 +21,7 @@ async function compress(t) {
 const host = process.env.PM_TECH || '';
 
 const fetchPmTech = () => new Promise((resolve) => {
-  fetch(host).then((resp) => {
+  fetch(host, requestOptions).then((resp) => {
     if (resp) {
       resp.json().then((data) => {
         const tag = data['postman-docs'];


### PR DESCRIPTION
**What are the changes?**
_Branched from `develop`_, this modifies the bff fetch scripts to pass an additional request header.

**Why make these changes?**
The url to fetch bff data is getting updated to support runtime requests. Access to the endpoint will need to be authorized for access. From node processes, auth will be achieved with this additional header.

*no-visuals (regressive)