### PR TITLE
changed 'e-remove' to 'Closed' on modal X button title

### DIFF
--- a/src/components/modules/Modal.js
+++ b/src/components/modules/Modal.js
@@ -36,7 +36,7 @@ const Modal = (create_id, images, i) => {
                 height="16"
                 viewBox="0 0 16 16"
               >
-                <title class="closed-label">e-remove</title>
+                <title class="closed-label">Close</title>
                 <g
                   stroke-width="1"
                   fill="#212121"


### PR DESCRIPTION
<img width="231" alt="Screen Shot 2022-05-05 at 10 25 48" src="https://user-images.githubusercontent.com/4358288/167453693-560c7d49-73ea-4259-836b-96a5cbbb0bfc.png">

* on hover, `e-remove` would show as the title
* changed title to be "Close"