### PR TITLE
[TW-764] Clarified how to trigger the v10 upgrade prompt

### DIFF
--- a/src/pages/docs/designing-and-developing-your-api/creating-an-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/creating-an-api.md
@@ -33,7 +33,7 @@ contextual_links:
     url: "/docs/designing-and-developing-your-api/managing-apis/"
 ---
 
-To start using the API Builder, you can create a new API in your workspace. You can also update or delete existing APIs.
+To start using the API Builder, you can create a new API in your workspace. You can also upgrade, rename, or delete existing APIs.
 
 > You must be signed in to your Postman account to create an API.
 
@@ -66,7 +66,7 @@ To create a new API:
 
 ## Updating an API
 
-Postman v10 can display APIs created in prior versions of Postman. To work with the API in Postman v10, you will be asked to update it.
+Postman v10 can display APIs created in prior versions of Postman. To work with the API in Postman v10, you'll be asked to upgrade the API when you make changes to it. For example, adding a collection, adding a definition file, and working with a connected Git repository.
 
 There are some differences in the way API versions work in Postman v10 compared to v9:
 


### PR DESCRIPTION
Also, changed occurrences of 'update' to 'upgrade' because this is a one-time action on an API. The header still uses 'update' because we link to this section from the product, and changing the header will change the URL.