### PR TITLE
[MARKENG-1408] Qualtrics added to LC

### DIFF
--- a/scripts/qualtrics.js
+++ b/scripts/qualtrics.js
@@ -1,0 +1,11 @@
+// Qualtrics widget for content ranking survey 
+// https://www.qualtrics.com/support/website-app-feedback/creatives-tab/creative-types/embedded-feedback/
+function qualtrics(){var g=function(e,h,f,g){
+    this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
+    this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
+    this.check=function(){var a=this.get(f);if(a)a=a.split(":");else if(100!=e)"v"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(":"));else return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case "v":return!1;case "r":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(":")),!c}return!0};
+    this.go=function(){if(this.check()){var a=document.createElement("script");a.type="text/javascript";a.src=g;document.body&&document.body.appendChild(a)}};
+    this.start=function(){var t=this;"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",function(){t.go()},!1):window.attachEvent&&window.attachEvent("onload",function(){t.go()}):t.go()};};
+    try{(new g(100,"r","QSI_S_ZN_cG6u1PkZV7TpCFo","https://zncg6u1pkzv7tpcfo-postman.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_cG6u1PkZV7TpCFo")).start()}catch(i){}};
+
+module.exports = qualtrics;

--- a/scripts/useQualtrics.js
+++ b/scripts/useQualtrics.js
@@ -1,0 +1,9 @@
+function useQualtrics(){var g=function(e,h,f,g){
+    this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
+    this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
+    this.check=function(){var a=this.get(f);if(a)a=a.split(":");else if(100!=e)"v"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(":"));else return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case "v":return!1;case "r":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(":")),!c}return!0};
+    this.go=function(){if(this.check()){var a=document.createElement("script");a.type="text/javascript";a.src=g;document.body&&document.body.appendChild(a)}};
+    this.start=function(){var t=this;"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",function(){t.go()},!1):window.attachEvent&&window.attachEvent("onload",function(){t.go()}):t.go()};};
+    try{(new g(100,"r","QSI_S_ZN_cG6u1PkZV7TpCFo","https://zncg6u1pkzv7tpcfo-postman.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_cG6u1PkZV7TpCFo")).start()}catch(i){}}
+
+module.exports = useQualtrics;

--- a/scripts/useQualtrics.js
+++ b/scripts/useQualtrics.js
@@ -1,9 +1,0 @@
-function useQualtrics(){var g=function(e,h,f,g){
-    this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
-    this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
-    this.check=function(){var a=this.get(f);if(a)a=a.split(":");else if(100!=e)"v"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(":"));else return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case "v":return!1;case "r":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(":")),!c}return!0};
-    this.go=function(){if(this.check()){var a=document.createElement("script");a.type="text/javascript";a.src=g;document.body&&document.body.appendChild(a)}};
-    this.start=function(){var t=this;"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",function(){t.go()},!1):window.attachEvent&&window.attachEvent("onload",function(){t.go()}):t.go()};};
-    try{(new g(100,"r","QSI_S_ZN_cG6u1PkZV7TpCFo","https://zncg6u1pkzv7tpcfo-postman.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_cG6u1PkZV7TpCFo")).start()}catch(i){}}
-
-module.exports = useQualtrics;

--- a/src/components/modules/loadQualtrics.jsx
+++ b/src/components/modules/loadQualtrics.jsx
@@ -1,27 +1,23 @@
 import React from 'react';
-
+const qualtrics = require('../../../scripts/qualtrics')
 class QualtricsScript extends React.Component {
   componentDidMount() {
     if (typeof window !== 'undefined') {
       (() => {
         const s = document.createElement('script');
         s.type = 'text/javascript';
-        s.innerHTML = `(function(){var g=function(e,h,f,g){
-          this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
-          this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
-          this.check=function(){var a=this.get(f);if(a)a=a.split(":");else if(100!=e)"v"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(":"));else return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case "v":return!1;case "r":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(":")),!c}return!0};
-          this.go=function(){if(this.check()){var a=document.createElement("script");a.type="text/javascript";a.src=g;document.body&&document.body.appendChild(a)}};
-          this.start=function(){var t=this;"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",function(){t.go()},!1):window.attachEvent&&window.attachEvent("onload",function(){t.go()}):t.go()};};
-          try{(new g(100,"r","QSI_S_ZN_cG6u1PkZV7TpCFo","https://zncg6u1pkzv7tpcfo-postman.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_cG6u1PkZV7TpCFo")).start()}catch(i){}})();`
+        s.onload = qualtrics()
         document.getElementsByTagName('head')[0].appendChild(s);
       })();
     }
   }
 
   render() {
-    return <div id='ZN_cG6u1PkZV7TpCFo'>
-      {/* <!--DO NOT REMOVE-CONTENTS PLACED HERE--> */}
-    </div>;
+    return (
+      <div className='pm-qualtrics-embedded'>
+        <div id='ZN_cG6u1PkZV7TpCFo' />
+      </div>
+    )
   }
 }
 

