### PR TITLE
updated icon for Intergalactic card on homepage

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -284,10 +284,10 @@ class IndexPage extends React.Component {
                 <div className="col-sm-6 col-lg-4 mb-3 mb-md-4 pr-md-5">
                   <LandingCard
                     title="Postman Intergalactic"
-                    description="See previous and upcoming educational webinars."
-                    cta="See webinars"
+                    description="A series of educational trainings taught by Postman team members with a live Q&A."
+                    cta="See upcoming webinars"
                     link="https://www.postman.com/events/intergalactic/"
-                    icon="https://voyager.postman.com/icon/camp-tent-icon-postman.svg"
+                    icon="https://voyager.postman.com/icon/product-ufo-icon-postman.svg"
                   />
                 </div>
                 <div className="col-sm-6 col-lg-4 mb-3 mb-md-4 pr-md-5">


### PR DESCRIPTION
* updated icon for Intergalactic card on homepage
* updated copy to match Intergalactic page it points to
* updated CTA label
<img width="390" alt="Screen Shot 2022-10-19 at 13 17 44" src="https://user-images.githubusercontent.com/4358288/196795191-169219b2-c1ec-4e37-a103-0a0d7002e97f.png">
