### PR TITLE
TW 655 Doc ability to hide a diff in the changelog

### DIFF
--- a/src/pages/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections.md
@@ -30,6 +30,7 @@ Each Postman Collection has a changelog that covers create, update, transfer, an
 ## Contents
 
 * Viewing changes to a [collection](#viewing-the-collection-changelog), [workspace](#viewing-workspace-activity), or [team](#viewing-team-activity)
+* [Hiding diffs in the changelog](#hiding-diffs-in-the-changelog)
 * [Restoring collections](#restoring-collections)
 * [Exporting team activity](#exporting-team-activity-to-other-platforms)
 * [Next steps](#next-steps)
@@ -87,6 +88,18 @@ To filter by element, select **Entity** at the top of the activity feed and sele
 ## Viewing team activity
 
 You can review your team's activity with a Postman Basic, Professional, or Enterprise account. To do so, select **Home** in the upper-left. You can view your team **Activity Feed** on the right.
+
+## Hiding diffs in the changelog
+
+If you have an [Editor role](/docs/collaborating-in-postman/roles-and-permissions/#collection-roles) for a collection, you can hide specific actions in its [changelog](#viewing-the-collection-changelog). When you hide a diff, users who don’t have Editor permissions on the collection won’t be able to view that entry in the changelog. This enables you to protect sensitive data in a public collection.
+
+Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> then select **Hide diff for this change**.
+
+<img alt="Hide a diff in the changelog" src="https://assets.postman.com/postman-docs/v10/changelog-hide-diff-v10.jpg" width="425px"/>
+
+To restore the diff to the changelog, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> then select  **Show diff to all users**. Once you restore the diff, all users will be able to view it in the changelog.
+
+<img alt="Restore a diff to the changelog" src="https://assets.postman.com/postman-docs/v10/changelog-unhide-diff-v10.jpg" width="425px"/>
 
 ## Restoring collections
 

--- a/src/pages/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections.md
@@ -91,15 +91,15 @@ You can review your team's activity with a Postman Basic, Professional, or Enter
 
 ## Hiding diffs in the changelog
 
-If you have an [Editor role](/docs/collaborating-in-postman/roles-and-permissions/#collection-roles) for a collection, you can hide specific actions in its [changelog](#viewing-the-collection-changelog). When you hide a diff, users who don’t have Editor permissions on the collection won’t be able to view that entry in the changelog. This enables you to protect sensitive data in a public collection.
+If you have an [Editor role](/docs/collaborating-in-postman/roles-and-permissions/#collection-roles) for a collection, you can hide specific actions in its [changelog](#viewing-the-collection-changelog). When you hide a changelog entry's diff, users who don’t have Editor permissions on the collection can't view that diff in the changelog. This enables you to protect sensitive data in a public collection.
 
-Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> then select **Hide diff for this change**.
+Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> for the changelog entry, then select **Hide diff for this change**.
 
 <img alt="Hide a diff in the changelog" src="https://assets.postman.com/postman-docs/v10/changelog-hide-diff-v10.jpg" width="425px"/>
 
-To restore the diff to the changelog, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> then select  **Show diff to all users**. Once you restore the diff, all users will be able to view it in the changelog.
+To unhide the diff, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> for the changelog entry, then select  **Show diff to all users**. Once you unhide the diff, all users will be able to view it in the changelog.
 
-<img alt="Restore a diff to the changelog" src="https://assets.postman.com/postman-docs/v10/changelog-unhide-diff-v10.jpg" width="425px"/>
+<img alt="Unhide a diff in the changelog" src="https://assets.postman.com/postman-docs/v10/changelog-unhide-diff-v10.jpg" width="425px"/>
 
 ## Restoring collections
 


### PR DESCRIPTION
This PR adds a section to https://learning.postman.com/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections/ about the ability to hide and unhide diffs from the changelog. 