### PR TITLE
Add content wordcount to bottom of doc body in development mode

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -156,18 +156,18 @@ module.exports = {
         }
       }
     },
-    {
-      resolve: 'gatsby-plugin-algolia',
-      options: {
-        appId: process.env.GATSBY_ALGOLIA_APP_ID,
-        apiKey: process.env.ALGOLIA_ADMIN_KEY,
-        queries,
-        chunkSize: 10000, // default: 1000
-        enablePartialUpdates: true, // only index new, changed, deleted records
-        matchFields: ['excerpt', 'contextual_links', 'search_keyword', 'headings', 'fields', 'modified'],
-        concurrentQueries: false,
-      },
-    },
+    // {
+    //   resolve: 'gatsby-plugin-algolia',
+    //   options: {
+    //     appId: process.env.GATSBY_ALGOLIA_APP_ID,
+    //     apiKey: process.env.ALGOLIA_ADMIN_KEY,
+    //     queries,
+    //     chunkSize: 10000, // default: 1000
+    //     enablePartialUpdates: true, // only index new, changed, deleted records
+    //     matchFields: ['excerpt', 'contextual_links', 'search_keyword', 'headings', 'fields', 'modified'],
+    //     concurrentQueries: false,
+    //   },
+    // },
     
     {
       resolve: 'gatsby-plugin-purgecss',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -156,19 +156,18 @@ module.exports = {
         }
       }
     },
-    // {
-    //   resolve: 'gatsby-plugin-algolia',
-    //   options: {
-    //     appId: process.env.GATSBY_ALGOLIA_APP_ID,
-    //     apiKey: process.env.ALGOLIA_ADMIN_KEY,
-    //     queries,
-    //     chunkSize: 10000, // default: 1000
-    //     enablePartialUpdates: true, // only index new, changed, deleted records
-    //     matchFields: ['excerpt', 'contextual_links', 'search_keyword', 'headings', 'fields', 'modified'],
-    //     concurrentQueries: false,
-    //   },
-    // },
-    
+    {
+      resolve: 'gatsby-plugin-algolia',
+      options: {
+        appId: process.env.GATSBY_ALGOLIA_APP_ID,
+        apiKey: process.env.ALGOLIA_ADMIN_KEY,
+        queries,
+        chunkSize: 10000, // default: 1000
+        enablePartialUpdates: true, // only index new, changed, deleted records
+        matchFields: ['excerpt', 'contextual_links', 'search_keyword', 'headings', 'fields', 'modified'],
+        concurrentQueries: false,
+      },
+    },
     {
       resolve: 'gatsby-plugin-purgecss',
       options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -42,6 +42,12 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       value: lastModifiedTime,
     })
   }
