### PR TITLE
Updated the styling for h3 on mobile

### DIFF
--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -78,7 +78,7 @@ h3,
 
   @media (max-width: 576px) {
     font-size: 24px;
-    letter-spacing: -0.64px;
+    letter-spacing: 0.64px;
     line-height: 1.5;
   }
 }


### PR DESCRIPTION
Before (left) after (right):
<img width="864" alt="Screen Shot 2022-08-18 at 12 02 43" src="https://user-images.githubusercontent.com/4358288/185474178-c7c959ed-7989-4cb8-92ba-a010f64c934c.png">
