### PR TITLE
[MARKENG-1826][c] update fetchPmTech script to use WORKER to avoid new build constraint

### DIFF
--- a/.github/workflows/beta-deploy.yml
+++ b/.github/workflows/beta-deploy.yml
@@ -46,6 +46,7 @@ jobs:
           RELIC_PRODUCTION_APPLICATION_ID: ${{ secrets.RELIC_PRODUCTION_APPLICATION_ID }}
           PM_TECH: ${{secrets.PM_TECH}}
           SITE_URL: ${{secrets.SITE_URL_BETA}}
+          WORKER: ${{secrets.WORKER}}
         run: |
             npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}
             npm install
@@ -61,7 +62,6 @@ jobs:
           DISTRIBUTION: ${{ secrets.BETA_DIST_ID }}
           AWS_ACCESS_KEY_ID: ${{ secrets.BETA_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.BETA_AWS_SECRET_ACCESS_KEY }}
-
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     - name: lint all markdownfiles
       env:
         PM_TECH: ${{secrets.PM_TECH}}
+        WORKER: ${{secrets.WORKER}}
       run: |
         npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}
         npm install
@@ -32,6 +33,7 @@ jobs:
     - name: running unit tests
       env:
         PM_TECH: ${{secrets.PM_TECH}}
+        WORKER: ${{secrets.WORKER}}
       run: |
         npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}
         npm install

--- a/.github/workflows/manual-rerun.yml
+++ b/.github/workflows/manual-rerun.yml
@@ -14,6 +14,7 @@ jobs:
     - name: lint all markdownfiles
       env:
         PM_TECH: ${{secrets.PM_TECH}}
+        WORKER: ${{secrets.WORKER}}
       run: |
         npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}
         npm install
@@ -28,6 +29,7 @@ jobs:
     - name: running unit tests
       env:
         PM_TECH: ${{secrets.PM_TECH}}
+        WORKER: ${{secrets.WORKER}}
       run: |
         npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}
         npm install

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -34,10 +34,10 @@ jobs:
         RELIC_PRODUCTION_APPLICATION_ID: ${{ secrets.RELIC_PRODUCTION_APPLICATION_ID }}
         PM_TECH: ${{secrets.PM_TECH}}
         SITE_URL: ${{secrets.SITE_URL_PROD}}
+        WORKER: ${{secrets.WORKER}}
 
       run: |
         npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}
         npm install
         npm run clean
         npm run build:prod && node_modules/s3-deploy/bin/s3-deploy './public/**' --cwd './public/' --bucket postman-learning-center-prod --deleteRemoved --distId $DIST_ID --invalidate '/*'
-

--- a/build/fetchPmTech.js
+++ b/build/fetchPmTech.js
@@ -18,14 +18,15 @@ async function compress(t) {
   return result;
 }
 
-const host = process.env.PM_TECH || '';
+const host = process.env.WORKER || '';
 
 const fetchPmTech = () => new Promise((resolve) => {
   fetch(host, requestOptions).then((resp) => {
     if (resp) {
       resp.json().then((data) => {
-        const tag = data['postman-docs'];
-        const script = base64.decode(data.version[tag]);
+        const pmTech = JSON.parse(data.pmTech);
+        const tag = pmTech['postman-docs'];
+        const script = base64.decode(pmTech.version[tag]);
 
         compress(script).then((compressed) => {
           sh.exec('mkdir -p bff-data');


### PR DESCRIPTION
**What are the changes?**
_Branched from `develop`_, this switches out the endpoint to use the WORKER secret for building the app.

**Why make these changes?**
This makes it similar to how the www app does it. The reason LC doesn't do it the www way is because there'd be some extraneous stuff in the build payload that doesn't concern LC. But more importantly, doesn't seem prone to this new build constraint.

_*no-visuals_