### PR TITLE
[TW-576] Fixing broken anchor link in Test script examples TOC

### DIFF
--- a/src/pages/docs/writing-scripts/script-references/test-examples.md
+++ b/src/pages/docs/writing-scripts/script-references/test-examples.md
@@ -72,7 +72,7 @@ Use the **Tests** tab in your requests, folders, and collections to write tests 
     * [Test not failing](#test-not-failing)
 * [Validating response structure](#validating-response-structure)
 * [Sending an asynchronous request](#sending-an-asynchronous-request)
-* [Older style of writing Postman tests (deprecated)](#older-style-of-writing-postman-tests-deprecated)
+* [Previous style of writing Postman tests (deprecated)](#previous-style-of-writing-postman-tests-deprecated)
 
 ## Getting started with tests
 
@@ -136,7 +136,7 @@ const responseJson = xml2Json(pm.response.text());
 
 > If you're dealing with complex XML responses you may find [console logging](/docs/sending-requests/troubleshooting-api-requests/#using-the-console) useful.
 
-To parse CSV, use the [CSV parse](https://github.com/adaltas/node-csv-parse) utility:
+To parse CSV, use the [CSV parse](https://github.com/adaltas/node-csv/tree/master/packages/csv-parse) utility:
 
 ```js
 const parse = require('csv-parse/lib/sync');
@@ -346,7 +346,7 @@ pm.test("Test array properties", () => {
 });
 ```
 
-> The order in `.members` does'nt affect the test.
+> The order in `.members` doesn't affect the test.
 
 ### Asserting object properties
 


### PR DESCRIPTION
In the Test script examples topic, fixing broken anchor link in TOC and other updates. Other updates include updating external link to CSV parse utility and fixing contraction typo.