### PR TITLE
Update link to Akamai TechDocs

### DIFF
--- a/src/pages/docs/sending-requests/authorization.md
+++ b/src/pages/docs/sending-requests/authorization.md
@@ -376,7 +376,7 @@ Advanced parameters for NTLM auth are as follows:
 
 > When the required details are complete in the __Authorization__ tab for your request, Postman will add them to the __Headers__.
 
-For information on obtaining your credentials, see [Akamai Developer - Authorize your Client](https://developer.akamai.com/legacy/introduction/Prov_Creds.html).
+For information on obtaining your credentials, see [Akamai Developer - Authorize your Client](https://techdocs.akamai.com/developer/docs/set-up-authentication-credentials).
 
 ## Syncing cookies
 


### PR DESCRIPTION
Akamai has launched a new documentation portal with new links. This will update the link to the right location. I am a Developer Advocate @ Akamai and work with our documentation team who brought this to my attention. Please contact me if there are questions on this. Thanks in advance! /Mike