+  // display console error if algolia indexed frontmatter length exceeds 9999 bytes on build
+  if (node.internal.type === 'frontmatterLength') {
+    if(JSON.parse(node.internal.content).value > 9999) {
+      console.error("IMPORTANT: Frontmatter has too many characters");
+    }
+  }
 };
 
 exports.createPages = async ({ graphql, actions }) => {
@@ -119,13 +125,15 @@ exports.sourceNodes = async ({
     return output;
   };
   const { createNode } = actions;
-  let mdFrontmatterCharacterCount = []
+  let mdFrontmatterCharacterCount = [];
+  let excerptCharacterCount = [];
   const getDirectories = (src) => glob.sync(`${src}/**/*`);
   const paths = getDirectories('./src/pages/docs')
     .filter((val) => val.slice(-3) === '.md')
     .map((val) => {
       const { data } = frontmatter(fs.readFileSync(val));
-      mdFrontmatterCharacterCount.push(data)
+      mdFrontmatterCharacterCount.push(data.title, data.search_keyword);
+      excerptCharacterCount.push(data.excerpt)
       // const algoliaLength = JSON.stringify(val[data]);
       // h = algoliaLength;
       const order = data.order || 200;
@@ -149,17 +157,19 @@ exports.sourceNodes = async ({
 
     let current = output;
     split.forEach((part) => {
-      current[part] = current[part] || {};
+      current[part] = current[part] || {}; 
       current = current[part];
     });
     current.url = `/${split.join('/')}/`;
   });
   mdFrontmatterCharacterCount = JSON.stringify(mdFrontmatterCharacterCount);
   // enable console.logs to view frontmatter object in terminal 'npm run dev'
-  console.log(mdFrontmatterCharacterCount, 'List of all frontmatter objects from md files')
+  // console.log(mdFrontmatterCharacterCount, 'List of all frontmatter objects from md files')
   mdFrontmatterCharacterCount = mdFrontmatterCharacterCount.length;
-  console.log('Length of all frontmatter from md files', mdFrontmatterCharacterCount)
-
+  // console.log('Length of all frontmatter from md files', mdFrontmatterCharacterCount)
+  excerptCharacterCount = JSON.stringify(excerptCharacterCount);
+  excerptCharacterCount = excerptCharacterCount.length;
+  
   createNode(prepareNode(mdFrontmatterCharacterCount, 'frontmatterLength'));
   createNode(prepareNode(output.docs, 'leftNavLinks'));
   createNode(prepareNode(FooterJson, 'FooterLinks'));

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -72,7 +72,7 @@ const DocPage = ({ data }) => {
                 <BreadCrumbsLinks data={{ parentLink, subParentLink }} />
                 <h1>{post.frontmatter.title}</h1>
                 <CreateDoc data={post} />
-                <div>
+                <div className='events__alert mb-3'>
                   <p>
                     <small>{excerptCount ? `Development Notification` : null }</small>
                   <br />

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -54,6 +54,10 @@ const DocPage = ({ data }) => {
   // Breadcrumbs (top of page) & Previous and Next Links (bottom of page) 
   const { parentLink, subParentLink, previous, next } = data;
 
+  let excerptLength = data.markdownRemark.excerpt.length; 
+  let excerptCount = process.env.GATSBY_EXCERPT_COUNT;
+  let overIndexLimit = excerptLength > 6700 ? (excerptLength - 6700) : 0;
+
   return (
     <Layout>
       <SEO title={post.frontmatter.title} slug={post.fields.slug} lastModifiedTime={lastModifiedTime} />
@@ -68,11 +72,18 @@ const DocPage = ({ data }) => {
                 <BreadCrumbsLinks data={{ parentLink, subParentLink }} />
                 <h1>{post.frontmatter.title}</h1>
                 <CreateDoc data={post} />
+                <div>
+                  <p>
+                    <small>{excerptCount ? `Development Notification` : null }</small>
+                  <br />
+                    <small>{excerptCount ? `Wordcount: ${excerptLength} and therefore ${overIndexLimit} words too long to be indexed by Algolia` : null}</small>
+                  </p>
+                </div>
                 <p>
                   <small className="font-italic">Last modified: {lastModifiedDate}</small>
                 </p>
-                                {/* Qualtrics */}
-                                <LoadQualtrics />
+                {/* Qualtrics */}
+                <LoadQualtrics />
                 <PreviousAndNextLinks data={{ previous, next }} />
               </main>
               <aside className="col-sm-12 col-md-12 col-lg-3 offset-lg-0 col-xl-3 offset-xl-1 right-column">
@@ -97,6 +108,7 @@ export const query = graphql`
   query($slug: String!) {
     markdownRemark(fields: { slug: { eq: $slug } }) {
       html
+      excerpt(pruneLength: 20000)
       frontmatter {
         title
         contextual_links {


### PR DESCRIPTION
You can see the wordcount in development mode when running `npm run dev`
<img width="783" alt="Screen Shot 2022-05-24 at 8 30 13 PM" src="https://user-images.githubusercontent.com/36343528/170173781-e2187361-f53a-473d-9143-2742e26069cd.png">

You cannot see it in a production build. Please comment out the `gatsby-plugin-algolia` plugin in gatsby-config.js and run `npm run build:prod && npm run serve `. No notification should be there: 

<img width="779" alt="Screen Shot 2022-05-24 at 8 50 42 PM" src="https://user-images.githubusercontent.com/36343528/170175814-57cbada5-4e2c-4e28-8b39-96f426a8f93d.png">

