### PR TITLE
[TW-498] Add permissions to import or deploy AWS API

### DIFF
--- a/src/pages/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws.md
+++ b/src/pages/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws.md
@@ -90,7 +90,7 @@ Next, create an IAM role for Postman in AWS:
     * `"apigateway:GET"` - (Required) Enables viewing API Gateway deployments for HTTP and REST APIs in Postman.
     * `"apigateway:PUT"` - Enables [exporting](#exporting-and-deploying-your-api) HTTP API schemas to the API Gateway.
     * `"apigateway:POST"` - Enables [deploying](#exporting-and-deploying-your-api) HTTP API schemas to a stage on the API Gateway.
-    * ` "apigateway:*"` - Assigns all GET, PUT, POST, PATCH, DELETE permissions to the IAM role.
+    * `"apigateway:*"` - Assigns all GET, PUT, POST, PATCH, DELETE permissions to the IAM role.
     * `"cloudwatch:GetMetricData"` - Enables [viewing CloudWatch metrics](#viewing-cloudwatch-metrics) in Postman.
 
 7. Select **Next: Tags**.
@@ -163,7 +163,7 @@ From the CloudWatch dashboard, you can take the following actions:
 * To view the this stage in AWS, select **View Stage on AWS**.
 * To view the latest CloudWatch metrics, select the refresh icon <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px">.
 
-#### Updating an existing IAM policy for CloudWatch
+### Updating an existing IAM policy for CloudWatch
 
 The Amazon API Gateway integration now supports viewing CloudWatch metrics in Postman. If you previously created an IAM policy when configuring the integration, you need to update the policy to enable CloudWatch metrics. Make sure to add the `"cloudwatch:GetMetricData"` action to your IAM policy:
 

--- a/src/pages/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws.md
+++ b/src/pages/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws.md
@@ -164,7 +164,7 @@ From the CloudWatch dashboard, you can take the following actions:
 
 #### Updating an existing IAM policy for CloudWatch
 
-The Amazon API Gateway integration now supports viewing CloudWatch metrics in Postman. If you previously created an IAM policy when configuring the integration, you need to update the policy to enable CloudWatch metrics. Add the `"cloudwatch:GetMetricData"` action to your IAM policy:
+The Amazon API Gateway integration now supports viewing CloudWatch metrics in Postman. If you previously created an IAM policy when configuring the integration, you need to update the policy to enable CloudWatch metrics. Make sure to add the `"cloudwatch:GetMetricData"` action to your IAM policy:
 
 ```json
 "Action": [

--- a/src/pages/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws.md
+++ b/src/pages/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws.md
@@ -62,7 +62,7 @@ Next, create an IAM role for Postman in AWS:
     > For more information, refer to the [AWS IAM guide on using external IDs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 
 5. Select **Next: Permissions**.
-6. Select an existing IAM policy or select **Create policy**. If you are creating a policy, use the following JSON:
+6. Select an existing IAM policy or select **Create policy**. If you are creating a policy, use the following JSON code:
 
     ```json
     {
@@ -73,6 +73,8 @@ Next, create an IAM role for Postman in AWS:
                 "Effect": "Allow",
                 "Action": [
                     "apigateway:GET",
+                    "apigateway:PUT",
+                    "apigateway:POST",
                     "cloudwatch:GetMetricData"
                 ],
                 "Resource": [
@@ -83,22 +85,18 @@ Next, create an IAM role for Postman in AWS:
     }
     ```
 
+    This policy will enable both importing and exporting for HTTP API schemas. (Import and export are not supported for REST API schemas.) You can customize the `Action` section in the IAM policy based on your needs:
+
+    * `"apigateway:GET"` - (Required) Enables viewing API Gateway metadata, stages, and deployments in Postman.
+    * `"apigateway:PUT"` - (Optional) Enables importing HTTP API schemas from the API Gateway.
+    * `"apigateway:POST"` - (Optional) Enables exporting and deploying HTTP API schemas to the API Gateway.
+    * `"cloudwatch:GetMetricData"` - (Optional) Enables viewing CloudWatch metrics in Postman.
+
 7. Select **Next: Tags**.
 8. Select **Next: Review**.
 9. Add a **Role name** and **Role description**, then select **Create role**.
 
 Copy the **Role ARN** from AWS and paste it in Postman under **Step 2: Enter role ARN and region**. Next, enter the **AWS Region** where the API Gateway is located and select the **API Gateway**. When you're ready, select **Connect**.
-
-#### Updating an exiting IAM policy for CloudWatch
-
-The Amazon API Gateway integration now supports viewing CloudWatch metrics in Postman. If you previously created an IAM policy when configuring the integration, you need to update the policy to enable CloudWatch metrics. Add the following actions to your IAM policy:
-
-```json
-"Action": [
-    "apigateway:GET",
-    "cloudwatch:GetMetricData"
-],
-```
 
 ### Authenticating with an AWS access key
 
@@ -163,6 +161,19 @@ From the CloudWatch dashboard, you can take the following actions:
 * To view metrics for your API Gateway in AWS, select **View Dashboard**.
 * To view the this stage in AWS, select **View Stage on AWS**.
 * To view the latest CloudWatch metrics, select the refresh icon <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px">.
+
+#### Updating an existing IAM policy for CloudWatch
+
+The Amazon API Gateway integration now supports viewing CloudWatch metrics in Postman. If you previously created an IAM policy when configuring the integration, you need to update the policy to enable CloudWatch metrics. Add the `"cloudwatch:GetMetricData"` action to your IAM policy:
+
+```json
+"Action": [
+    "apigateway:GET",
+    "apigateway:PUT",
+    "apigateway:POST",
+    "cloudwatch:GetMetricData"
+],
+```
 
 ## Importing a schema from Amazon API Gateway
 

--- a/src/pages/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws.md
+++ b/src/pages/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws.md
@@ -1,7 +1,7 @@
 ---
 title: 'Deploying to an Amazon API Gateway'
 page_id: 'deploying_an_api_aws'
-updated: 2022-04-21
+updated: 2022-05-16
 search_keyword: "deploy, aws, api gateway"
 warning: false
 contextual_links:
@@ -85,12 +85,13 @@ Next, create an IAM role for Postman in AWS:
     }
     ```
 
-    This policy will enable both importing and exporting for HTTP API schemas. (Import and export are not supported for REST API schemas.) You can customize the `Action` section in the IAM policy based on your needs:
+    This policy will enable exporting and deploying for HTTP API schemas. (Exporting and deploying aren't supported for REST API schemas.) You can customize the `Action` section in the IAM policy based on your needs:
 
-    * `"apigateway:GET"` - (Required) Enables viewing API Gateway metadata, stages, and deployments in Postman.
-    * `"apigateway:PUT"` - (Optional) Enables importing HTTP API schemas from the API Gateway.
-    * `"apigateway:POST"` - (Optional) Enables exporting and deploying HTTP API schemas to the API Gateway.
-    * `"cloudwatch:GetMetricData"` - (Optional) Enables viewing CloudWatch metrics in Postman.
+    * `"apigateway:GET"` - (Required) Enables viewing API Gateway deployments for HTTP and REST APIs in Postman.
+    * `"apigateway:PUT"` - Enables [exporting](#exporting-and-deploying-your-api) HTTP API schemas to the API Gateway.
+    * `"apigateway:POST"` - Enables [deploying](#exporting-and-deploying-your-api) HTTP API schemas to a stage on the API Gateway.
+    * ` "apigateway:*"` - Assigns all GET, PUT, POST, PATCH, DELETE permissions to the IAM role.
+    * `"cloudwatch:GetMetricData"` - Enables [viewing CloudWatch metrics](#viewing-cloudwatch-metrics) in Postman.
 
 7. Select **Next: Tags**.
 8. Select **Next: Review**.
@@ -203,6 +204,8 @@ Exporting an HTTP API schema makes it available in the connected Amazon API Gate
     > To deploy your schema, your gateway must have at least one route with a configured integration.
 
 1. Select **Deploy**.
+
+    > If you have a problem exporting or deploying, make sure you've assigned both the PUT and POST permissions [in your IAM policy](#authenticating-with-an-aws-iam-role).
 
 <img alt="Deploying an API" src="https://assets.postman.com/postman-docs/deploy-api-schema-on-aws-v9-8.jpg" width="502px"/>
 

--- a/src/pages/docs/designing-and-developing-your-api/importing-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/importing-an-api.md
@@ -120,7 +120,7 @@ Next, create an IAM role for Postman in AWS:
     > For more information, refer to the [AWS IAM guide on using external IDs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 
 1. Select **Next: Permissions**.
-6. Select an existing IAM policy or select **Create policy**. If you are creating a policy, use the following JSON code:
+1. Select an existing IAM policy or select **Create policy**. If you are creating a policy, use the following JSON code:
 
     ```json
     {
@@ -148,7 +148,7 @@ Next, create an IAM role for Postman in AWS:
     * `"apigateway:GET"` - (Required) Enables viewing API Gateway deployments for HTTP and REST APIs in Postman.
     * `"apigateway:PUT"` - Enables [exporting](/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws/#exporting-and-deploying-your-api) HTTP API schemas to the API Gateway.
     * `"apigateway:POST"` - Enables [deploying](/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws/#exporting-and-deploying-your-api) HTTP API schemas to a stage on the API Gateway.
-    * ` "apigateway:*"` - Assigns all GET, PUT, POST, PATCH, DELETE permissions to the IAM role.
+    * `"apigateway:*"` - Assigns all GET, PUT, POST, PATCH, DELETE permissions to the IAM role.
     * `"cloudwatch:GetMetricData"` - Enables [viewing CloudWatch metrics](/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws/#viewing-cloudwatch-metrics) in Postman.
 
 1. Select **Next: Tags**.

--- a/src/pages/docs/designing-and-developing-your-api/importing-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/importing-an-api.md
@@ -1,6 +1,6 @@
 ---
 title: 'Importing an API'
-updated: 2022-04-15
+updated: 2022-05-16
 search_keyword: "import, aws, api gateway"
 contextual_links:
   - type: section

--- a/src/pages/docs/designing-and-developing-your-api/importing-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/importing-an-api.md
@@ -120,7 +120,7 @@ Next, create an IAM role for Postman in AWS:
     > For more information, refer to the [AWS IAM guide on using external IDs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 
 1. Select **Next: Permissions**.
-1. Select an existing IAM policy or select **Create policy**. If you are creating a policy, use the following JSON:
+6. Select an existing IAM policy or select **Create policy**. If you are creating a policy, use the following JSON code:
 
     ```json
     {
@@ -131,6 +131,8 @@ Next, create an IAM role for Postman in AWS:
                 "Effect": "Allow",
                 "Action": [
                     "apigateway:GET",
+                    "apigateway:PUT",
+                    "apigateway:POST",
                     "cloudwatch:GetMetricData"
                 ],
                 "Resource": [
@@ -140,6 +142,14 @@ Next, create an IAM role for Postman in AWS:
         ]
     }
     ```
+
+    This policy will enable exporting and deploying for HTTP API schemas. (Exporting and deploying aren't supported for REST API schemas.) You can customize the `Action` section in the IAM policy based on your needs:
+
+    * `"apigateway:GET"` - (Required) Enables viewing API Gateway deployments for HTTP and REST APIs in Postman.
+    * `"apigateway:PUT"` - Enables [exporting](/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws/#exporting-and-deploying-your-api) HTTP API schemas to the API Gateway.
+    * `"apigateway:POST"` - Enables [deploying](/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws/#exporting-and-deploying-your-api) HTTP API schemas to a stage on the API Gateway.
+    * ` "apigateway:*"` - Assigns all GET, PUT, POST, PATCH, DELETE permissions to the IAM role.
+    * `"cloudwatch:GetMetricData"` - Enables [viewing CloudWatch metrics](/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws/#viewing-cloudwatch-metrics) in Postman.
 
 1. Select **Next: Tags**.
 1. Select **Next: Review**.
@@ -160,7 +170,7 @@ Next, enter information about the connection:
 * Enter the **AWS Region** where the API Gateway is located and select the **API Gateway**.
 * Enter an **API Name** for the imported API.
 
-When you're ready, select **Import**.
+When you're ready, select **Import**. After importing your API schema, you can [view API deployments in Postman](/docs/designing-and-developing-your-api/deploying-an-api/deploying-an-api-aws/).
 
 ## Supported API schema formats
 


### PR DESCRIPTION
Added IAM policy permissions needed for exporting or deploying an HTTP API schema from Postman to Amazon API Gateway