### PR TITLE
[TW-801] Change "context bar" to "right sidebar"

### DIFF
--- a/src/pages/docs/collaborating-in-postman/using-version-control/forking-entities.md
+++ b/src/pages/docs/collaborating-in-postman/using-version-control/forking-entities.md
@@ -81,7 +81,7 @@ To view a list of users who have forked a collection, environment, or flow, sele
 
 To access the list of forks for a collection, environment, or flow, do the following:
 
-1. Select the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg#icon" width="14px"> in the context bar.
+1. Select the fork icon <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg#icon" width="14px"> in the right sidebar.
 1. Select the fork name under **Forks**.
 
     > You can also select the user's avatar under **Forks** to view the user's public profile.

--- a/src/pages/docs/collaborating-in-postman/using-version-control/reviewing-pull-requests.md
+++ b/src/pages/docs/collaborating-in-postman/using-version-control/reviewing-pull-requests.md
@@ -52,7 +52,7 @@ If you're tagged as a reviewer on a pull request, you can view the changes, comm
 
 ## Reviewing pull requests
 
-To access the list of pull requests, go to the element and select the pull requests icon <img alt="Pull request icon" src="https://assets.postman.com/postman-docs/icon-pull-request.jpg#icon" width="16px"> in the context bar. Each item shows the pull request's status, which will be `OPEN` for any that haven't been merged or declined. Select a pull request's name to open it.
+To access the list of pull requests, go to the element and select the pull requests icon <img alt="Pull request icon" src="https://assets.postman.com/postman-docs/icon-pull-request.jpg#icon" width="16px"> in the right sidebar. Each item shows the pull request's status, which will be `OPEN` for any that haven't been merged or declined. Select a pull request's name to open it.
 
 <img src="https://assets.postman.com/postman-docs/v10/open-pull-request-list-v10.jpg" alt="Pull request list" width="350px"/>
 

--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/mock-with-api.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/mock-with-api.md
@@ -68,7 +68,7 @@ Select **Send** to send the `GET All Collections` request. The response pane dis
 
 <img alt="Getting the collection ID" src="https://assets.postman.com/postman-docs/v10/mock-api-get-collection-id-v10.jpg" width="750px">
 
-> You can also find the collection ID in Postman. First, select **Collections** in the sidebar and select the `testAPI` collection. Then select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right context bar to access the collection ID.
+> You can also find the collection ID in Postman. First, select **Collections** in the sidebar and select the `testAPI` collection. Then select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar to access the collection ID.
 
 ### Get the environment ID
 
@@ -78,7 +78,7 @@ Make sure to add an `x-api-key` header with your Postman API Key, and then selec
 
 <img alt="Getting the environment ID" src="https://assets.postman.com/postman-docs/v10/mock-api-environment-id-v10.jpg" width="750px">
 
-> You can also find the environment ID in Postman. First, select **Environments** in the sidebar and select the `testAPIenv` environment. Then select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right context bar to access the environment ID.
+> You can also find the environment ID in Postman. First, select **Environments** in the sidebar and select the `testAPIenv` environment. Then select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar to access the environment ID.
 
 ## Step 3: Create a mock server with the Postman API
 

--- a/src/pages/docs/postman-cli/postman-cli-options.md
+++ b/src/pages/docs/postman-cli/postman-cli-options.md
@@ -87,7 +87,7 @@ You can run your collections with the `postman collection run` command:
 
 This command runs a collection and sends all run results and responses to Postman servers. You can specify the collection with its file path or Collection ID.
 
-> You can find the collection ID in Postman. First, select **Collections** in the sidebar and select a collection. Then select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right context bar to access the collection ID.
+> You can find the collection ID in Postman. First, select **Collections** in the sidebar and select a collection. Then select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right right sidebar to access the collection ID.
 
 #### Examples
 

--- a/src/pages/docs/postman-flows/flows-intro/the-interface.md
+++ b/src/pages/docs/postman-flows/flows-intro/the-interface.md
@@ -3,15 +3,15 @@ title: "The Postman Flows interface"
 updated: 2022-11-17
 ---
 
-The Postman Flows interface has three main parts: the toolbar, the context bar, and the console.
+The Postman Flows interface has three main parts: the toolbar, the right sidebar, and the console.
 
 ## Contents
 
 * [Toolbar](#toolbar)
-* [Context bar](#context-bar)
+* [Right sidebar](#right-sidebar)
 * [Console](#console)
 
-![interface](https://assets.postman.com/postman-labs-docs/interface/updated-interface-main.png)
+![interface](https://assets.postman.com/postman-docs/v10/flows-interface-main.jpg)
 
 ## Toolbar
 
@@ -43,10 +43,10 @@ The toolbar gives you access to tools you can use to manipulate the canvas.
 
   ![add text](https://assets.postman.com/postman-labs-docs/interface/updated-interface-add-annotations.gif)
 
-## Context bar
+## Right sidebar
 
-The context bar is the place where you'll see more information about your Flow and its current state.
-![context bar](https://assets.postman.com/postman-labs-docs/interface/updated-interface-context-bar.png)
+The right sidebar is the place where you'll see more information about your Flow and its current state.
+![Right sidebar](https://assets.postman.com/postman-labs-docs/interface/updated-interface-context-bar.png)
 
 * **Element info**
 

--- a/src/pages/docs/publishing-your-api/viewing-documentation.md
+++ b/src/pages/docs/publishing-your-api/viewing-documentation.md
@@ -54,7 +54,7 @@ To view documentation for a collection, do the following:
 
     > You can also search for collections on the [Public API Network](https://www.postman.com/explore/collections).
 
-1. Select the documentation icon <img alt="Documentation icon" src="https://assets.postman.com/postman-docs/documentation-icon-v8-10.jpg#icon" width="16px"> in the context bar to view documentation for the selected item.
+1. Select the documentation icon <img alt="Documentation icon" src="https://assets.postman.com/postman-docs/documentation-icon-v8-10.jpg#icon" width="16px"> in the right sidebar to view documentation for the selected item.
 1. To view all of the documentation for the collection, select **View complete collection documentation**.
 
 <img alt="View complete documentation" src="https://assets.postman.com/postman-docs/documentation-view-complete-v9.jpg" width="566px"/>

--- a/src/pages/docs/running-collections/building-workflows.md
+++ b/src/pages/docs/running-collections/building-workflows.md
@@ -82,7 +82,7 @@ You can use `postman.setNextRequest()` in the pre-request script or the test scr
 
 ### Specify the next request using the request ID
 
-Instead of specifying the name of the request to run next, you can provide the request ID. To find the request ID, open a request and select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the context bar at right.
+Instead of specifying the name of the request to run next, you can provide the request ID. To find the request ID, open a request and select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar.
 
 Note that the ID shown is the user ID followed by the request ID. Omit the first eight digits and dash to get the request ID. You can also get the request ID using the `pm.info.requestId` function (see [Scripting Workflows](/docs/writing-scripts/script-references/postman-sandbox-api-reference/#scripting-workflows)).
 


### PR DESCRIPTION
We now use the term "right sidebar" instead of "context bar" per https://learning.postman.com/docs/getting-started/navigating-postman/#right-sidebar