### PR TITLE
[TW-723] Doc header/body matching in mock server UI

### DIFF
--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -35,7 +35,7 @@ contextual_links:
     url: "/docs/writing-scripts/test-scripts/"
 ---
 
-You can make requests that return mock data defined within Postman if you do not have a production API ready, or you do not want to run your requests against real data yet. By adding a mock server to your collection and adding examples to your requests, you can simulate the behavior of a real API.
+You can make requests that return mock data defined within Postman if you do not have a production API ready, or you do not want to run your requests against real data yet. By adding a mock server to your [collection](/docs/sending-requests/intro-to-collections/) and adding [examples](/docs/sending-requests/examples/) to your requests, you can simulate the behavior of a real API.
 
 When you send a request to a mock server, Postman will match the request configuration to the examples you have saved for the request and respond with the data you added to the example. To view existing mocks in your workspace, select **Mock Servers** in the sidebar.
 
@@ -43,17 +43,17 @@ When you send a request to a mock server, Postman will match the request configu
 
 ## Contents
 
-* [Mocks quick start](#mocks-quick-start)
+* [Mock server quick start](#mock-server-quick-start)
 * [Creating mock servers](#creating-mock-servers)
 * [Configuring mock server details](#configuring-mock-server-details)
     * [Editing the mock server configuration](#editing-the-mock-server-configuration)
     * [Matching request body and headers](#matching-request-body-and-headers)
-* [Making requests to mocks](#making-requests-to-mocks)
+* [Making requests to mock servers](#making-requests-to-mock-servers)
     * [Using HTTP access control for a mock](#using-http-access-control-for-a-mock)
 * [Viewing mock calls](#viewing-mock-calls)
     * [Troubleshooting mock calls](#troubleshooting-mock-calls)
 
-## Mocks quick start
+## Mock server quick start
 
 To test using a mock server, carry out the following steps:
 
@@ -155,15 +155,15 @@ To use body or header matching with a mock server:
 
 <img alt="Matching body and headers" src="https://assets.postman.com/postman-docs/v10/mock-server-header-body-matching-v10.jpg" width="466px" />
 
-## Making requests to mocks
+## Making requests to mock servers
 
-With your mock URL, you can start making requests right away. Make sure the request you want to mock has at least one [example](/docs/sending-requests/examples/) added to it.
+Use the mock server's URL to make calls to the mock server. Select **Mock Servers** in the sidebar, select a mock server, and select **Copy Mock URL**.
 
-<img alt="Add example" src="https://assets.postman.com/postman-docs/add-example-v8.jpg" width="300px"/>
+Make sure the request you want to mock has at least one saved [example](/docs/sending-requests/examples/). To add an example to a request, select **Send**. Then, in the response pane, select **Save Response > Save as example**.
 
-[![Example added](https://assets.postman.com/postman-docs/example-added-v8.jpg)](https://assets.postman.com/postman-docs/example-added-v8.jpg)
+<img alt="Adding an example" src="https://assets.postman.com/postman-docs/v10/examples-save-response-v10.jpg" />
 
-Open a tab (or edit the address in an existing tab) and add the mock URL:
+Open a new request tab (or edit the address in an existing tab) and add the mock URL:
 
 ```shell
 https://<mock-id>.mock.pstmn.io/<request-path>
@@ -172,30 +172,28 @@ https://<mock-id>.mock.pstmn.io/<request-path>
 For example:
 
 ```shell
-https://3589dfde-f398-45cd-88eb-b0fa0192fc3f.mock.pstmn.io/matches
+https://4bb57fc2-219e-421e-86b4-4ffda6bf1b3b.mock.pstmn.io/matches
 ```
 
-The mock URL includes the mock's ID and the path for the request with a saved example.
+The mock URL includes the mock server's ID and the path for the request you want to mock. Select **Send** to send the request to the mock server.
 
-[![Mock example](https://assets.postman.com/postman-docs/mock-example-v8.jpg)](https://assets.postman.com/postman-docs/mock-example-v8.jpg)
+<img alt="Sending a mock request" src="https://assets.postman.com/postman-docs/v10/mock-server-send-request-v10.jpg" />
 
-If you save your mock URL to a variable, you can reference it across requests—for example if you have a production server and a mock server, you could have an [environment](/docs/sending-requests/managing-environments/) for each one with the same variable name in each for the mock URL. With your requests using the variable, you can then switch between the two environments.
+> If you save the mock URL to a [variable](/docs/sending-requests/variables/), you can reference it across requests. For example, if you have a production server and a mock server, you can have an [environment](/docs/sending-requests/managing-environments/) for each server. Create a variable with the same name in each environment for the mock URL. By using the variable in your requests, you can switch between the two environments to call the production server or the mock server.
 
-> You can also retrieve your mock ID from the [Postman API](https://documenter.postman.com/view/631643/JsLs/?version=latest#018b5d62-f6fc-f752-597e-c1eb4bb98d24).
+When you send a request to the mock server URL, the mock server sends back a response based on one of the examples you added to the request with the same path and method. [You can provide multiple examples](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/), and Postman will return the one that matches your request most closely.
 
-When you **Send** a request to your mock server URL it will send back one of the examples you added to the request with the same path and method. ([You can provide multiple examples](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/) and Postman will return the one that matches your request configuration most closely).
-
-If you configured a delay for your mock server, Postman will wait the specified period of time before sending the response.
+If you configured a delay for your mock server, Postman waits the specified period of time before sending the response.
 
 > Your Postman account gives you a limited number of free mock server calls per month. Check your [usage limits](https://go.postman.co/usage).
 
 ### Using HTTP access control for a mock
 
-In addition to using Postman to make requests to mock endpoints, you can also make those requests in a browser.
+In addition to using Postman to make requests to mock endpoints, you can also make those requests in a web browser.
 
-A web browser makes a cross-origin HTTP request when it requests a resource from a domain, protocol, or port that's different from its own. [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) is a standard that defines a way in which a browser and server can interact securely, in this case referring to how a web browser interacts with the mock endpoints hosted on the Postman server.
+A web browser makes a cross-origin HTTP request when it requests a resource from a domain, protocol, or port that's different from its own. [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) is a standard that defines a way in which a browser and server can interact securely. In this case, CORS refers to how a web browser interacts with the mock endpoints hosted on the Postman mock server.
 
-CORS is enabled for Postman mock servers. As a result, you can stub your web apps with mocked data using the mock endpoints. Development or production web apps can then make requests to your Postman mock endpoint and receive example responses.
+CORS is enabled for Postman mock servers, so you can stub your web apps with mocked data using the mock endpoints. Development or production web apps can then make requests to your Postman mock endpoint and receive example responses.
 
 ## Viewing mock calls
 

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -61,11 +61,11 @@ To test using a mock server, do the following steps:
 
 1. In Postman, send a request to any API. Your request must be saved to a collection.
 1. In the response pane, select **Save Response > Save as example**. Postman automatically populates the example with the response you received when you sent the request.
-1. Open the collection where the request was saved and select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar. Next to **Mock servers**, select **+ New**.
+1. Select **Collections** in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the collection where the request was saved and select **Mock collection**.
 1. Give your mock a name and leave the other settings at their defaults. Select **Create Mock Server**.
 1. Copy the mock URL and go back into your request. Replace the base part of the URL with the mock server URL (everything before the path, for example up to `/customers`).
 1. Select **Send**. Postman returns the example response you saved for the request, this time from the mock server.
-1. Open the example and change the mock response JSON, then save it and send the request again. Postman returns your edited mock response.
+1. Open the example and change the response, then save the example and send the request again. Postman returns your edited mock response.
 
 ## Creating mock servers
 
@@ -85,9 +85,9 @@ Configure your [mock server details](#configuring-mock-server-details).
 
 ### Creating a mock from a collection
 
-Open a collection in Postman and select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar. Next to **Mock servers**, select **+ New**.
+Select **Collections** in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the collection you want to mock and select **Mock collection**.
 
-<img alt="Mocking a collection" src="https://assets.postman.com/postman-docs/v10/mock-server-create-from-collection-v10.jpg" />
+<img alt="Mocking a collection" src="https://assets.postman.com/postman-docs/v10/mock-server-mock-collection-v10.jpg" width="373px" />
 
 Configure your [mock server details](#configuring-mock-server-details).
 
@@ -151,7 +151,7 @@ To use body or header matching with a mock server:
 1. Under **Response Matching**, select the matching options you want to use:
 
     * **Request body** - The mock server will match the request's body to the body of the saved examples.
-    * **Headers** - The mock server will match the request's headers to the headers of the saved examples. In the box, add the header keys that you want to match, using commas to separate the keys. Header matching isn't case-sensitive.
+    * **Headers** - The mock server will match the request's headers to the headers of the saved examples. In the box, add the header keys that you want the mock server to match, using commas to separate the keys. Header matching isn't case-sensitive.
 
 1. Select **Update Mock Server**.
 
@@ -161,9 +161,7 @@ To use body or header matching with a mock server:
 
 Use the mock server's URL to make calls to the mock server. Select **Mock Servers** in the sidebar, select a mock server, and select **Copy Mock URL**.
 
-Make sure the request you want to mock has at least one saved [example](/docs/sending-requests/examples/). To add an example to a request, select **Send**. Then, in the response pane, select **Save Response > Save as example**.
-
-<img alt="Adding an example" src="https://assets.postman.com/postman-docs/v10/examples-save-response-v10.jpg" />
+Make sure the request you want to mock has at least one saved example. You can send a request and save the response as an example. You can also define a custom example. Learn more about [adding examples to a request](/docs/sending-requests/examples/#adding-an-example).
 
 Open a new request tab (or edit the address in an existing tab) and add the mock URL:
 
@@ -196,7 +194,7 @@ Postman mock servers support [environment variables](/docs/sending-requests/vari
 * To use environment variables, select the environment in the [mock server's configuration](#editing-the-mock-server-configuration).
 * To use collection variables, define them on the **Variables** tab in the [collection you are mocking](/docs/sending-requests/variables/#defining-collection-variables).
 
-When you use an environment or collection variable in a saved example, the mock server resolves the variable and replaces it with the current value. If an environment variable and a collection variable have the same name, Postman uses the environment variable. Learn more about [variable scopes](/docs/sending-requests/variables/#variable-scopes).
+When you use an environment or collection variable in a saved example, the mock server resolves the variable and replaces it with the variable's initial value. If an environment variable and a collection variable have the same name, Postman uses the environment variable. Learn more about [variable scopes](/docs/sending-requests/variables/#variable-scopes).
 
 <img alt="Using variables with mock servers" src="https://assets.postman.com/postman-docs/v10/mock-server-using-variables-v10.jpg" width="467px" />
 

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -37,17 +37,15 @@ contextual_links:
 
 You can make requests that return mock data defined within Postman if you do not have a production API ready, or you do not want to run your requests against real data yet. By adding a mock server to your collection and adding examples to your requests, you can simulate the behavior of a real API.
 
-When you send a request to a mock server, Postman will match the request configuration to the examples you have saved for the request and respond with the data you added to the example. To view existing mocks in your workspace, select __Mock Servers__ in the sidebar.
+When you send a request to a mock server, Postman will match the request configuration to the examples you have saved for the request and respond with the data you added to the example. To view existing mocks in your workspace, select **Mock Servers** in the sidebar.
 
 > You need to be signed into a Postman account to create a mock server.
-
-[![Mock server](https://assets.postman.com/postman-docs/mocks-v8.jpg)](https://assets.postman.com/postman-docs/mocks-v8.jpg)
 
 ## Contents
 
 * [Mocks quick start](#mocks-quick-start)
 * [Creating mock servers](#creating-mock-servers)
-* [Configuring mock details](#configuring-mock-details)
+* [Configuring mock server details](#configuring-mock-server-details)
     * [Editing the mock server configuration](#editing-the-mock-server-configuration)
     * [Matching request body and headers](#matching-request-body-and-headers)
 * [Making requests to mocks](#making-requests-to-mocks)
@@ -59,57 +57,57 @@ When you send a request to a mock server, Postman will match the request configu
 
 To test using a mock server, carry out the following steps:
 
-* Make a request to any API in Postman. Your request must be saved to a collection.
-* Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> at the top right, then select __Add example__. Postman will automatically populate the example with the response you received when you sent the request.
-* Select **Collections** in the sidebar, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to your collection, and select **Mock collection**.
+* In Postman, send a request to any API. Your request must be saved to a collection.
+* In the response pane, select **Save Response > Save as example**. Postman automatically populates the example with the response you received when you sent the request.
+* Open the collection where the request was saved and select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar. Next to **Mock servers**, select **+ New**.
 * Give your mock a name and leave the other settings at their defaults. Select **Create Mock Server**.
 * Copy the mock URL and go back into your request. Replace the base part of the URL with the mock server URL (everything before the path, for example up to `/customers`).
-* Select **Send**. Postman will return the example response you saved for the request, this time from the mock server.
-* Open the example again and alter the mock response JSON, then save it and send the request again. Postman will return your edited mock response.
+* Select **Send**. Postman returns the example response you saved for the request, this time from the mock server.
+* Open the example and change the mock response JSON, then save it and send the request again. Postman returns your edited mock response.
 
 ## Creating mock servers
 
-You can create mock servers from an existing collection, or Postman will create a new collection for your mock server. You can create a new mock [from scratch](#creating-a-mock-from-scratch), [from a collection](#creating-a-mock-from-a-collection), [from the sidebar](#creating-a-mock-from-the-sidebar), [from an API](#creating-a-mock-from-an-api), or [from your history](#creating-a-mock-from-history).
+You can create mock servers from an existing collection, or Postman will create a new collection for your mock server. You can create a new mock [from scratch](#creating-a-mock-from-scratch), [from a collection](#creating-a-mock-from-a-collection), [from the sidebar](#creating-a-mock-from-the-sidebar), or [from your history](#creating-a-mock-from-history).
 
 ### Creating a mock from scratch
 
-In __Mock Servers__ in the sidebar, select __+__.
+Select **Mock Servers** in the sidebar, then select **+**.
 
-<img alt="New mock" src="https://assets.postman.com/postman-docs/new-mock-v8.jpg" width="350px"/>
+<img alt="Creating a new mock server" src="https://assets.postman.com/postman-docs/v10/mock-server-new-v10.jpg" width="382px" />
 
-Select an existing collection or add a new one (adding an initial request for a new one).
+Select an existing collection, or create a new collection and add an initial request.
 
-[![Mock new collection](https://assets.postman.com/postman-docs/mock-collection-v8.jpg)](https://assets.postman.com/postman-docs/mock-collection-v8.jpg)
+<img alt="Selecting a collection to mock" src="https://assets.postman.com/postman-docs/v10/mock-server-add-collection-v10.jpg" />
 
-Configure your [mock details](#configuring-mock-details).
+Configure your [mock server details](#configuring-mock-server-details).
 
 ### Creating a mock from a collection
 
-Open a collection in Postman, and select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar. Select __Create mock server__.
+Open a collection in Postman and select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar. Next to **Mock servers**, select **+ New**.
 
-[![New mock](https://assets.postman.com/postman-docs/add-mock-v8.jpg)](https://assets.postman.com/postman-docs/add-mock-v8.jpg)
+<img alt="Mocking a collection" src="https://assets.postman.com/postman-docs/v10/mock-server-create-from-collection-v10.jpg" />
 
-Configure your [mock details](#configuring-mock-details).
+Configure your [mock server details](#configuring-mock-server-details).
 
 ### Creating a mock from the sidebar
 
-Select __New__ and choose __Mock Server__.
+In the sidebar, select **New** and select **Mock Server**.
 
-[![New mock](https://assets.postman.com/postman-docs/mock-new-v8.jpg)](https://assets.postman.com/postman-docs/mock-new-v8.jpg)
+<img alt="Creating a mock server using the New button" src="https://assets.postman.com/postman-docs/v10/mock-server-new-button-v10.jpg" />
 
-Choose whether you want to mock an existing collection or generate a new one for your mock (adding a request).
+Select an existing collection, or create a new collection and add an initial request.
 
-Configure your [mock details](#configuring-mock-details).
+Configure your [mock server details](#configuring-mock-server-details).
 
 ### Creating a mock from history
 
-You can build a mock based on requests from your Postman history. In __History__ on the left, hover over a request or date and select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> __> Mock Request__.
+You can build a mock server based on requests from your Postman history. Select **History** in the sidebar, then select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to a request and select **Mock Request**. (You can also mock all the requests for particular date.)
 
-<img alt="Mock history" src="https://assets.postman.com/postman-docs/mock-history-v8.jpg" width="350px"/>
+<img alt="Creating a mock server from History" src="https://assets.postman.com/postman-docs/v10/mock-server-create-from-history-v10.jpg" width="382px"/>
 
-Configure your [mock details](#configuring-mock-details).
+Configure your [mock server details](#configuring-mock-server-details).
 
-## Configuring mock details
+## Configuring mock server details
 
 When you create a mock server you will give it a name, choose an optional environment to run the mock against, and configure a delay before the server sends your mock responses (choosing to simulate 2G/3G networks or specify a custom delay in milliseconds).
 
@@ -128,10 +126,6 @@ Postman will display the details you'll need to use the mock (you can also get t
 [![Mock detail](https://assets.postman.com/postman-docs/mock-detail-v8.jpg)](https://assets.postman.com/postman-docs/mock-detail-v8.jpg)
 
 Select **Copy Mock URL** to begin making requests to your mock.
-
-Details about the mock are in the collection overview info on the right.
-
-[![Mock in collection](https://assets.postman.com/postman-docs/mock-info-v8.jpg)](https://assets.postman.com/postman-docs/mock-info-v8.jpg)
 
 > To delete a mock, select **Mock Servers** in the sidebar, then select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the mock's name.
 

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -103,35 +103,35 @@ Configure your [mock server details](#configuring-mock-server-details).
 
 You can build a mock server based on requests from your Postman history. Select **History** in the sidebar, then select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to a request and select **Mock Request**. (You can also mock all the requests for particular date.)
 
-<img alt="Creating a mock server from History" src="https://assets.postman.com/postman-docs/v10/mock-server-create-from-history-v10.jpg" width="382px"/>
+<img alt="Creating a mock server from History" src="https://assets.postman.com/postman-docs/v10/mock-server-create-from-history-v10.jpg" width="382px" />
 
 Configure your [mock server details](#configuring-mock-server-details).
 
 ## Configuring mock server details
 
-When you create a mock server you will give it a name, choose an optional environment to run the mock against, and configure a delay before the server sends your mock responses (choosing to simulate 2G/3G networks or specify a custom delay in milliseconds).
+To configure your new mock server, give it a name. You can select an optional environment to have your mock sever use environment variables. You can also configure a delay before the mock server sends responses to simulate network delays.
 
-If you choose to make your mock server private, you will need to add a [Postman API key](/docs/developer/intro-api/) in the request header: `x-api-key:<Your-Postman-API-key>`. You can [share the collection](/docs/collaborating-in-postman/sharing/) and your collaborators can use their Postman API keys to consume the mock.
+> You can save the mock URL to an [environment variable](/docs/sending-requests/variables/) in a new environment. You can then reference the variable in your requests by making the new environment active before sending the request.
 
-> Not all configuration options may be available, depending on the method you used to create the mock server.
+If you choose to make your mock server private, you need to add a [Postman API key](/docs/developer/intro-api/) in the request header when sending requests to the mock server: `x-api-key:<Your-Postman-API-key>`. If you [share the collection](/docs/collaborating-in-postman/sharing/), others can use their Postman API keys to make calls to the mock server.
 
-[![New mock](https://assets.postman.com/postman-docs/mock-config-v9.jpg)](https://assets.postman.com/postman-docs/mock-config-v9.jpg)
+> Not all configuration options will be available, depending on the method you used to create the mock server.
 
-With your details in place, select **Create Mock Server**.
+<img alt="Configuring mock server details" src="https://assets.postman.com/postman-docs/v10/mock-server-configure-details-v10.jpg" />
 
-> You can also opt to save the mock URL to an [environment variable](/docs/sending-requests/variables/) which you can then reference in your requests by making the environment active before sending.
+After you finish selecting configuration options, select **Create Mock Server**. Postman displays the details you need to use the mock server. (You can get these details at any time by selecting **Mock Servers** in the sidebar and selecting the mock server.)
 
-Postman will display the details you'll need to use the mock (you can also get these from the collection at any time).
+<img alt="Getting the mock server URL" src="https://assets.postman.com/postman-docs/v10/mock-server-get-url-v10.jpg" />
 
-[![Mock detail](https://assets.postman.com/postman-docs/mock-detail-v8.jpg)](https://assets.postman.com/postman-docs/mock-detail-v8.jpg)
+Select **Copy Mock URL** to begin making requests to your mock server.
 
-Select **Copy Mock URL** to begin making requests to your mock.
-
-> To delete a mock, select **Mock Servers** in the sidebar, then select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the mock's name.
+> To delete a mock server, select **Mock Servers** in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the mock server's name and select **Delete**.
 
 ### Editing the mock server configuration
 
 You can change the configuration for a mock server at any time. Select **Mock Servers** in the sidebar, select a mock server, and select <img alt="Settings icon" src="https://assets.postman.com/postman-docs/icon-settings-v9.jpg#icon" width="16px"> **Edit Configuration**.
+
+<img alt="Editing mock server configuration" src="https://assets.postman.com/postman-docs/v10/mock-server-edit-configuration-v10.jpg" />
 
 You can change the mock server's name, environment, network delay, and privacy setting. You can also [specify options for response matching](#matching-request-body-and-headers). When you are done changing the configuration settings, select **Update Mock Server**.
 
@@ -149,9 +149,11 @@ To use body or header matching with a mock server:
 1. Under **Response Matching**, select the matching options you want to use:
 
     * **Request body** - The mock server will match the request's body to the body of the saved examples.
-    * **Headers** - The mock server will match the request's headers to the headers of the saved examples.
+    * **Headers** - The mock server will match the request's headers to the headers of the saved examples. In the box, add the header keys that you want to match, using commas to separate the keys. Header matching isn't case-sensitive.
 
 1. Select **Update Mock Server**.
+
+<img alt="Matching body and headers" src="https://assets.postman.com/postman-docs/v10/mock-server-header-body-matching-v10.jpg" width="466px" />
 
 ## Making requests to mocks
 

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -35,9 +35,9 @@ contextual_links:
     url: "/docs/writing-scripts/test-scripts/"
 ---
 
-You can make requests that return mock data defined within Postman if you do not have a production API ready, or you do not want to run your requests against real data yet. By adding a mock server to your [collection](/docs/sending-requests/intro-to-collections/) and adding [examples](/docs/sending-requests/examples/) to your requests, you can simulate the behavior of a real API.
+Postman enables you to create _mock servers_ to assist with API development and testing. A mock server simulates the behavior of a real API server by accepting requests and returning responses. By adding a mock server to your [collection](/docs/sending-requests/intro-to-collections/) and adding [examples](/docs/sending-requests/examples/) to your requests, you can simulate the behavior of a real API.
 
-When you send a request to a mock server, Postman will match the request configuration to the examples you have saved for the request and respond with the data you added to the example. To view existing mocks in your workspace, select **Mock Servers** in the sidebar.
+When you send a request to a mock server, Postman matches the request to a saved example in your collection. Postman then responds with the data you added to the example. To view existing mock servers in your workspace, select **Mock Servers** in the sidebar.
 
 > You need to be signed into a Postman account to create a mock server.
 
@@ -52,6 +52,7 @@ When you send a request to a mock server, Postman will match the request configu
     * [Using HTTP access control for a mock](#using-http-access-control-for-a-mock)
 * [Viewing mock calls](#viewing-mock-calls)
     * [Troubleshooting mock calls](#troubleshooting-mock-calls)
+* [Next steps](#next-steps)
 
 ## Mock server quick start
 
@@ -181,7 +182,7 @@ The mock URL includes the mock server's ID and the path for the request you want
 
 > If you save the mock URL to a [variable](/docs/sending-requests/variables/), you can reference it across requests. For example, if you have a production server and a mock server, you can have an [environment](/docs/sending-requests/managing-environments/) for each server. Create a variable with the same name in each environment for the mock URL. By using the variable in your requests, you can switch between the two environments to call the production server or the mock server.
 
-When you send a request to the mock server URL, the mock server sends back a response based on one of the examples you added to the request with the same path and method. [You can provide multiple examples](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/), and Postman will return the one that matches your request most closely.
+When you send a request to the mock server, the mock server sends back a response based on an example with the same path and method. [You can provide multiple examples](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/), and Postman will return the one that [best matches your request](/docs/designing-and-developing-your-api/mocking-data/matching-algorithm/).
 
 If you configured a delay for your mock server, Postman waits the specified period of time before sending the response.
 
@@ -209,7 +210,7 @@ You can use the search box to find particular calls. Select the refresh icon <im
 
 You can use the mock call log to troubleshoot your requests to mock servers.
 
-If the **Response** column contains `No matching requests`, this might mean that your mock server is not set up correctly. Make sure there is an [example saved for the request](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/) in the collection you are mocking.
+If `No matching requests` displays in the **Response** column, this might mean there is a problem with your mock server configuration. Make sure there is an [example saved for the request](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/) in the collection you are mocking.
 
 <img alt="Troubleshooting mock calls" src="https://assets.postman.com/postman-docs/v10/mock-server-no-match-v10.jpg" />
 

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -56,15 +56,15 @@ When you send a request to a mock server, Postman matches the request to a saved
 
 ## Mock server quick start
 
-To test using a mock server, carry out the following steps:
+To test using a mock server, do the following steps:
 
-* In Postman, send a request to any API. Your request must be saved to a collection.
-* In the response pane, select **Save Response > Save as example**. Postman automatically populates the example with the response you received when you sent the request.
-* Open the collection where the request was saved and select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar. Next to **Mock servers**, select **+ New**.
-* Give your mock a name and leave the other settings at their defaults. Select **Create Mock Server**.
-* Copy the mock URL and go back into your request. Replace the base part of the URL with the mock server URL (everything before the path, for example up to `/customers`).
-* Select **Send**. Postman returns the example response you saved for the request, this time from the mock server.
-* Open the example and change the mock response JSON, then save it and send the request again. Postman returns your edited mock response.
+1. In Postman, send a request to any API. Your request must be saved to a collection.
+1. In the response pane, select **Save Response > Save as example**. Postman automatically populates the example with the response you received when you sent the request.
+1. Open the collection where the request was saved and select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar. Next to **Mock servers**, select **+ New**.
+1. Give your mock a name and leave the other settings at their defaults. Select **Create Mock Server**.
+1. Copy the mock URL and go back into your request. Replace the base part of the URL with the mock server URL (everything before the path, for example up to `/customers`).
+1. Select **Send**. Postman returns the example response you saved for the request, this time from the mock server.
+1. Open the example and change the mock response JSON, then save it and send the request again. Postman returns your edited mock response.
 
 ## Creating mock servers
 

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -49,6 +49,7 @@ When you send a request to a mock server, Postman matches the request to a saved
     * [Editing the mock server configuration](#editing-the-mock-server-configuration)
     * [Matching request body and headers](#matching-request-body-and-headers)
 * [Making requests to mock servers](#making-requests-to-mock-servers)
+    * [Using variables with mock servers](#using-variables-with-mock-servers)
     * [Using HTTP access control for a mock](#using-http-access-control-for-a-mock)
 * [Viewing mock calls](#viewing-mock-calls)
     * [Troubleshooting mock calls](#troubleshooting-mock-calls)
@@ -112,7 +113,7 @@ Configure your [mock server details](#configuring-mock-server-details).
 
 To configure your new mock server, give it a name. You can select an optional environment to have your mock sever use environment variables. You can also configure a delay before the mock server sends responses to simulate network delays.
 
-> You can save the mock URL to an [environment variable](/docs/sending-requests/variables/) in a new environment. You can then reference the variable in your requests by making the new environment active before sending the request.
+> You can save the mock URL to an [environment variable](/docs/sending-requests/variables/) in a new environment. You can then reference the variable in your requests by making the new environment active before sending the request. Learn more about [using variables with mock servers](#using-variables-with-mock-servers).
 
 If you choose to make your mock server private, you need to add a [Postman API key](/docs/developer/intro-api/) in the request header when sending requests to the mock server: `x-api-key:<Your-Postman-API-key>`. If you [share the collection](/docs/collaborating-in-postman/sharing/), others can use their Postman API keys to make calls to the mock server.
 
@@ -180,13 +181,26 @@ The mock URL includes the mock server's ID and the path for the request you want
 
 <img alt="Sending a mock request" src="https://assets.postman.com/postman-docs/v10/mock-server-send-request-v10.jpg" />
 
-> If you save the mock URL to a [variable](/docs/sending-requests/variables/), you can reference it across requests. For example, if you have a production server and a mock server, you can have an [environment](/docs/sending-requests/managing-environments/) for each server. Create a variable with the same name in each environment for the mock URL. By using the variable in your requests, you can switch between the two environments to call the production server or the mock server.
-
 When you send a request to the mock server, the mock server sends back a response based on an example with the same path and method. [You can provide multiple examples](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/), and Postman will return the one that [best matches your request](/docs/designing-and-developing-your-api/mocking-data/matching-algorithm/).
 
 If you configured a delay for your mock server, Postman waits the specified period of time before sending the response.
 
 > Your Postman account gives you a limited number of free mock server calls per month. Check your [usage limits](https://go.postman.co/usage).
+
+### Using variables with mock servers
+
+[Variables](/docs/sending-requests/variables/) enable you to store values and use them in your requests and saved examples. If you change the value of a variable, the new value is used wherever the variable occurs..
+
+Postman mock servers support [environment variables](/docs/sending-requests/variables/#defining-environment-variables) and [collection variables](/docs/sending-requests/variables/#defining-collection-variables). (Mock servers don't support using global variables.)
+
+* To use environment variables, select the environment in the [mock server's configuration](#editing-the-mock-server-configuration).
+* To use collection variables, define them on the **Variables** tab in the [collection you are mocking](/docs/sending-requests/variables/#defining-collection-variables).
+
+When you use an environment or collection variable in a saved example, the mock server resolves the variable and replaces it with the current value. If an environment variable and a collection variable have the same name, Postman uses the environment variable. Learn more about [variable scopes](/docs/sending-requests/variables/#variable-scopes).
+
+<img alt="Using variables with mock servers" src="https://assets.postman.com/postman-docs/v10/mock-server-using-variables-v10.jpg" width="467px" />
+
+> If you save the URL of a mock server to a [variable](/docs/sending-requests/variables/), you can reference it across requests. For example, if you have a production server and a mock server, you can have an [environment](/docs/sending-requests/managing-environments/) for each server. In each environment, create a variable with the same name for the mock URL. By using the variable in your requests, you can switch between the two environments to call the production server or the mock server.
 
 ### Using HTTP access control for a mock
 

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -1,7 +1,6 @@
 ---
 title: "Setting up mock servers"
-updated: 2022-09-15
-page_id: "setting_up_mock"
+updated: 2022-10-17
 contextual_links:
   - type: section
     name: "Prerequisites"
@@ -44,26 +43,29 @@ When you send a request to a mock server, Postman will match the request configu
 
 [![Mock server](https://assets.postman.com/postman-docs/mocks-v8.jpg)](https://assets.postman.com/postman-docs/mocks-v8.jpg)
 
+## Contents
+
+* [Mocks quick start](#mocks-quick-start)
+* [Creating mock servers](#creating-mock-servers)
+* [Configuring mock details](#configuring-mock-details)
+    * [Editing the mock server configuration](#editing-the-mock-server-configuration)
+    * [Matching request body and headers](#matching-request-body-and-headers)
+* [Making requests to mocks](#making-requests-to-mocks)
+    * [Using HTTP access control for a mock](#using-http-access-control-for-a-mock)
+* [Viewing mock calls](#viewing-mock-calls)
+    * [Troubleshooting mock calls](#troubleshooting-mock-calls)
+
 ## Mocks quick start
 
 To test using a mock server, carry out the following steps:
 
 * Make a request to any API in Postman. Your request must be saved to a collection.
 * Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> at the top right, then select __Add example__. Postman will automatically populate the example with the response you received when you sent the request.
-* In **Collections** in the sidebar, select the collection, and then select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> on the right. Select **Create mock server**.
-* Give your mock a name, leaving the default tag selected, and the delay option unchecked. Select **Create Mock Server**.
+* Select **Collections** in the sidebar, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to your collection, and select **Mock collection**.
+* Give your mock a name and leave the other settings at their defaults. Select **Create Mock Server**.
 * Copy the mock URL and go back into your request. Replace the base part of the URL with the mock server URL (everything before the path, for example up to `/customers`).
 * Select **Send**. Postman will return the example response you saved for the request, this time from the mock server.
 * Open the example again and alter the mock response JSON, then save it and send the request again. Postman will return your edited mock response.
-
-## Contents
-
-* [Creating mock servers](#creating-mock-servers)
-    * [Configuring mock details](#configuring-mock-details)
-* [Making requests to mocks](#making-requests-to-mocks)
-    * [Using HTTP access control for a mock](#using-http-access-control-for-a-mock)
-* [Viewing mock calls](#viewing-mock-calls)
-    * [Troubleshooting mock calls](#troubleshooting-mock-calls)
 
 ## Creating mock servers
 
@@ -131,7 +133,31 @@ Details about the mock are in the collection overview info on the right.
 
 [![Mock in collection](https://assets.postman.com/postman-docs/mock-info-v8.jpg)](https://assets.postman.com/postman-docs/mock-info-v8.jpg)
 
-To edit or delete a mock, select **Mock Servers** on the left, then select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the mock's name.
+> To delete a mock, select **Mock Servers** in the sidebar, then select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the mock's name.
+
+### Editing the mock server configuration
+
+You can change the configuration for a mock server at any time. Select **Mock Servers** in the sidebar, select a mock server, and select <img alt="Settings icon" src="https://assets.postman.com/postman-docs/icon-settings-v9.jpg#icon" width="16px"> **Edit Configuration**.
+
+You can change the mock server's name, environment, network delay, and privacy setting. You can also [specify options for response matching](#matching-request-body-and-headers). When you are done changing the configuration settings, select **Update Mock Server**.
+
+> You can't change the mock server's collection. If you need to mock a different collection, [create a new mock server](#creating-mock-servers).
+
+### Matching request body and headers
+
+When you send a request to the mock server, Postman uses a [matching algorithm](/docs/designing-and-developing-your-api/mocking-data/matching-algorithm/) to decide which example to return in a response.
+
+By default, the matching algorithm doesn't consider the request's body or headers when selecting the best response to return. You can change this behavior in the mock server's configuration. Using body or header matching, you can specify the exact response you want the mock server to return by matching the body or headers of the saved example.
+
+To use body or header matching with a mock server:
+
+1. Select **Mock Servers** in the sidebar, select a mock server, and select <img alt="Settings icon" src="https://assets.postman.com/postman-docs/icon-settings-v9.jpg#icon" width="16px"> **Edit Configuration**.
+1. Under **Response Matching**, select the matching options you want to use:
+
+    * **Request body** - The mock server will match the request's body to the body of the saved examples.
+    * **Headers** - The mock server will match the request's headers to the headers of the saved examples.
+
+1. Select **Update Mock Server**.
 
 ## Making requests to mocks
 

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/setting-up-mock.md
@@ -197,29 +197,27 @@ CORS is enabled for Postman mock servers, so you can stub your web apps with moc
 
 ## Viewing mock calls
 
-You can view and search the details of calls to your mock servers using the mock call log. Open a mock from __Mock Servers__ in the sidebar. Your mock overview and call log will open.
+You can view and search the details of calls to your mock servers using the mock call log. To view the call log, select **Mock Servers** in the sidebar and select a mock server.
 
-[![Mock Call](https://assets.postman.com/postman-docs/mock-calls-v8.jpg)](https://assets.postman.com/postman-docs/mock-calls-v8.jpg)
+<img alt="Viewing mock calls" src="https://assets.postman.com/postman-docs/v10/mock-server-call-log-v10.jpg" />
 
-The mock call log lists an overview of calls made to the mock url, together with request and response details you can drill down into.
+The call log displays a list of calls made to the mock server URL. Each entry shows the time the request was sent, the request method and path, and a response overview. Select an entry for more details about the request headers and body or the response headers and body.
 
-Mock call log entries indicate the time a request was sent, the request method and path, and a response overview. Select an entry for more details about the request headers and body, or response headers and body.
-
-Use the search field to find particular calls. Use the refresh icon <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> at the top of the list to view up to date requests.
+You can use the search box to find particular calls. Select the refresh icon <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> to view the most recent requests.
 
 ### Troubleshooting mock calls
 
 You can use the mock call log to troubleshoot your requests to mock servers.
 
-[![Mock Call Error](https://assets.postman.com/postman-docs/mock-not-found-v8.jpg)](https://assets.postman.com/postman-docs/mock-not-found-v8.jpg)
+If the **Response** column contains `No matching requests`, this might mean that your mock server is not set up correctly. Make sure there is an [example saved for the request](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/) in the collection you are mocking.
 
-If the __Response__ column contains `No matching requests`, this may mean that your mock server is not setup correctly. Make sure [you have an example saved for the request](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/) in the collection you have the mock connected to.
+<img alt="Troubleshooting mock calls" src="https://assets.postman.com/postman-docs/v10/mock-server-no-match-v10.jpg" />
 
-In the case of a service outage, you will get a `502`, `503`, or `504` response. Check the Postman [status page](https://status.postman.com/) for updates if you encounter this.
+In the case of a service outage, you will get a `502`, `503`, or `504` response. Check the Postman [status page](https://status.postman.com/) for updates.
 
 ## Next steps
 
-For more information about mock servers, read the following resources:
+To learn more about mock servers, see the following resources:
 
 * [Mocking with examples](/docs/designing-and-developing-your-api/mocking-data/mocking-with-examples/)
 * [Mocking with the Postman API](/docs/designing-and-developing-your-api/mocking-data/mock-with-api/)


### PR DESCRIPTION
- Refresh "Setting up mock servers" page
- Add section "Editing the mock server configuration"
- Add section "Matching request body and headers"
- Add section "Using variables in mock servers"
- Update screenshots
- Fix vale errors