### PR TITLE
[TW-685] Added API linting results sections to CI integrations

### DIFF
--- a/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
@@ -65,7 +65,7 @@ Using the Postman CLI, you can enforce [API Governance and API Security rules ea
 
 To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for Bitbucket Pipelines](#configuring-the-postman-cli-for-bitbucket-pipelines) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
-<img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-v10.jpg">
 
 ## Configuring the Postman CLI for Bitbucket Pipelines
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
@@ -61,7 +61,7 @@ To view details for collections that were run as part of a build, first [configu
 
 ## Viewing API linting results
 
-Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [`api lint` command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
 
 To view API linting results that were run as part of the build, first [configure the Postman CLI for Bitbucket Pipelines](#configuring-the-postman-cli-for-bitbucket-pipelines) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
@@ -63,7 +63,7 @@ To view details for collections that were run as part of a build, first [configu
 
 Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [`api lint` command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
 
-To view API linting results that were run as part of the build, first [configure the Postman CLI for Bitbucket Pipelines](#configuring-the-postman-cli-for-bitbucket-pipelines) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for Bitbucket Pipelines](#configuring-the-postman-cli-for-bitbucket-pipelines) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
 <img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
@@ -59,6 +59,14 @@ To view details for collections that were run as part of a build, first [configu
 
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/running-collections/intro-to-collection-runs/).
 
+## Viewing API linting results
+
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+
+To view API linting results that were run as part of the build, first [configure the Postman CLI for Bitbucket Pipelines](#configuring-the-postman-cli-for-bitbucket-pipelines) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+
+<img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+
 ## Configuring the Postman CLI for Bitbucket Pipelines
 
 With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your Bitbucket pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `bitbucket-pipelines.yml` file in your Bitbucket repository.
@@ -73,7 +81,7 @@ To generate configuration code for the Postman CLI:
 1. Under **CI/CD Builds**, select **View All Builds**.
 1. Select **Configure Postman CLI**.
 1. Select a **Collection** to run during pipeline builds. To be available in the list, you must first [add the collection as a test suite](/docs/designing-and-developing-your-api/testing-an-api/#adding-tests) to your API. You can also select an **Environment** to use.
-1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)). To review rule violations, go to the API's overview page and select **View files** under **Definition**.
+1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)).
 1. Select the **Operating system** for your CI/CD pipeline.
 1. Select **Copy Postman CLI Command** to copy the Postman CLI configuration.
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
@@ -59,7 +59,7 @@ To view details for collections that were run as part of a build, first [configu
 
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/running-collections/intro-to-collection-runs/).
 
-## Viewing API linting results
+## Viewing API Governance and API Security rule violations
 
 Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [`api lint` command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
@@ -58,6 +58,14 @@ Select **View All Builds** to view the full list of build jobs. From here you ca
 
 <img alt="View all CircleCI builds" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
 
+## Viewing API linting results
+
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+
+To view API linting results that were run as part of the build, first [configure the Postman CLI for CircleCI](#configuring-the-postman-cli-for-circleci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+
+<img alt="View API linting results" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+
 ## Configuring the Postman CLI for CircleCI
 
 With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your CircleCI pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `config.yml` file in your CircleCI project.
@@ -70,7 +78,7 @@ To generate configuration code for the Postman CLI:
 1. Under **CI/CD Builds**, select **View All Builds**.
 1. Select **Configure Postman CLI**.
 1. Select a **Collection** to run during pipeline builds. To be available in the dropdown list, you must first [add the collection as a test suite](/docs/designing-and-developing-your-api/testing-an-api/#adding-tests) to your API. You can also select an **Environment** to use.
-1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)). To review rule violations, go to the API's overview page and select **View files** under **Definition**.
+1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)).
 1. Select the **Operating system** for your CI/CD pipeline.
 1. Select **Copy Postman CLI Command** to copy the Postman CLI configuration.
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
@@ -64,7 +64,7 @@ Using the Postman CLI, you can enforce [API Governance and API Security rules ea
 
 To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for CircleCI](#configuring-the-postman-cli-for-circleci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
-<img alt="View API linting results" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-v10.jpg">
 
 ## Configuring the Postman CLI for CircleCI
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
@@ -58,11 +58,11 @@ Select **View All Builds** to view the full list of build jobs. From here you ca
 
 <img alt="View all CircleCI builds" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
 
-## Viewing API linting results
+## Viewing API Governance and API Security rule violations
 
-Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [`api lint` command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
 
-To view API linting results that were run as part of the build, first [configure the Postman CLI for CircleCI](#configuring-the-postman-cli-for-circleci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for CircleCI](#configuring-the-postman-cli-for-circleci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
 <img alt="View API linting results" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
@@ -22,6 +22,7 @@ To set up a GitHub Actions integration for your API, first create a pipeline in 
 * [Configuring a GitHub Actions integration](#configuring-a-github-actions-integration)
 * [Viewing build status](#viewing-build-status)
 * [Viewing collection run details](#viewing-collection-run-details)
+* [Viewing API linting results](#viewing-api-linting-results)
 * [Configuring the Postman CLI for GitHub Actions](#configuring-the-postman-cli-for-github-actions)
 
 ## Creating a pipeline in GitHub
@@ -74,6 +75,14 @@ To view details for collections that were run as part of a build, first [configu
 
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/running-collections/intro-to-collection-runs/).
 
+## Viewing API linting results
+
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+
+To view API linting results that were run as part of the build, first [configure the Postman CLI for GitHub Actions](#configuring-the-postman-cli-for-github-actions) and then start a new build on GitHub. After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+
+<img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+
 ## Configuring the Postman CLI for GitHub Actions
 
 With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your GitHub pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to a YAML file in the `.github/workflows` directory in your GitHub repository.
@@ -88,7 +97,7 @@ To generate configuration code for the Postman CLI:
 1. Under the repository name, select **View All Builds**.
 1. Select **Configure Postman CLI**.
 1. Select a **Collection** to run during pipeline builds. To be available in the list, you must first [add the collection as a test suite](/docs/designing-and-developing-your-api/testing-an-api/#adding-tests) to your API. You can also select an **Environment** to use.
-1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)). To review rule violations, go to the API's overview page and select **View files** under **Definition**.
+1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)).
 1. Select the **Operating system** for your CI/CD pipeline.
 1. Select **Copy Postman CLI Command** to copy the Postman CLI configuration.
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
@@ -63,7 +63,7 @@ Select **View All Builds** to view the full list of build jobs. From here you ca
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px">.
 
-<img alt="View all GitHub builds" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+<img alt="View all GitHub builds" src="https://assets.postman.com/postman-docs/v10/github-actions-collection-runs-v10.jpg">
 
 ## Viewing collection run details
 
@@ -71,7 +71,7 @@ Using the Postman CLI, you can run Postman collections with your API tests as pa
 
 To view details for collections that were run as part of a build, first [configure the Postman CLI for GitHub](#configuring-the-postman-cli-for-github-actions) and then start a new build in GitHub. To learn more about starting builds, see [the GitHub Actions documentation](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow). After the build is complete, use the arrows to expand a build and expand a collection to view details about a collection run.
 
-<img alt="View GitHub Actions collection runs" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+<img alt="View GitHub Actions collection runs" src="https://assets.postman.com/postman-docs/v10/github-actions-collection-runs-v10.jpg">
 
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/running-collections/intro-to-collection-runs/).
 
@@ -81,7 +81,7 @@ Using the Postman CLI, you can enforce [API Governance and API Security rules ea
 
 To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for GitHub Actions](#configuring-the-postman-cli-for-github-actions) and then start a new build on GitHub. After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
-<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-v10.jpg">
+<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/github-actions-api-governance-and-security-results-v10.jpg">
 
 ## Configuring the Postman CLI for GitHub Actions
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
@@ -22,7 +22,7 @@ To set up a GitHub Actions integration for your API, first create a pipeline in 
 * [Configuring a GitHub Actions integration](#configuring-a-github-actions-integration)
 * [Viewing build status](#viewing-build-status)
 * [Viewing collection run details](#viewing-collection-run-details)
-* [Viewing API linting results](#viewing-api-linting-results)
+* [Viewing API Governance and API Security rule violations](#viewing-api-governance-and-api-security-rule-violations)
 * [Configuring the Postman CLI for GitHub Actions](#configuring-the-postman-cli-for-github-actions)
 
 ## Creating a pipeline in GitHub
@@ -75,11 +75,11 @@ To view details for collections that were run as part of a build, first [configu
 
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/running-collections/intro-to-collection-runs/).
 
-## Viewing API linting results
+## Viewing API Governance and API Security rule violations
 
-Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [`api lint` command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
 
-To view API linting results that were run as part of the build, first [configure the Postman CLI for GitHub Actions](#configuring-the-postman-cli-for-github-actions) and then start a new build on GitHub. After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for GitHub Actions](#configuring-the-postman-cli-for-github-actions) and then start a new build on GitHub. After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
 <img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
@@ -81,7 +81,7 @@ Using the Postman CLI, you can enforce [API Governance and API Security rules ea
 
 To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for GitHub Actions](#configuring-the-postman-cli-for-github-actions) and then start a new build on GitHub. After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
-<img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-v10.jpg">
 
 ## Configuring the Postman CLI for GitHub Actions
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
@@ -78,7 +78,7 @@ Using the Postman CLI, you can enforce [API Governance and API Security rules ea
 
 To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for GitLab](#configuring-the-postman-cli-for-gitlab-cicd) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
-<img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-v10.jpg">
 
 ## Configuring the Postman CLI for GitLab CI/CD
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
@@ -72,6 +72,14 @@ To view details for collections that were run as part of a build, first [configu
 
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/running-collections/intro-to-collection-runs/).
 
+## Viewing API linting results
+
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+
+To view API linting results that were run as part of the build, first [configure the Postman CLI for GitLab](#configuring-the-postman-cli-for-gitlab-cicd) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+
+<img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+
 ## Configuring the Postman CLI for GitLab CI/CD
 
 With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your GitLab pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `.gitlab-ci.yml` file in your GitLab repository.
@@ -86,7 +94,7 @@ To generate configuration code for the Postman CLI:
 1. Under **CI/CD Builds**, select **View All Builds**.
 1. Select **Configure Postman CLI**.
 1. Select a **Collection** to run during pipeline builds. To be available in the dropdown list, you must first [add the collection as a test suite](/docs/designing-and-developing-your-api/testing-an-api/#adding-tests) to your API. You can also select an **Environment** to use.
-1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)). To review rule violations, go to the API's overview page and select **View files** under **Definition**.
+1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)).
 1. Select the **Operating system** for your CI/CD pipeline.
 1. Select **Copy Postman CLI Command** to copy the Postman CLI configuration.
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
@@ -72,11 +72,11 @@ To view details for collections that were run as part of a build, first [configu
 
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/running-collections/intro-to-collection-runs/).
 
-## Viewing API linting results
+## Viewing API Governance and API Security rule violations
 
-Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [`api lint` command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
 
-To view API linting results that were run as part of the build, first [configure the Postman CLI for GitLab](#configuring-the-postman-cli-for-gitlab-cicd) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for GitLab](#configuring-the-postman-cli-for-gitlab-cicd) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
 <img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
@@ -73,11 +73,11 @@ To view details for collections that were run as part of a build, first [configu
 
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/running-collections/intro-to-collection-runs/).
 
-## Viewing API linting results
+## Viewing API Governance and API Security rule violations
 
-Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [`api lint` command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
 
-To view API linting results that were run as part of the build, first [configure the Postman CLI for Jenkins](#configuring-the-postman-cli-for-jenkins) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for Jenkins](#configuring-the-postman-cli-for-jenkins) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
 <img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
@@ -79,7 +79,7 @@ Using the Postman CLI, you can enforce [API Governance and API Security rules ea
 
 To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for Jenkins](#configuring-the-postman-cli-for-jenkins) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
-<img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-v10.jpg">
 
 ## Configuring the Postman CLI for Jenkins
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
@@ -73,6 +73,14 @@ To view details for collections that were run as part of a build, first [configu
 
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/running-collections/intro-to-collection-runs/).
 
+## Viewing API linting results
+
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+
+To view API linting results that were run as part of the build, first [configure the Postman CLI for Jenkins](#configuring-the-postman-cli-for-jenkins) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+
+<img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+
 ## Configuring the Postman CLI for Jenkins
 
 With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your Jenkins pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to your Jenkins pipeline.
@@ -87,7 +95,7 @@ To generate configuration code for the Postman CLI:
 1. Under **CI/CD Builds**, select **View Builds**.
 1. Select **Configure Postman CLI**.
 1. Select a **Collection** to run during pipeline builds. To be available in the dropdown list, you must first [add the collection as a test suite](/docs/designing-and-developing-your-api/testing-an-api/#adding-tests) to your API. You can also select an **Environment** to use.
-1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)). To review rule violations, go to the API's overview page and select **View files** under **Definition**.
+1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)).
 1. Select the **Operating system** for your CI/CD pipeline.
 1. Select **Copy Postman CLI Command** to copy the Postman CLI configuration.
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
@@ -62,7 +62,7 @@ Using the Postman CLI, you can enforce [API Governance and API Security rules ea
 
 To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for Travis CI](#configuring-the-postman-cli-for-travis-ci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
-<img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-v10.jpg">
 
 ## Configuring the Postman CLI for Travis CI
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
@@ -56,6 +56,14 @@ Select **View All Builds** to view the full list of build jobs. From here you ca
 
 <img alt="View all Travis CI builds" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
 
+## Viewing API linting results
+
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+
+To view API linting results that were run as part of the build, first [configure the Postman CLI for Travis CI](#configuring-the-postman-cli-for-travis-ci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+
+<img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+
 ## Configuring the Postman CLI for Travis CI
 
 With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your Travis CI pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `.travis.yml` file in your Travis CI project.
@@ -68,7 +76,7 @@ To generate configuration code for the Postman CLI:
 1. Under **CI/CD Builds**, select **View All Builds**.
 1. Select **Configure Postman CLI**.
 1. Select a **Collection** to run during pipeline builds. To be available in the dropdown list, you must first [add the collection as a test suite](/docs/designing-and-developing-your-api/testing-an-api/#adding-tests) to your API. You can also select an **Environment** to use.
-1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)). To review rule violations, go to the API's overview page and select **View files** under **Definition**.
+1. (Optional) Select the checkbox to enforce API Governance and API Security rules each time the CI/CD pipeline runs ([Enterprise teams only](https://www.postman.com/pricing/)).
 1. Select the **Operating system** for your CI/CD pipeline.
 1. Select **Copy Postman CLI Command** to copy the Postman CLI configuration.
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
@@ -56,11 +56,11 @@ Select **View All Builds** to view the full list of build jobs. From here you ca
 
 <img alt="View all Travis CI builds" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
 
-## Viewing API linting results
+## Viewing API Governance and API Security rule violations
 
-Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [API linting command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
+Using the Postman CLI, you can enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) using the [`api lint` command](/docs/postman-cli/postman-cli-options/#governance-and-security) ([Enterprise teams only](https://www.postman.com/pricing/)).
 
-To view API linting results that were run as part of the build, first [configure the Postman CLI for Travis CI](#configuring-the-postman-cli-for-travis-ci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view API linting results.
+To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for Travis CI](#configuring-the-postman-cli-for-travis-ci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
 <img alt="View API linting" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
 

--- a/src/pages/docs/postman-cli/postman-cli-options.md
+++ b/src/pages/docs/postman-cli/postman-cli-options.md
@@ -128,11 +128,11 @@ postman collection run 12345678-12345ab-1234-1ab2-1ab2-ab1234112a12
 
 ## Governance and security
 
-API governance is the practice of applying a defined set of standards consistently across your API design and testing phases of your development process. The Postman CLI includes an API linting command, described below. (This feature is available for [Enterprise teams only](https://www.postman.com/pricing/)).
+API governance is the practice of applying a defined set of standards consistently across your API design and testing phases of your development process. The Postman CLI includes a command that checks your API definitions against your team's configured API Governance and API Security rules. (This feature is available for [Enterprise teams only](https://www.postman.com/pricing/)).
 
 ### postman api lint
 
-This command runs validation checks for governance and security rules against the API definition provided in the Postman config file, a local file, or a UUID. You can only lint single-file definitions. `api lint` shows a warning if unable to find the API ID to send data back to Postman.
+This command runs validation checks for governance and security rules against the API definition provided in the Postman config file, a local file, or a UUID. `api lint` shows a warning if unable to find the API ID to send data back to Postman.
 
 > This command supports APIs that are stored on Postman and aren't linked to Git.
 

--- a/src/pages/docs/postman-cli/postman-cli-overview.md
+++ b/src/pages/docs/postman-cli/postman-cli-overview.md
@@ -20,7 +20,7 @@ The Postman CLI is a secure command-line companion for Postman. It is secured an
 * Run a collection with its collection ID or path.
 * Send run results to Postman by default.
 * Supports log in and log out.
-* Lint an API and run validation checks for governance and security rules.
+* Check API definitions against configured API Governance and API Security rules
 
 ## Contents
 
@@ -42,7 +42,7 @@ The table below shows some high-level differences between the Postman CLI and Ne
 | Downloadable programmatically | Downloadable programmatically
 | Not available as a library | Available as a library
 | Supports log in and log out | Doesn't support log in and log out |
-| Supports API linting | Doesn't support API linting |
+| Checks API definition against configured API Governance and API Security rules | Doesn't check API definition against configured API Governance and API Security rules |
 
 ## Deciding which command-line companion to use
 


### PR DESCRIPTION
In each CI integration page:
* Added a section about viewing API linting results.
* Removed brief explanation about viewing rule violations because the instructions are not specific to CI integrations. Viewing instructions are now in the new "Viewing API linting results" section.

**Note:** Screenshots in the "Viewing API linting results" section are placeholders for now.