### PR TITLE
[TW-541] Clarified how to receive PR notifications in Slack

### DIFF
--- a/src/pages/docs/getting-started/postman-account.md
+++ b/src/pages/docs/getting-started/postman-account.md
@@ -137,13 +137,13 @@ Your Postman profile is visible to your Postman team, and you can choose to make
 
 ## Updating your notification preferences
 
-You can update your [notification preferences](https://go.postman.co/settings/me/notifications/) by selecting your avatar in the upper-right corner > **Notification Preferences**.
+You can update your [notification preferences](https://go.postman.co/settings/me/notifications/) by selecting your avatar in the upper-right corner > **Settings** > **Notifications**.
 
 You can opt in to or out of email or in-app notifications about security, usage, monitors, and comments by selecting or de-selecting the boxes next to each item. Select **Update Preferences** to save changes.
 
 In addition to email and in-app notifications, you can also send many notifications to Slack using the [Slack integration](/docs/integrations/available-integrations/slack/). After you add the Slack integration, you can select notification events in the **On Slack** column. These notifications are sent to Slack by the integration.
 
-<img alt="Update notification preferences" src="https://assets.postman.com/postman-docs/notification-preferences-v9-4.jpg">
+<img alt="Update notification preferences" src="https://assets.postman.com/postman-docs/v10/notification-preferences-v10.jpg">
 
 ## Managing your active sessions
 

--- a/src/pages/docs/integrations/available-integrations/slack.md
+++ b/src/pages/docs/integrations/available-integrations/slack.md
@@ -96,7 +96,7 @@ After adding the integration, you can specify which notifications are sent to Sl
 
 In the Slack column, you can opt in to or out of notifications such as security, usage, monitors, and comments. Select or de-select the boxes next to each item. Select **Update Preferences** to save changes.
 
->  You can't receive notifications in Slack when team members modify pull requests. You can receive notifications in Slack when you're mentioned in pull request comments. Select **I’m mentioned in a comment** in the **On Slack** column. To learn more about adding comments to pull requests, see [Adding comments](/docs/collaborating-in-postman/version-control/#adding-comments).
+> You can't receive notifications in Slack when team members modify pull requests. You can receive notifications in Slack when you're mentioned in pull request comments. Select **I’m mentioned in a comment** in the **On Slack** column. To learn more about adding comments to pull requests, see [Adding comments](/docs/collaborating-in-postman/version-control/#adding-comments).
 
 ## Add an activity feed to Slack
 

--- a/src/pages/docs/integrations/available-integrations/slack.md
+++ b/src/pages/docs/integrations/available-integrations/slack.md
@@ -90,11 +90,13 @@ The following is an example of a set of monitor results when sent to Slack:
 
 For the **Receive Postman Notification** integration, after allowing Slack permissions, your integration will be configured.
 
-After adding the integration, you can specify which notifications are sent to Slack. Update your [notification preferences](https://go.postman.co/settings/me/notifications) by selecting your avatar in the upper-right corner, then selecting **Notification Preferences**.
+After adding the integration, you can specify which notifications are sent to Slack. Update your [notification preferences](https://go.postman.co/settings/me/notifications) by selecting your avatar in the upper-right corner > **Settings** > **Notifications**.
 
-<img alt="Update notification preferences" src="https://assets.postman.com/postman-docs/notification-preferences-v9-4.jpg">
+<img alt="Update notification preferences" src="https://assets.postman.com/postman-docs/v10/notification-preferences-v10.jpg">
 
 In the Slack column, you can opt in to or out of notifications such as security, usage, monitors, and comments. Select or de-select the boxes next to each item. Select **Update Preferences** to save changes.
+
+>  You can't receive notifications in Slack when team members modify pull requests. You can receive notifications in Slack when you're mentioned in pull request comments. Select **I’m mentioned in a comment** in the **On Slack** column. To learn more about adding comments to pull requests, see [Adding comments](/docs/collaborating-in-postman/version-control/#adding-comments).
 
 ## Add an activity feed to Slack
 


### PR DESCRIPTION
* To receive PR notification via Slack, users must mention you in PR comments. I added a note explaining this in more detail.
* Updated the "Notification preferences" screenshot to match the UI.
* Updated written instructions for accessing the "Notification preferences" screen.