### PR TITLE
[TW-786] Clarify custom domain integration is for GitHub Enterprise Server

### DIFF
--- a/src/pages/docs/integrations/available-integrations/bigpanda.md
+++ b/src/pages/docs/integrations/available-integrations/bigpanda.md
@@ -49,7 +49,7 @@ After you set up the integration, you can view real-time alerts based on the res
 
 1. From the **[Home](https://go.postman.co/home)** page, select **[Integrations](https://go.postman.co/integrations)**.
 
-    ![select integrations](https://assets.postman.com/postman-docs/home-integrations.jpg)
+    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/v10/home-integrations-v10.jpg" width="390px">
 
 1. Select **[Browse All Integrations](https://go.postman.co/integrations/browse?category=all)**.
 1. Search and select **BigPanda**.

--- a/src/pages/docs/integrations/available-integrations/bitbucket.md
+++ b/src/pages/docs/integrations/available-integrations/bitbucket.md
@@ -41,7 +41,7 @@ You can back up your Postman Collections to your Bitbucket repository. Once the 
 
 From the **[Home](https://go.postman.co/home)** page select **[Integrations](https://go.postman.co/integrations)**.
 
-![home page and integrations](https://assets.postman.com/postman-docs/home-integrations.jpg)
+<img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/v10/home-integrations-v10.jpg" width="390px">
 
 Search and select **Bitbucket**.
 

--- a/src/pages/docs/integrations/available-integrations/coralogix.md
+++ b/src/pages/docs/integrations/available-integrations/coralogix.md
@@ -38,7 +38,7 @@ Setting up a Coralogix integration requires you to get an API key from Coralogix
 
 1. From the **[Home](https://go.postman.co/home)** page select **[Integrations](https://go.postman.co/integrations)**.
 
-    ![home page and integrations](https://assets.postman.com/postman-docs/home-integrations.jpg)
+    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/v10/home-integrations-v10.jpg" width="390px">
 
 1. Select **Browse All Integrations**.
 

--- a/src/pages/docs/integrations/available-integrations/datadog.md
+++ b/src/pages/docs/integrations/available-integrations/datadog.md
@@ -44,7 +44,7 @@ Setting up a Datadog integration requires you to get an API key from Datadog and
 
 1. From the **[Home](https://go.postman.co/home)** page select **[Integrations](https://go.postman.co/integrations)**.
 
-    ![home page and integrations](https://assets.postman.com/postman-docs/home-integrations.jpg)
+    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/v10/home-integrations-v10.jpg" width="390px">
 
 1. Search and select **Datadog**.
 1. You can select **View All** for a list of all the integrations already created by your team.

--- a/src/pages/docs/integrations/available-integrations/dropbox.md
+++ b/src/pages/docs/integrations/available-integrations/dropbox.md
@@ -23,7 +23,7 @@ Back up and synchronize your Postman Collections on Dropbox for file sharing, st
 
 1. From the **[Home](https://go.postman.co/home)** page, select **[Integrations](https://go.postman.co/integrations)**.
 
-    ![integrations page](https://assets.postman.com/postman-docs/home-integrations.jpg)
+    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/v10/home-integrations-v10.jpg" width="390px">
 
 1. Select **[Browse All Integrations](https://go.postman.co/integrations/browse?category=all)**.
 

--- a/src/pages/docs/integrations/available-integrations/github.md
+++ b/src/pages/docs/integrations/available-integrations/github.md
@@ -1,7 +1,6 @@
 ---
 title: "GitHub"
 updated: 2022-11-29
-warning: false
 contextual_links:
   - type: section
     name: "Prerequisites"
@@ -35,8 +34,8 @@ Setting up a GitHub integration requires you to generate a GitHub personal acces
 
 * [API sync with GitHub](#api-sync-with-github)
 * [Generating a GitHub personal access token](#generating-a-github-personal-access-token)
-* [Backing up collections on GitHub](#backing-up-collections-on-github)
-* [Backing up collections to GitHub on a custom domain](#backing-up-collections-to-github-on-a-custom-domain)
+* [Backing up collections to GitHub](#backing-up-collections-to-github)
+* [Backing up collections to GitHub Enterprise Server](#backing-up-collections-to-github-enterprise-server)
 * [Troubleshooting the GitHub integration](#troubleshooting-the-github-integration)
 
 ## API sync with GitHub
@@ -57,7 +56,7 @@ To integrate with GitHub, you need a GitHub personal access token.
 
 > For more information about generating a token, see the [GitHub documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 
-## Backing up collections on GitHub
+## Backing up collections to GitHub
 
  You can back up a Postman collection to a GitHub repository. After you create the integration, any new changes to the collection in Postman will also appear in the GitHub repository.
 
@@ -85,23 +84,23 @@ To integrate with GitHub, you need a GitHub personal access token.
    * Enter the file name of the collection in the repository.
    * Select the branch where you want to push the collection. The branch must already exist in your repository. If you don't specify a branch, Postman will push the collection to the default branch of the repository.
 
-   <img alt="Configure GitHub integration" src="https://assets.postman.com/postman-docs/v10/integrations-github-config-v10.jpg" width="507px">
+   <img alt="Configure GitHub integration" src="https://assets.postman.com/postman-docs/v10/integrations-github-add-v10.jpg" width="507px">
 
 1. To finish setting up the integration, select **Add Integration**.
 
-Every change saved to your Postman collection automatically commits changes to your GitHub repo in JSON format. Go to your GitHub repository to view your collections.
+Every change saved to your Postman collection automatically commits changes to your GitHub repository in JSON format. Go to your GitHub repository to view your collections.
 
 <img alt="Collection backup in GitHub" src="https://assets.postman.com/postman-docs/v10/integrations-github-repo-v10.jpg" />
 
-## Backing up collections to GitHub on a custom domain
+## Backing up collections to GitHub Enterprise Server
 
-To back up collections to GitHub on a custom domain, follow the same step as backing up a collection with the following differences:
+You can back up a Postman collection to a GitHub Enterprise Server repository on a custom domain. Follow the same step as [backing up collections to GitHub](#backing-up-collections-to-github) with the following differences:
 
 1. After searching for the GitHub integration in Postman, select **Add Integration** next to **Backup a collection (custom domain)**.
 
-1. Along with your personal access token, enter your GitHub custom domain, then select **Authenticate and Proceed**.
+1. Along with your personal access token, enter the custom domain of your enterprise server (for example, `https://my-git-server.example.com`). Then select **Authenticate and Proceed**.
 
-   <img alt="GitHub custom domain" src="https://assets.postman.com/postman-docs/integrations-github-custom-domain-pat.jpg" width="500px">
+   <img alt="GitHub custom domain" src="https://assets.postman.com/postman-docs/v10/integrations-github-custom-domain-v10.jpg" width="515px">
 
 1. Configure the integration with your collection, repository, directory, file name, and branch.
 
@@ -109,26 +108,30 @@ To back up collections to GitHub on a custom domain, follow the same step as bac
 
 ### Static IP support
 
-If your network is behind a firewall that requires IP addresses from an allowlist, you must use a static IP address to enable collection backups to GitHub on a custom domain.
+If your network is behind a firewall, you must allowlist a static IP address to enable collection backups to GitHub Enterprise Server on a custom domain.
 
 Contact your IT team to allowlist the following static IP in your firewall:
 
 * US East: `3.212.102.200`
 
-Once you allowlist this IP address, calls for this integration will be able to connect to your network and allow the integration to work as expected.
+Once you allowlist this IP address, the collection backup integration will be able to connect to your private network.
 
-> GitHub Enterprise requires the ability to reach the above IP from the network where your GitHub Enterprise server instance is hosted. If your server instance is in a VPC, you may need to modify the network access control list or rules there.
+> The **Backup a collection (custom domain)** integration requires the ability to reach the static IP address `3.212.102.200` from the network where your GitHub Enterprise Server instance is hosted. If your server instance is in a VPC, you may need to change the VPC's network access control list or rules.
 
 ## Troubleshooting the GitHub integration
 
-If your GitHub integration has issues or your data isn't pushed to GitHub, check the following requirements:
+If your GitHub integration has issues or your data isn't pushed to GitHub, make sure you've met the following requirements:
 
-* You added the GitHub integration in the same workspace as the content you want to push to the GitHub repo.
-* You selected the correct GitHub integration in Postman. For example, if you use a [custom domain](#backing-up-collections-to-github-on-a-custom-domain), make sure you selected the **Backup a collection (custom domain)** integration.
-* You initialized your GitHub repo with a `README.md` file. When creating a new repository, you can select the **Add a README file** check box.
-* You selected the scopes `user` and `repo` when creating your GitHub [personal access token](#generating-a-github-personal-access-token).
+* You added the GitHub integration in the same workspace as the content you want to push to the GitHub repository.
+* You selected the correct GitHub integration in Postman. For example, if you use [GitHub Enterprise Server on a custom domain](#backing-up-collections-to-github-enterprise-server), make sure you selected the **Backup a collection (custom domain)** integration.
+* You initialized your GitHub repository with a `README.md` file. When creating a new repository, you can select the **Add a README file** check box.
+* You selected the correct permissions when creating your GitHub [personal access token](#generating-a-github-personal-access-token):
+
+    * **Classic token** - Make sure to select the `repo` and `user` scopes.
+    * **Fine-grained token** - Make sure the token has access to the repository you want to back up to and has the following Repository permissions: `Contents (Read and write)` and `Metadata (Read-only)`.
+
 * The branch you specified when setting up the integration already exists on GitHub. Postman won't create the branch if it doesn't already exist.
 * You have permissions to push to the branch.
-* If your enterprise version of GitHub is on-premises or self-hosted, check with your IT team for [firewall requirements](#static-ip-support).
+* If your instance of GitHub Enterprise Server is on-premises or self-hosted, check with your IT team for [firewall requirements](#static-ip-support).
 
 Edit the integration to make any required changes. If the integration still doesn't work after you edit it, delete the integration and add it again.

--- a/src/pages/docs/integrations/available-integrations/github.md
+++ b/src/pages/docs/integrations/available-integrations/github.md
@@ -1,6 +1,6 @@
 ---
 title: "GitHub"
-updated: 2022-03-15
+updated: 2022-11-29
 warning: false
 contextual_links:
   - type: section
@@ -25,11 +25,11 @@ contextual_links:
 
 > **[GitHub Enterprise Server integrations are available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
-Back up your Postman collections to GitHub, a cloud-based hosting service for Git repositories, with the Postman to GitHub integration.
+Back up your Postman collections to GitHub, a cloud-based hosting service for Git repositories, with the Postman to GitHub integration. You can also backup collections to a custom domain on GitHub Enterprise Server.
 
 Setting up a GitHub integration requires you to generate a GitHub personal access token and configure how you would like to back up your collections.
 
-> To import data into Postman from a GitHub repository, see [Importing via GitHub repositories](/docs/getting-started/importing-and-exporting-data/#importing-via-github-repositories).
+> To import data into Postman from a GitHub repository, see [Importing from GitHub repositories](http://localhost:8000/docs/getting-started/importing-and-exporting-data/#importing-from-github-repositories).
 
 ## Contents
 
@@ -41,11 +41,11 @@ Setting up a GitHub integration requires you to generate a GitHub personal acces
 
 ## API sync with GitHub
 
-Postman 9.0 introduced the ability to connect a Git repository to an API. Instead of using an integration, you can directly connect a GitHub repo to an API in the API Builder. This provides two-way sync of schemas and associated collections, plus adds features for syncing branches and release tags between Postman and your repo. For more information on the repo sync feature, see [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/).
+With Postman v10, you can connect a GitHub repository to an API in the API Builder. Once connected, you can sync your API's definition and associated collections between Postman and GitHub. You can switch branches, pull changes from the repository, and push changes to the repository, all from within Postman. To learn more about syncing your API with GitHub, see [Versioning APIs](/docs/designing-and-developing-your-api/versioning-an-api/).
 
 ## Generating a GitHub personal access token
 
-To integrate with GitHub, you will need a GitHub personal access token.
+To integrate with GitHub, you need a GitHub personal access token.
 
 1. Sign in to [GitHub](https://github.com/).
 1. If you don’t already have a personal access token, [generate a new one](https://github.com/settings/tokens). You can use a classic token or a [fine-grained token](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/).
@@ -59,11 +59,11 @@ To integrate with GitHub, you will need a GitHub personal access token.
 
 ## Backing up collections on GitHub
 
- You can back up a Postman Collection to a GitHub repository. After you create the integration, any new changes to the collection in Postman will also appear in the GitHub repository.
+ You can back up a Postman collection to a GitHub repository. After you create the integration, any new changes to the collection in Postman will also appear in the GitHub repository.
 
 1. From the **[Home](https://go.postman.co/home)** page select **[Integrations](https://go.postman.co/integrations)**.
 
-    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/home-integrations.jpg" width="500px">
+    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/home-integrations.jpg" width="400px">
 
 1. Search and select **GitHub**.
 
@@ -81,17 +81,15 @@ To integrate with GitHub, you will need a GitHub personal access token.
    * Select the workspace with the collection you want to back up.
    * Select a collection to back up.
    * Select the GitHub repository where you want to back up the collection.
-   * Enter the directory where you want to push the collection. If the directory doesn't exist, Postman will create it for you. If you don't specify a directory, Postman will create a `Postman Collections` directory.
+   * Enter the directory where you want to push the collection. If the directory doesn't exist, Postman will create it for you. If you don't specify a directory, Postman will create a `Postman collections` directory.
    * Enter the file name of the collection in the repository.
-   * Enter the branch where you want to push the collection. The branch must already exist in your repository. If you don't specify a branch, Postman will push the collection to the default branch of the repository.
+   * Select the branch where you want to push the collection. The branch must already exist in your repository. If you don't specify a branch, Postman will push the collection to the default branch of the repository.
 
    <img alt="Configure GitHub integration" src="https://assets.postman.com/postman-docs/integrations-github-add.jpg" width="500px">
 
 1. To finish setting up the integration, select **Add Integration**.
 
-Every change saved to your Postman Collection automatically commits changes to your GitHub repo in JSON format. Go to your GitHub repository to view your collections.
-
-<img alt="Github integrations screen" src="https://assets.postman.com/postman-docs/Github_Integrations5.png" style="border: 1px solid #4a4a4a">
+Every change saved to your Postman collection automatically commits changes to your GitHub repo in JSON format. Go to your GitHub repository to view your collections.
 
 ## Backing up collections to GitHub on a custom domain
 

--- a/src/pages/docs/integrations/available-integrations/github.md
+++ b/src/pages/docs/integrations/available-integrations/github.md
@@ -63,17 +63,17 @@ To integrate with GitHub, you need a GitHub personal access token.
 
 1. From the **[Home](https://go.postman.co/home)** page select **[Integrations](https://go.postman.co/integrations)**.
 
-    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/home-integrations.jpg" width="400px">
+    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/v10/home-integrations-v10.jpg" width="390px">
 
 1. Search and select **GitHub**.
 
-    [![GitHub integration](https://assets.postman.com/postman-docs/integrations-github1.jpg)](https://assets.postman.com/postman-docs/integrations-github1.jpg)
+    <img alt="GitHub integration" src="https://assets.postman.com/postman-docs/v10/integrations-github-v10.jpg" />
 
 1. Next to **Backup a collection**, select **Add Integration**.
 
 1. Enter your GitHub **Personal Access Token** and select **Authenticate and Proceed**.
 
-    <img alt="Access token" src="https://assets.postman.com/postman-docs/integrations-github-schema-pat.jpg" width="500px">
+    <img alt="GitHub integration" src="https://assets.postman.com/postman-docs/v10/integrations-github-authenticate-v10.jpg" width="515px" />
 
 1. After Postman verifies the token, you can configure the integration:
 
@@ -85,11 +85,13 @@ To integrate with GitHub, you need a GitHub personal access token.
    * Enter the file name of the collection in the repository.
    * Select the branch where you want to push the collection. The branch must already exist in your repository. If you don't specify a branch, Postman will push the collection to the default branch of the repository.
 
-   <img alt="Configure GitHub integration" src="https://assets.postman.com/postman-docs/integrations-github-add.jpg" width="500px">
+   <img alt="Configure GitHub integration" src="https://assets.postman.com/postman-docs/v10/integrations-github-config-v10.jpg" width="507px">
 
 1. To finish setting up the integration, select **Add Integration**.
 
 Every change saved to your Postman collection automatically commits changes to your GitHub repo in JSON format. Go to your GitHub repository to view your collections.
+
+<img alt="Collection backup in GitHub" src="https://assets.postman.com/postman-docs/v10/integrations-github-repo-v10.jpg" />
 
 ## Backing up collections to GitHub on a custom domain
 

--- a/src/pages/docs/integrations/available-integrations/keen.md
+++ b/src/pages/docs/integrations/available-integrations/keen.md
@@ -32,7 +32,7 @@ Setting up a Keen integration requires you to get a project ID and API key befor
 
 1. From the **[Home](https://go.postman.co/home)** page select **[Integrations](https://go.postman.co/integrations)**.
 
-    ![home page and integrations](https://assets.postman.com/postman-docs/home-integrations.jpg)
+    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/v10/home-integrations-v10.jpg" width="390px">
 
 1. Search and select **Keen**.
 

--- a/src/pages/docs/integrations/available-integrations/microsoft-teams.md
+++ b/src/pages/docs/integrations/available-integrations/microsoft-teams.md
@@ -48,7 +48,7 @@ To configure a Microsoft Teams integration, you will need to first create a Micr
 
 1. From the **[Home](https://go.postman.co/home)** page select **[Integrations](https://go.postman.co/integrations)**.
 
-    ![home page and integrations](https://assets.postman.com/postman-docs/home-integrations.jpg)
+    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/v10/home-integrations-v10.jpg" width="390px">
 
 1. Search and select **Microsoft Teams**.
 

--- a/src/pages/docs/integrations/available-integrations/opsgenie.md
+++ b/src/pages/docs/integrations/available-integrations/opsgenie.md
@@ -50,7 +50,7 @@ For more information, refer to [Create an API integration](https://support.atlas
 
 1. From the **[Home](https://go.postman.co/home)** page, select **[Integrations](https://go.postman.co/integrations)**.
 
-    ![home page and integrations](https://assets.postman.com/postman-docs/home-integrations.jpg)
+    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/v10/home-integrations-v10.jpg" width="390px">
 
 1. Search and select **Opsgenie**.
 

--- a/src/pages/docs/integrations/available-integrations/splunk-on-call.md
+++ b/src/pages/docs/integrations/available-integrations/splunk-on-call.md
@@ -40,7 +40,7 @@ If you are using teams in Splunk On-Call, you can route alerts to specific teams
 
 1. On the **[Home](https://go.postman.co/home)** page, select **[Integrations](https://go.postman.co/integrations)**.
 
-    ![Home page and integrations](https://assets.postman.com/postman-docs/home-integrations.jpg)
+    <img alt="Home page and integrations" src="https://assets.postman.com/postman-docs/v10/home-integrations-v10.jpg" width="390px">
 
 1. Search and select **Splunk On-Call**.
 1. Select **Add Integration** and enter the following:


### PR DESCRIPTION
- Make it clearer that the "Backup a collection (custom domain" integration is for GitHub Enterprise Server
- Refresh GitHub integrations page
- Update screenshots on GitHub integrations page
- Use the new "Home > Integrations" screenshot on other integration pages