### PR TITLE
Windows CLI installation doesn't set path

### DIFF
--- a/src/pages/docs/postman-cli/postman-cli-installation.md
+++ b/src/pages/docs/postman-cli/postman-cli-installation.md
@@ -59,7 +59,7 @@ curl -o- "https://dl-cli.pstmn.io/install/osx_64.sh" | sh
 
 ## Windows installation
 
-Run the following commands to install the Postman CLI for Windows. This will download an install script and run it. The install script creates a `%USERPROFILE%\AppData\Local\Postman CLI` directory if it doesn't exist yet, then installs a `postman` binary there. The install script also adds `%USERPROFILE%\AppData\Local\Postman CLI` to the `PATH` environment variable.
+Run the following commands to install the Postman CLI for Windows. This will download an install script and run it. The install script creates a `%USERPROFILE%\AppData\Local\Microsoft\WindowsApps` directory if it doesn't exist yet, then installs a `postman` binary there.
 
 ```powershell
 powershell.exe -NoProfile -InputFormat None -ExecutionPolicy AllSigned -Command "[System.Net.ServicePointManager]::SecurityProtocol = 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://dl-cli.pstmn.io/install/win64.ps1'))"


### PR DESCRIPTION
```pwsh
$POSTMAN_CLI_PATH = "$Env:USERPROFILE\AppData\Local\Microsoft\WindowsApps"
New-Item -type directory -path "$POSTMAN_CLI_PATH" -Force | `Out-Null`
$client = New-Object System.Net.WebClient
$client.DownloadFile("https://dl-cli.pstmn.io/download/latest/win64", "$POSTMAN_CLI_PATH\postman-cli.zip")
Expand-Archive "$POSTMAN_CLI_PATH\postman-cli.zip" "$POSTMAN_CLI_PATH" -Force
Remove-Item "$POSTMAN_CLI_PATH\postman-cli.zip"
mv "$POSTMAN_CLI_PATH\postman-cli.exe" "$POSTMAN_CLI_PATH\postman.exe" -Force
echo "The Postman CLI has been installed"
```