### PR TITLE
Created node for frontmatter character count of all md files 

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -118,14 +118,16 @@ exports.sourceNodes = async ({
     const output = { ...data, ...nodeMeta };
     return output;
   };
-
   const { createNode } = actions;
-
+  let mdFrontmatterCharacterCount = []
   const getDirectories = (src) => glob.sync(`${src}/**/*`);
   const paths = getDirectories('./src/pages/docs')
     .filter((val) => val.slice(-3) === '.md')
     .map((val) => {
       const { data } = frontmatter(fs.readFileSync(val));
+      mdFrontmatterCharacterCount.push(data)
+      // const algoliaLength = JSON.stringify(val[data]);
+      // h = algoliaLength;
       const order = data.order || 200;
       return [val, order];
     })
@@ -140,7 +142,7 @@ exports.sourceNodes = async ({
     .filter((val) => !ignorePaths.includes(val));
 
   const output = {};
-
+  
   paths.forEach((val) => {
     let split = val.split('/');
     split = split.filter((url) => url !== '');
@@ -152,8 +154,13 @@ exports.sourceNodes = async ({
     });
     current.url = `/${split.join('/')}/`;
   });
+  mdFrontmatterCharacterCount = JSON.stringify(mdFrontmatterCharacterCount);
+  // enable console.logs to view frontmatter object in terminal 'npm run dev'
+  console.log(mdFrontmatterCharacterCount, 'List of all frontmatter objects from md files')
+  mdFrontmatterCharacterCount = mdFrontmatterCharacterCount.length;
+  console.log('Length of all frontmatter from md files', mdFrontmatterCharacterCount)
 
+  createNode(prepareNode(mdFrontmatterCharacterCount, 'frontmatterLength'));
   createNode(prepareNode(output.docs, 'leftNavLinks'));
-  // createNode(prepareNode(HeaderJson, 'headerLinks'));
   createNode(prepareNode(FooterJson, 'FooterLinks'));
 };


### PR DESCRIPTION
This creates a new node to grab the length of all frontmatter from the md files.
I added two console logs you can enable / disable so you can view the query in the terminal. 

GraphQL query can be found under (http://localhost:8000/___graphql)
```
 frontmatterLength {
    value
  }
```


Terminal (for testing)
<img width="1080" alt="Screen Shot 2022-05-06 at 2 44 49 PM" src="https://user-images.githubusercontent.com/42796716/167220854-7794d2c3-f817-482c-98b6-a99a873f806d.png">

GraphQL query
<img width="1572" alt="Screen Shot 2022-05-06 at 2 45 14 PM" src="https://user-images.githubusercontent.com/42796716/167220876-60bb95d6-7524-47e5-b690-0c276e93a14d.png">