--- a/src/components/modules/loadQualtrics.jsx
+++ b/src/components/modules/loadQualtrics.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+class QualtricsScript extends React.Component {
+  componentDidMount() {
+    if (typeof window !== 'undefined') {
+      (() => {
+        const s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.innerHTML = `(function(){var g=function(e,h,f,g){
+          this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
+          this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
+          this.check=function(){var a=this.get(f);if(a)a=a.split(":");else if(100!=e)"v"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(":"));else return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case "v":return!1;case "r":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(":")),!c}return!0};
+          this.go=function(){if(this.check()){var a=document.createElement("script");a.type="text/javascript";a.src=g;document.body&&document.body.appendChild(a)}};
+          this.start=function(){var t=this;"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",function(){t.go()},!1):window.attachEvent&&window.attachEvent("onload",function(){t.go()}):t.go()};};
+          try{(new g(100,"r","QSI_S_ZN_cG6u1PkZV7TpCFo","https://zncg6u1pkzv7tpcfo-postman.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_cG6u1PkZV7TpCFo")).start()}catch(i){}})();`
+        document.getElementsByTagName('head')[0].appendChild(s);
+      })();
+    }
+  }
+
+  render() {
+    return <div id='ZN_cG6u1PkZV7TpCFo'>
+      {/* <!--DO NOT REMOVE-CONTENTS PLACED HERE--> */}
+    </div>;
+  }
+}
+
+const LoadQualtrics = () => <QualtricsScript />;
+
+export default LoadQualtrics;

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -9,7 +9,7 @@
  import PropTypes from 'prop-types';
  import Helmet from 'react-helmet';
  import { useStaticQuery, graphql } from 'gatsby';
- 
+
  function SEO({
    lang, meta, title, slug, lastModifiedTime
  }) {

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -68,11 +68,11 @@ const DocPage = ({ data }) => {
                 <BreadCrumbsLinks data={{ parentLink, subParentLink }} />
                 <h1>{post.frontmatter.title}</h1>
                 <CreateDoc data={post} />
-                {/* Qualtrics */}
-               <LoadQualtrics />
                 <p>
                   <small className="font-italic">Last modified: {lastModifiedDate}</small>
                 </p>
+                                {/* Qualtrics */}
+                                <LoadQualtrics />
                 <PreviousAndNextLinks data={{ previous, next }} />
               </main>
               <aside className="col-sm-12 col-md-12 col-lg-3 offset-lg-0 col-xl-3 offset-xl-1 right-column">

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/no-danger */
+const useQualtrics = require('../../scripts/useQualtrics');
 import React, { useState, useEffect } from 'react';
 import { graphql } from 'gatsby';
 
@@ -20,6 +21,7 @@ function CreateDoc(props) {
   const [post, setModal] = useState({ ...props })
 
   useEffect(() => {
+    useQualtrics();
     const { data } = props;
     const { html } = data;
     // parses a string containing HTML & returns an HTMLDocument
@@ -67,6 +69,8 @@ const DocPage = ({ data }) => {
                 <BreadCrumbsLinks data={{ parentLink, subParentLink }} />
                 <h1>{post.frontmatter.title}</h1>
                 <CreateDoc data={post} />
+                {/* Qualtrics */}
+                <div id='ZN_cG6u1PkZV7TpCFo'/>
                 <p>
                   <small className="font-italic">Last modified: {lastModifiedDate}</small>
                 </p>

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-danger */
-const useQualtrics = require('../../scripts/useQualtrics');
 import React, { useState, useEffect } from 'react';
 import { graphql } from 'gatsby';
 
@@ -16,12 +15,12 @@ import 'prismjs/themes/prism-tomorrow.css';
 import { useModal } from '../components/modules/Modal';
 import PreviousAndNextLinks from '../components/modules/PreviousAndNextLinks';
 import BreadCrumbsLinks from '../components/modules/BreadCrumbsLinks';
+import LoadQualtrics from '../components/modules/loadQualtrics';
 
 function CreateDoc(props) {
   const [post, setModal] = useState({ ...props })
 
   useEffect(() => {
-    useQualtrics();
     const { data } = props;
     const { html } = data;
     // parses a string containing HTML & returns an HTMLDocument
@@ -70,7 +69,7 @@ const DocPage = ({ data }) => {
                 <h1>{post.frontmatter.title}</h1>
                 <CreateDoc data={post} />
                 {/* Qualtrics */}
-                <div id='ZN_cG6u1PkZV7TpCFo'/>
+               <LoadQualtrics />
                 <p>
                   <small className="font-italic">Last modified: {lastModifiedDate}</small>
                 </p>


### PR DESCRIPTION
Adding Qualtrics script to Learning Center docs for content ranking survery.

I created an JSX element and a js file to load the qualtrics script on load. Qualtrics requires a css selector so I wrapped the parent with 'pm-qualtrics-embedded'.

<img width="921" alt="Screen Shot 2022-05-06 at 12 43 10 PM" src="https://user-images.githubusercontent.com/42796716/167207180-d614aad3-a6de-4dc0-85b4-6962eb80fd81.png">
<img width="451" alt="Screen Shot 2022-05-06 at 12 42 48 PM" src="https://user-images.githubusercontent.com/42796716/167207197-61e4af63-249b-45dd-a008-9df7a7571da2.png">


