### PR TITLE
[MARKENG-1638][c] implement PMs pattern for GTM/GA

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,31 +19,6 @@ module.exports = {
   },
   trailingSlash: 'always',
   plugins: [
-    {
-      resolve: 'gatsby-plugin-google-analytics',
-      options: {
-        // The property ID; the tracking code won't be generated without it
-        trackingId: 'UA-43979731-4',
-        // eslint-disable-next-line max-len
-        // Defines where to place the tracking script - `true` in the head and `false` in the body
-        head: true,
-        // Setting this parameter is optional
-        anonymize: true,
-        // Setting this parameter is also optional
-        respectDNT: true,
-        // Delays sending pageview hits on route update (in milliseconds)
-        pageTransitionDelay: 1000,
-        // Defers execution of google analytics script after page load
-        defer: true,
-      },
-    },
-    {
-      resolve: 'gatsby-plugin-google-tagmanager',
-      options: {
-        id: 'GTM-M42M5N',
-        includeInDevelopment: true,
-      },
-    },
     'gatsby-plugin-react-helmet',
     {
       resolve: 'gatsby-source-filesystem',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9341,15 +9341,6 @@
         }
       }
     },
-    "gatsby-plugin-google-tagmanager": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-4.17.0.tgz",
-      "integrity": "sha512-nZWYP0zU4Z5EWmeqEWI1+w/e30VHvU/Eh6nsta/iLLUyqLnkPZvP1kmZaq109M+BbJEsLO6T97rj9SF3k9Il2w==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "web-vitals": "^1.1.2"
-      }
-    },
     "gatsby-plugin-manifest": {
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-4.17.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "gatsby-plugin-env-variables": "2.2.0",
     "gatsby-plugin-gdpr-cookies": "2.0.9",
     "gatsby-plugin-google-analytics": "4.17.0",
-    "gatsby-plugin-google-tagmanager": "4.17.0",
     "gatsby-plugin-manifest": "4.17.0",
     "gatsby-plugin-meta-redirect": "1.1.1",
     "gatsby-plugin-newrelic": "2.2.2",


### PR DESCRIPTION
**What are the changes?**
_Branched from `develop`_, this removes `gatsby-plugin-google-tagmanager`, disables the Gatsby configuration of both two plug-ins _(gatsby-plugin-google-analytics & gatsby-plugin-google-tagmanager)_, and implements Postman's pattern for GTM/GA script insertion.

**Why make these changes?**
By implementing our own pattern, we have finite control of how GTM & GA behaves. This aims to serve as a model for our other web apps that use GA/GTM.

*While `gatsby-plugin-google-tagmanager` was removed from the package json file, `gatsby-plugin-google-analytics` was not. This is because components import the package for `trackCustomEvent` & `OutboundLink`.
<img width="582" alt="trackCustomEvent-n-OutboundLink" src="https://user-images.githubusercontent.com/56083362/183701456-88246152-e30a-4c04-8d76-9dccacd991b2.png">

