### PR TITLE
TW 688 Add a note about Governance to the CI page

### DIFF
--- a/src/pages/docs/integrations/ci-integrations.md
+++ b/src/pages/docs/integrations/ci-integrations.md
@@ -52,9 +52,9 @@ To connect your API to your CI project, see the steps for your CI tool:
 
 ## Configuring the Postman CLI for CI
 
-Running API tests as part of your CI pipeline helps to keep expectations between your API producers and consumers in sync. The Postman CLI can also perform [API Governance and API Security checks](/docs/api-governance/api-governance-overview/) as part of your CI pipeline.
+Running API tests as part of your CI pipeline helps to keep expectations between your API producers and consumers in sync. The Postman CLI can also perform [API Governance and API Security checks](/docs/api-governance/api-governance-overview/) as part of your CI pipeline ([Enterprise teams only](https://www.postman.com/pricing/)).
 
-To run your API tests and API Governance and API Security checks along with each build, first generate the Postman CLI configuration code in Postman. Then add the configuration code to your CI project. Each time a CI build runs, the Postman CLI uses the Postman API to run the collections that contain your tests. You can view the results of your tests in Postman.
+To run your API tests along with each build and, optionally, your API Governance and API Security checks, first generate the Postman CLI configuration code in Postman. Then add the configuration code to your CI project. Each time a CI build runs, the Postman CLI uses the Postman API to run the collections that contain your tests. You can view the results of your tests in Postman.
 
 To configure the Postman CLI to run API tests, see the steps for your CI tool:
 

--- a/src/pages/docs/integrations/ci-integrations.md
+++ b/src/pages/docs/integrations/ci-integrations.md
@@ -58,9 +58,9 @@ To run your API tests along with each build and, optionally, your API Governance
 
 To configure the Postman CLI to run API tests, see the steps for your CI tool:
 
-* [Bitbucket Pipelines](/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines/#configuring-newman-for-bitbucket-pipelines)
-* [CircleCI](/docs/integrations/available-integrations/ci-integrations/circleci/#configuring-newman-for-circleci)
+* [Bitbucket Pipelines](/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines/#configuring-the-postman-cli-for-bitbucket-pipelines)
+* [CircleCI](/docs/integrations/available-integrations/ci-integrations/circleci/#configuring-the-postman-cli-for-circleci)
 * [GitHub Actions](/docs/integrations/available-integrations/ci-integrations/github-actions/#configuring-the-postman-cli-for-github-actions)
-* [GitLab CI/CD](/docs/integrations/available-integrations/ci-integrations/gitlab-ci/#configuring-newman-for-gitlab-cicd)
-* [Jenkins](/docs/integrations/available-integrations/ci-integrations/jenkins/#configuring-newman-for-jenkins)
-* [Travis CI](/docs/integrations/available-integrations/ci-integrations/travis-ci/#configuring-newman-for-travis-ci)
+* [GitLab CI/CD](/docs/integrations/available-integrations/ci-integrations/gitlab-ci/#configuring-the-postman-cli-for-gitlab-cicd)
+* [Jenkins](/docs/integrations/available-integrations/ci-integrations/jenkins/#configuring-the-postman-cli-for-jenkins)
+* [Travis CI](/docs/integrations/available-integrations/ci-integrations/travis-ci/#configuring-the-postman-cli-for-travis-ci)

--- a/src/pages/docs/integrations/ci-integrations.md
+++ b/src/pages/docs/integrations/ci-integrations.md
@@ -52,9 +52,9 @@ To connect your API to your CI project, see the steps for your CI tool:
 
 ## Configuring the Postman CLI for CI
 
-Running API tests as part of your CI pipeline helps to keep expectations between your API producers and consumers in sync.
+Running API tests as part of your CI pipeline helps to keep expectations between your API producers and consumers in sync. The Postman CLI can also perform [API Governance and API Security checks](/docs/api-governance/api-governance-overview/) as part of your CI pipeline.
 
-To run your API tests along with each build, first generate the Postman CLI configuration code in Postman. Then add the configuration code to your CI project. Each time a CI build runs, the Postman CLI uses the Postman API to run the collections that contain your tests. You can view the results of your tests in Postman.
+To run your API tests and API Governance and API Security checks along with each build, first generate the Postman CLI configuration code in Postman. Then add the configuration code to your CI project. Each time a CI build runs, the Postman CLI uses the Postman API to run the collections that contain your tests. You can view the results of your tests in Postman.
 
 To configure the Postman CLI to run API tests, see the steps for your CI tool:
 


### PR DESCRIPTION
@savageCoder55 Since each individual integration page has a section about the Postman CLI with a step that mentions API Governance and API Security (for example: https://learning.postman.com/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines/#configuring-the-postman-cli-for-bitbucket-pipelines, step 5), I think this wording update covers your request in TW 688. Let me know if you'd like any additional information added here!