### PR TITLE
[MARKENG-1159] Added metatags for docs

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -22,7 +22,8 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       name: 'slug',
       value: slug,
     });
-    /* Returns the latest commit log for a specific doc file (View Doc.jsx for query) */
+    /* Used on doc.jsx / View GraphQL query
+    /* Returns the latest commit log for a specific doc file */
     const lastModifiedDate = execSync(
       `git log -1 --pretty='%ad' --date=format:'%Y/%m/%d' ${node.fileAbsolutePath}`
     ).toString()
@@ -31,6 +32,16 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       name: "lastModifiedDate",
       value: lastModifiedDate,
     })
+    /* Returns the last modified time (SEO)  */
+    const lastModifiedTime = execSync(
+      `git log -1 --pretty="format:%ci" ${node.fileAbsolutePath}`
+    ).toString().replace(/\s+/g, '');
+    actions.createNodeField({
+      node,
+      name: "lastModifiedTime",
+      value: lastModifiedTime,
+    })
+    console.log(lastModifiedTime)
   }
 };
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -41,7 +41,6 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       name: "lastModifiedTime",
       value: lastModifiedTime,
     })
-    console.log(lastModifiedTime)
   }
 };
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -34,8 +34,8 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
     })
     /* Returns the last modified time (SEO)  */
     const lastModifiedTime = execSync(
-      `git log -1 --pretty="format:%ci" ${node.fileAbsolutePath}`
-    ).toString().replace(/\s+/g, '');
+      `git log -1 --pretty="format:%cI" ${node.fileAbsolutePath}`
+    ).toString();
     actions.createNodeField({
       node,
       name: "lastModifiedTime",

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -13,7 +13,6 @@
  function SEO({
    lang, meta, title, slug, lastModifiedTime
  }) {
-   console.log(lastModifiedTime)
    const { site } = useStaticQuery(
      graphql`
        query {

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -11,8 +11,9 @@
  import { useStaticQuery, graphql } from 'gatsby';
  
  function SEO({
-   lang, meta, title, slug,
+   lang, meta, title, slug, lastModifiedTime
  }) {
+   console.log(lastModifiedTime)
    const { site } = useStaticQuery(
      graphql`
        query {
@@ -22,11 +23,10 @@
              description
              author
            }
-         }
+         }   
        }
      `,
    );
- 
    return (
      <Helmet
        htmlAttributes={{
@@ -54,6 +54,14 @@
          {
            property: 'og:site_name',
            content: 'Postman Learning Center',
+         },
+         {
+          property: 'article:publisher',
+          content: 'https://www.facebook.com/getpostman/',
+         },
+         {
+          property: 'article:modified_time',
+          content: lastModifiedTime
          },
          {
            property: 'og:image',

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -47,14 +47,15 @@ const DisplayContextualLinks = (props) => {
 }
 const DocPage = ({ data }) => {
   const post = data.markdownRemark;
-  /* Last modified date (bottom of page) */
-  const date = data.markdownRemark.fields.lastModifiedDate;
-  /* Breadcrumbs (top of page) & Previous and Next Links (bottom of page) */
+    // Last modified date - displaed at bottom of docs
+    // Last modified time - meta data for SEO
+  const {lastModifiedDate, lastModifiedTime } = data.markdownRemark.fields;
+  // Breadcrumbs (top of page) & Previous and Next Links (bottom of page) 
   const { parentLink, subParentLink, previous, next } = data;
 
   return (
     <Layout>
-      <SEO title={post.frontmatter.title} slug={post.fields.slug} />
+      <SEO title={post.frontmatter.title} slug={post.fields.slug} lastModifiedTime={lastModifiedTime} />
       <div className="container-fluid">
         <div className="row row-eq-height">
           <nav className="col-sm-12 col-md-4 col-lg-3 left-nav-re">
@@ -67,7 +68,7 @@ const DocPage = ({ data }) => {
                 <h1>{post.frontmatter.title}</h1>
                 <CreateDoc data={post} />
                 <p>
-                  <small className="font-italic">Last modified: {date}</small>
+                  <small className="font-italic">Last modified: {lastModifiedDate}</small>
                 </p>
                 <PreviousAndNextLinks data={{ previous, next }} />
               </main>
@@ -105,6 +106,7 @@ export const query = graphql`
       fields {
         slug
         lastModifiedDate
+        lastModifiedTime
       }
     }
   }


### PR DESCRIPTION
Issue: Add article:publisher and article:modified_time to meta for SEO

Added static article:publisher tag and an exec.sync command to grab the latest modified time that runs on build which appends the tags to the HTML head.

article:publisher
![Screen Shot 2022-04-29 at 8 18 40 PM](https://user-images.githubusercontent.com/42796716/166316686-9ed4f373-8b40-45b6-950a-e3aeb295847a.png)

Modified Time
![Screen Shot 2022-04-29 at 8 49 38 PM](https://user-images.githubusercontent.com/42796716/166316769-fee2fc02-928e-49c9-b232-6d393a6963b8.png)

