### PR TITLE
Added Postman's NewRelic integration quickstart link

### DIFF
--- a/src/pages/docs/integrations/available-integrations/new-relic.md
+++ b/src/pages/docs/integrations/available-integrations/new-relic.md
@@ -18,7 +18,7 @@ contextual_links:
     url: "https://youtu.be/voAUfBx8fnE"
 ---
 
-New Relic is an application performance management solution to monitor real-time and trending data for your processes or web apps. Using Postman's New Relic integration, you can send [Postman monitor](/docs/monitoring-your-api/intro-monitors/) results to New Relic.
+New Relic is an application performance management solution to monitor real-time and trending data for your processes or web apps. Using Postman's [New Relic integration](https://newrelic.com/instant-observability/postman/d465bf08-b737-4bc5-b5ad-dd5be272967b), you can send [Postman monitor](/docs/monitoring-your-api/intro-monitors/) results to New Relic.
 
 Setting up a New Relic monitor integration requires you to get an API key (Ingest License key) from New Relic and configure your Postman monitors. After you set up the integration, you can view real-time alerts based on the results of your monitors.
 


### PR DESCRIPTION
Hi Postman devs,

We have many users on our platform who are using Postman and would like to instrument it. We’d love to provide a smooth experience for Postman users who need to use commercial monitoring solutions, such as New Relic. Please see our documentation [here](https://newrelic.com/instant-observability/postman/d465bf08-b737-4bc5-b5ad-dd5be272967b) .

Please consider adding a link for your direct users to provide an option for New Relic.  For your convenience, we have submitted this PR with our proposed content.

Please feel free to let us know if you have any questions or concerns.

Thank you for your consideration.
