### PR TITLE
converted button CTAs to use Sentence Case

### DIFF
--- a/src/components/Shared/EditDoc.jsx
+++ b/src/components/Shared/EditDoc.jsx
@@ -41,7 +41,7 @@ class EditDoc extends Component {
             />
           </svg> */}
         </i>
-        Edit this doc
+        Edit this Doc
       </a>
     );
   }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -164,7 +164,7 @@ class IndexPage extends React.Component {
                     Check out the docs and support resources!
                   </p>
                   <a href="/docs/getting-started/introduction/" className="btn btn__primary-hollow mb-5">
-                    Explore the docs
+                    Explore the Docs
                   </a>
                 </div>
                 <div className="col-sm-12 col-md-6 col-lg-6 align-self-center">


### PR DESCRIPTION
- converted button CTAs (2) to use Sentence case as per design guide

Currently:
<img width="202" alt="Screen Shot 2022-07-27 at 17 51 10" src="https://user-images.githubusercontent.com/4358288/181397062-866cd6c0-5195-4069-8a98-b6c4545db73b.png">
<img width="189" alt="Screen Shot 2022-07-27 at 17 51 15" src="https://user-images.githubusercontent.com/4358288/181397068-c1d5a993-e9b3-4cd8-a86d-53dd6f686959.png">

