### PR TITLE
Add Comment and SingleMainWindow to Linux Desktop File

### DIFF
--- a/src/pages/docs/getting-started/installation-and-updates.md
+++ b/src/pages/docs/getting-started/installation-and-updates.md
@@ -97,11 +97,13 @@ Enter the following content in the file, replacing `/path/to/Downloads` with the
 [Desktop Entry]
 Encoding=UTF-8
 Name=Postman
+Comment=An API platform for building and using APIs
 Exec=/path/to/Downloads/Postman/app/Postman %U
 Icon=/path/to/Downloads/Postman/app/resources/app/assets/icon.png
 Terminal=false
 Type=Application
 Categories=Development;
+SingleMainWindow=true
 ```
 
 > Postman supports the following distributions:


### PR DESCRIPTION
Add a `Comment` which is used as a tooltip in some desktop environments and `SingleMainWindow` which signals that only one window can be opened to the Linux Desktop file example.