### PR TITLE
TW 609 User profile updates

### DIFF
--- a/src/components/LeftNav/LeftNavItems.jsx
+++ b/src/components/LeftNav/LeftNavItems.jsx
@@ -55,7 +55,7 @@ export const leftNavItems = [
         url: '/docs/getting-started/postman-account/',
       },
       {
-        name: 'Creating your Postman profile',
+        name: 'Customizing your Postman profile',
         url: '/docs/getting-started/postman-profile/',
       },
       {

--- a/src/components/LeftNav/LeftNavItems.jsx
+++ b/src/components/LeftNav/LeftNavItems.jsx
@@ -55,6 +55,10 @@ export const leftNavItems = [
         url: '/docs/getting-started/postman-account/',
       },
       {
+        name: 'Creating your Postman profile',
+        url: '/docs/getting-started/postman-profile/',
+      },
+      {
         name: 'Syncing your work',
         url: '/docs/getting-started/syncing/',
       },

--- a/src/pages/docs/getting-started/postman-account.md
+++ b/src/pages/docs/getting-started/postman-account.md
@@ -12,7 +12,7 @@ contextual_links:
   - type: section
     name: "Next Steps"
   - type: link
-    name: "Creating your Postman profile"
+    name: "Customizing your Postman profile"
     url: "/docs/getting-started/postman-profile/"
 
 warning: false
@@ -50,7 +50,7 @@ Postman prompts you to sign in or sign up. Select __Create Account__. You can si
 
 When you sign up for a Postman account, you'll be prompted to provide some information about yourself, including your name and role, to help customize your Postman experience. Enter your details and select __Continue__.
 
-Your new Postman profile will be visible to collaborators and anyone viewing resources you share or publish. To learn more about your Postman profile and how to customize it, see [Creating your Postman profile](/docs/getting-started/postman-profile/).
+Your new Postman profile will be visible to collaborators and anyone viewing resources you share or publish. To learn more about your Postman profile and how to customize it, see [Customizing your Postman profile](/docs/getting-started/postman-profile/).
 
 ### Creating or joining a team
 

--- a/src/pages/docs/getting-started/postman-account.md
+++ b/src/pages/docs/getting-started/postman-account.md
@@ -10,17 +10,10 @@ contextual_links:
     name: "Download and Install"
     url: "https://www.postman.com/downloads/"
   - type: section
-    name: "Additional Resources"
-  - type: subtitle
-    name: "Videos"
-  - type: link
-    name: "Public Profiles | Postman Level Up"
-    url:  "https://youtu.be/w-EgqQ8Anvw"
-  - type: section
     name: "Next Steps"
   - type: link
-    name: "Syncing your work"
-    url: "/docs/getting-started/syncing/"
+    name: "Creating your Postman profile"
+    url: "/docs/getting-started/postman-profile/"
 
 warning: false
 
@@ -40,11 +33,6 @@ Signing up for a Postman account is optional, and you can use the Postman deskto
     * [Changing your email address](#changing-your-email-address)
     * [Resetting your password](#resetting-your-password)
     * [Deleting your account](#deleting-your-account)
-* [Updating your profile settings](#updating-your-profile-settings)
-    * [Updating your username](#updating-your-username)
-    * [Updating your About Me section](#updating-your-about-me-section)
-    * [Pinning elements to your profile](#pinning-elements-to-your-profile)
-    * [Making your profile public](#making-your-profile-public)
 * [Updating your notification preferences](#updating-your-notification-preferences)
 * [Managing your active sessions](#managing-your-active-sessions)
 * [Upgrading your account](#upgrading-your-account)
@@ -62,9 +50,7 @@ Postman prompts you to sign in or sign up. Select __Create Account__. You can si
 
 When you sign up for a Postman account, you'll be prompted to provide some information about yourself, including your name and role, to help customize your Postman experience. Enter your details and select __Continue__.
 
-Your new Postman profile will be visible to collaborators and anyone viewing resources you share or publish.
-
-> You can update your [account settings](#updating-your-account-settings) and [profile settings](#updating-your-profile-settings) at any time.
+Your new Postman profile will be visible to collaborators and anyone viewing resources you share or publish. To learn more about your Postman profile and how to customize it, see [Creating your Postman profile](/docs/getting-started/postman-profile/).
 
 ### Creating or joining a team
 
@@ -126,28 +112,6 @@ You must leave all Postman teams that you're a member of prior to deleting your 
 If you're a member of an Enterprise team with [SCIM](/docs/administration/scim-provisioning/scim-provisioning-overview/) enabled, you must contact a Team Admin to remove your Postman account from that team.
 
 Once you're no longer a member of any Postman team, you can permanently delete your Postman account in your [account settings](https://go.postman.co/settings/me/account/). Select your avatar in the upper-right corner > **Settings** > **Account**. Select **Delete Account**. Before deleting your account, Postman will prompt you to sign in again to confirm that you own the account.
-
-## Updating your profile
-
-You can update your Postman profile and add more details about you on your [profile settings](https://go.postman.co/settings/me/) page.
-
-Your profile includes an About Me section, an activity feed, pinned elements, the lists elements you have forked and are watching, and a list of the workspaces, collections, and APIs you have contributed in Postman.
-
-<!-- TODO: screenshot -->
-
-### Updating your username
-
-You can update your username at any time by navigating to your [profile settings](https://go.postman.co/settings/me/). Select your avatar in the upper-right corner > **Settings**. Edit your username and select **Update Profile** to save changes.
-
-### Updating your About Me section
-
-supports markdown. add information about you, your work, interests, and contributions - anything you want people looking at your profile to know!
-
-### Pinning elements to your profile
-
-### Making your profile public
-
-Your Postman profile is visible to your Postman team, and you can choose to make your profile public to the Postman community. You can turn your public profile on or off at any time in your [profile settings](https://go.postman.co/settings/me/). Select your avatar in the upper-right corner > **Settings** > **Profile**. Select **Make profile public**, then select **Update Profile** to save your changes.
 
 ## Updating your notification preferences
 

--- a/src/pages/docs/getting-started/postman-account.md
+++ b/src/pages/docs/getting-started/postman-account.md
@@ -36,7 +36,15 @@ Signing up for a Postman account is optional, and you can use the Postman deskto
 
 * [Signing up for a Postman account](#signing-up-for-a-postman-account)
 * [Signing into Postman](#signing-into-postman)
-* [Updating your account and profile settings](#updating-your-account-and-profile-settings)
+* [Updating your account settings](#updating-your-account-settings)
+    * [Changing your email address](#changing-your-email-address)
+    * [Resetting your password](#resetting-your-password)
+    * [Deleting your account](#deleting-your-account)
+* [Updating your profile settings](#updating-your-profile-settings)
+    * [Updating your username](#updating-your-username)
+    * [Updating your About Me section](#updating-your-about-me-section)
+    * [Pinning elements to your profile](#pinning-elements-to-your-profile)
+    * [Making your profile public](#making-your-profile-public)
 * [Updating your notification preferences](#updating-your-notification-preferences)
 * [Managing your active sessions](#managing-your-active-sessions)
 * [Upgrading your account](#upgrading-your-account)
@@ -56,7 +64,7 @@ When you sign up for a Postman account, you'll be prompted to provide some infor
 
 Your new Postman profile will be visible to collaborators and anyone viewing resources you share or publish.
 
-> You can [update your account and profile settings](#updating-your-account-and-profile-settings) at any time.
+> You can update your [account settings](#updating-your-account-settings) and [profile settings](#updating-your-profile-settings) at any time.
 
 ### Creating or joining a team
 
@@ -89,21 +97,17 @@ If you're a member of multiple Postman teams with varying authentication methods
 
 You can sign in to multiple accounts at the same time in Postman. Select your avatar in the top right to switch between accounts or select __+ Add Account__ to sign in with another one.
 
-## Updating your account and profile settings
-
-You can manage your account and profile settings on your [account settings](https://go.postman.co/settings/me/) page. Account settings include your email address and password, and profile settings include your username, bio, and profile photo.
-
-### Updating your account settings
+## Updating your account settings
 
 You can manage account settings including your email address, password, and workspace data on your [account settings](https://go.postman.co/settings/me/account/) page.
 
-#### Changing your email address
+### Changing your email address
 
 If you're on a Professional, Basic, or Free plan, you can change the email address associated with your Postman account. Open your [account settings](https://go.postman.co/settings/me/account/) page. Select your avatar in the upper-right corner > **Settings** > **Account**. Edit your email address and select **Update Email** to save changes.
 
 If you're on an Enterprise plan, you must contact your Team Admins to update the email address associated with your Postman account.
 
-#### Resetting your password
+### Resetting your password
 
 If you're on a Professional, Basic, or Free plan, you can reset your password if you're already signed in by navigating to your [account settings](https://go.postman.co/settings/me/account/) page. Select your avatar in the upper-right corner > **Settings** > **Account**. Select **Edit Password**.
 
@@ -113,7 +117,7 @@ If you aren't signed in to your Postman account, you can recover your username o
 
 If you're on an Enterprise plan, you must contact your Team Admins to update the password associated with your Postman account.
 
-#### Deleting your account
+### Deleting your account
 
 Deleting your account is an irreversible operation. Any data synced to your account will be deleted and no longer be accessible.
 
@@ -123,15 +127,25 @@ If you're a member of an Enterprise team with [SCIM](/docs/administration/scim-p
 
 Once you're no longer a member of any Postman team, you can permanently delete your Postman account in your [account settings](https://go.postman.co/settings/me/account/). Select your avatar in the upper-right corner > **Settings** > **Account**. Select **Delete Account**. Before deleting your account, Postman will prompt you to sign in again to confirm that you own the account.
 
-### Updating your profile
+## Updating your profile
 
 You can update your Postman profile and add more details about you on your [profile settings](https://go.postman.co/settings/me/) page.
 
-#### Updating your username
+Your profile includes an About Me section, an activity feed, pinned elements, the lists elements you have forked and are watching, and a list of the workspaces, collections, and APIs you have contributed in Postman.
+
+<!-- TODO: screenshot -->
+
+### Updating your username
 
 You can update your username at any time by navigating to your [profile settings](https://go.postman.co/settings/me/). Select your avatar in the upper-right corner > **Settings**. Edit your username and select **Update Profile** to save changes.
 
-#### Making your profile public
+### Updating your About Me section
+
+supports markdown. add information about you, your work, interests, and contributions - anything you want people looking at your profile to know!
+
+### Pinning elements to your profile
+
+### Making your profile public
 
 Your Postman profile is visible to your Postman team, and you can choose to make your profile public to the Postman community. You can turn your public profile on or off at any time in your [profile settings](https://go.postman.co/settings/me/). Select your avatar in the upper-right corner > **Settings** > **Profile**. Select **Make profile public**, then select **Update Profile** to save your changes.
 

--- a/src/pages/docs/getting-started/postman-profile.md
+++ b/src/pages/docs/getting-started/postman-profile.md
@@ -1,5 +1,5 @@
 ---
-title: "Creating your Postman profile"
+title: "Customizing your Postman profile"
 updated: 2022-10-05
 contextual_links:
   - type: section
@@ -18,27 +18,64 @@ contextual_links:
 
 <!-- TODO: intro -->
 
-You can update your Postman profile and add more details about you on your [profile settings](https://go.postman.co/settings/me/) page.
+After you create a Postman account, you can customize your Postman profile. Your Postman profile gives you a way to share important information about yourself with other Postman users.
 
-Your profile includes an About Me section, an activity feed, pinned elements, the lists elements you have forked and are watching, and a list of the workspaces, collections, and APIs you have contributed in Postman.
+Your profile includes:
+
+* Links to relevant resources like your GitHub profile
+* Links to any teams you are a part of
+* An About Me section
+* A Highlights section with pinned elements
+* An Activity feed with a chronological list of your recent activity in the public API network
 
 <!-- TODO: screenshot -->
 
-* [Updating your username](#updating-your-username)
-* [Updating your About Me section](#updating-your-about-me-section)
-* [Pinning elements to your profile](#pinning-elements-to-your-profile)
+## Contents
+
 * [Making your profile public](#making-your-profile-public)
-
-## Updating your username
-
-You can update your username at any time by navigating to your [profile settings](https://go.postman.co/settings/me/). Select your avatar in the upper-right corner > **Settings**. Edit your username and select **Update Profile** to save changes.
-
-## Updating your About Me section
-
-supports markdown. add information about you, your work, interests, and contributions - anything you want people looking at your profile to know!
-
-## Pinning elements to your profile
+* [Updating your personal information](#updating-your-personal-information)
+* [Adding an About Me section](#adding-an-about-me-section)
+* [Updating your About Me section](#updating-your-about-me-section)
+* [Pinning elements to your Highlights](#pinning-elements-to-your-highlights)
 
 ## Making your profile public
 
-Your Postman profile is visible to your Postman team, and you can choose to make your profile public to the Postman community. You can turn your public profile on or off at any time in your [profile settings](https://go.postman.co/settings/me/). Select your avatar in the upper-right corner > **Settings** > **Profile**. Select **Make profile public**, then select **Update Profile** to save your changes.
+By default, your Postman profile is visible to your Postman team. You can also choose to make your profile public to the Postman community. Having a public profile enables you to share important information about yourself and your work with other Postman users.
+
+To turn your public profile on or off at any time in your [profile settings](https://go.postman.co/settings/me/):
+
+1. Select your avatar in the Postman header > **Settings**.
+1. Select **Profile** from the list of options.
+1. Select **Make profile public**.
+1. Select **Update Profile** to save your changes.
+
+## Updating your personal information
+
+Update your _profile picture_, _display name_, _Postman username_, _display bio_, and your _social media links_ at any time in your [profile settings](https://go.postman.co/settings/me/):
+
+1. Select your avatar in the Postman header > **Settings**.
+1. Select **Profile** from the list of options.
+1. Edit the fields you want to update.
+S. Select **Update Profile** to save changes.
+
+## Adding an About Me section
+
+Your **About Me** section contains information about, well, YOU! You can add information about your work, interests, and contributions&mdash;anything you want people looking at your profile to know. Update your **About Me** section at any time in your [profile settings](https://go.postman.co/settings/me/):
+
+1. Select your avatar in the Postman header > **Settings**.
+1. Select **Profile** from the list of options.
+1. ????? <!-- TODO: what the heck -->
+1. Under **About Me**, select **Edit**. The editor supports Markdown, or you can use the built-in text formatting tools.
+1. Select **Save**.
+
+## Updating your About Me section
+
+If you have already created an About Me section, you can edit it by selecting the edit icon <img alt="Edit icon" src="https://assets.postman.com/postman-docs/documentation-edit-icon-v8-10.jpg#icon" width="18px">. Make your changes, then select **Save**.
+
+## Pinning elements to your Highlights
+
+All elements must be available on the public API network???
+
+if you don't choose any elements to pin to your profile, Postman will select the most popular elements (what criteria?) for this section.
+
+To edit the elements in the Highlights section, select the edit icon <img alt="Edit icon" src="https://assets.postman.com/postman-docs/documentation-edit-icon-v8-10.jpg#icon" width="18px">. To remove elements, select the close icon <img alt="Close icon" src="https://assets.postman.com/postman-docs/icon-close.jpg#icon" width="16px"> next to the element name. To add an element to your Highlights section, select it from the list. Select **Save**.

--- a/src/pages/docs/getting-started/postman-profile.md
+++ b/src/pages/docs/getting-started/postman-profile.md
@@ -16,17 +16,17 @@ contextual_links:
     url: "/docs/getting-started/syncing/"
 ---
 
-<!-- TODO: intro -->
-
 After you create a Postman account, you can customize your Postman profile. Your Postman profile gives you a way to share important information about yourself with other Postman users.
 
 Your profile includes:
 
-* Links to relevant resources like your GitHub profile
+* A profile picture
+* A short bio
+* Social media links like your GitHub profile
 * Links to any teams you are a part of
-* An About Me section
-* A Highlights section with pinned elements
-* An Activity feed with a chronological list of your recent activity in the public API network
+* An **About Me** section
+* A **Highlights** section with pinned elements
+* An **Activity** feed with a chronological list of your public activities
 
 <!-- TODO: screenshot -->
 
@@ -63,19 +63,31 @@ S. Select **Update Profile** to save changes.
 Your **About Me** section contains information about, well, YOU! You can add information about your work, interests, and contributions&mdash;anything you want people looking at your profile to know. Update your **About Me** section at any time in your [profile settings](https://go.postman.co/settings/me/):
 
 1. Select your avatar in the Postman header > **Settings**.
-1. Select **Profile** from the list of options.
-1. ????? <!-- TODO: what the heck -->
+1. Select **View your profile**.
+1. Select **View public profile**. <!-- TODO: is this the final workflow? -->
 1. Under **About Me**, select **Edit**. The editor supports Markdown, or you can use the built-in text formatting tools.
 1. Select **Save**.
 
+<!-- TODO: screenshot -->
+
 ## Updating your About Me section
 
-If you have already created an About Me section, you can edit it by selecting the edit icon <img alt="Edit icon" src="https://assets.postman.com/postman-docs/documentation-edit-icon-v8-10.jpg#icon" width="18px">. Make your changes, then select **Save**.
+If you have already created an [**About Me** section](#adding-an-about-me-section), you can edit it by selecting the edit icon <img alt="Edit icon" src="https://assets.postman.com/postman-docs/documentation-edit-icon-v8-10.jpg#icon" width="18px">. Make your changes, then select **Save**.
 
 ## Pinning elements to your Highlights
 
-All elements must be available on the public API network???
+> Every element in your Highlights section must be publicly available.
 
-if you don't choose any elements to pin to your profile, Postman will select the most popular elements (what criteria?) for this section.
+Your **Highlights** section lets you show off your work to other Postman users. If you don't choose any elements to pin to this section, Postman displays the most popular elements that you've worked on. <!-- TODO: what's the criteria for "popular"? -->
 
-To edit the elements in the Highlights section, select the edit icon <img alt="Edit icon" src="https://assets.postman.com/postman-docs/documentation-edit-icon-v8-10.jpg#icon" width="18px">. To remove elements, select the close icon <img alt="Close icon" src="https://assets.postman.com/postman-docs/icon-close.jpg#icon" width="16px"> next to the element name. To add an element to your Highlights section, select it from the list. Select **Save**.
+Update your **Highlights** section at any time in your [profile settings](https://go.postman.co/settings/me/):
+
+1. Select your avatar in the Postman header > **Settings**.
+1. Select **View your profile**.
+1. Select **View public profile**. <!-- TODO: is this the final workflow? -->
+1. Under **Highlights**, select the edit icon <img alt="Edit icon" src="https://assets.postman.com/postman-docs/documentation-edit-icon-v8-10.jpg#icon" width="18px">.
+1. To remove elements from the section, select the close icon <img alt="Close icon" src="https://assets.postman.com/postman-docs/icon-close.jpg#icon" width="16px"> next to the element name under **Selected works in highlight**.
+1. To add an element to the section, select the element type, then select the element from the list.
+1. After you have added or removed elements, select **Save**.
+
+<!-- TODO: screenshot -->

--- a/src/pages/docs/getting-started/postman-profile.md
+++ b/src/pages/docs/getting-started/postman-profile.md
@@ -1,0 +1,44 @@
+---
+title: "Creating your Postman profile"
+updated: 2022-10-05
+contextual_links:
+  - type: section
+    name: "Additional Resources"
+  - type: subtitle
+    name: "Videos"
+  - type: link
+    name: "Public Profiles | Postman Level Up"
+    url:  "https://youtu.be/w-EgqQ8Anvw"
+  - type: section
+    name: "Next Steps"
+  - type: link
+    name: "Syncing your work"
+    url: "/docs/getting-started/syncing/"
+---
+
+<!-- TODO: intro -->
+
+You can update your Postman profile and add more details about you on your [profile settings](https://go.postman.co/settings/me/) page.
+
+Your profile includes an About Me section, an activity feed, pinned elements, the lists elements you have forked and are watching, and a list of the workspaces, collections, and APIs you have contributed in Postman.
+
+<!-- TODO: screenshot -->
+
+* [Updating your username](#updating-your-username)
+* [Updating your About Me section](#updating-your-about-me-section)
+* [Pinning elements to your profile](#pinning-elements-to-your-profile)
+* [Making your profile public](#making-your-profile-public)
+
+## Updating your username
+
+You can update your username at any time by navigating to your [profile settings](https://go.postman.co/settings/me/). Select your avatar in the upper-right corner > **Settings**. Edit your username and select **Update Profile** to save changes.
+
+## Updating your About Me section
+
+supports markdown. add information about you, your work, interests, and contributions - anything you want people looking at your profile to know!
+
+## Pinning elements to your profile
+
+## Making your profile public
+
+Your Postman profile is visible to your Postman team, and you can choose to make your profile public to the Postman community. You can turn your public profile on or off at any time in your [profile settings](https://go.postman.co/settings/me/). Select your avatar in the upper-right corner > **Settings** > **Profile**. Select **Make profile public**, then select **Update Profile** to save your changes.


### PR DESCRIPTION
This PR creates a new page specifically about Postman user profiles, and removes existing user profile content out of https://learning.postman.com/docs/getting-started/postman-account/. @jkonrath-postman lmk if you'd prefer a different approach. 

I added TODO notes as placeholders for screenshots and potential workflow changes, to be updated before product launch.