### PR TITLE
[TW-774] Wording changes to CI integrations

### DIFF
--- a/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
@@ -69,7 +69,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for Bitbucket Pipelines
 
-With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your Bitbucket pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `bitbucket-pipelines.yml` file in your Bitbucket repository.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests as part of your Bitbucket pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `bitbucket-pipelines.yml` file in your Bitbucket repository.
 
 Each time the pipeline runs, the Postman CLI runs the collections that contain your tests. You can view the results of your tests in Postman. You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
@@ -42,7 +42,7 @@ To view build jobs, open an API and select **Test and Automation**. The most rec
 Select **View All Builds** to view the full list of build jobs. From here you can take the following actions:
 
 * Use the dropdown lists to filter jobs by branch or build status.
-* To view a build in Bitbucket Pipelines, select the build name.
+* To open a build in Bitbucket Pipelines, select the build name.
 * To start a new build, select **Run Build**. Select or enter the name of the branch to use and select **Run Build**. To cancel a running build, select **Cancel** next to the build.
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px">.
@@ -69,7 +69,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for Bitbucket Pipelines
 
-With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your Bitbucket pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `bitbucket-pipelines.yml` file in your Bitbucket repository.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your Bitbucket pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `bitbucket-pipelines.yml` file in your Bitbucket repository.
 
 Each time the pipeline runs, the Postman CLI runs the collections that contain your tests. You can view the results of your tests in Postman. You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
@@ -71,7 +71,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for CircleCI
 
-With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your CircleCI pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `config.yml` file in your CircleCI project.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests as part of your CircleCI pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `config.yml` file in your CircleCI project.
 
 You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
@@ -54,7 +54,7 @@ To view build jobs, open an API and select **Test and Automation**. The most rec
 Select **View All Builds** to view the full list of build jobs. From here you can take the following actions:
 
 * Use the dropdown lists to filter jobs by branch or build status.
-* To view a build in CircleCI, hover over a build and select **View build details**.
+* To open a build in CircleCI, hover over a build and select **View build details**.
 * To start a new build, select **Run Build**. Select or enter the name of the branch to use and select **Run Build**.
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px">.
@@ -71,7 +71,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for CircleCI
 
-With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your CircleCI pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `config.yml` file in your CircleCI project.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your CircleCI pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `config.yml` file in your CircleCI project.
 
 You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
@@ -57,7 +57,7 @@ To view build jobs, open an API and select **Test and Automation**. The most rec
 Select **View All Builds** to view the full list of build jobs. From here you can take the following actions:
 
 * Use the dropdown lists to filter jobs by branch or build status.
-* To view a build in GitHub, select the build name.
+* To open a build in GitHub, select the build name.
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px">.
 
@@ -83,7 +83,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for GitHub Actions
 
-With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your GitHub pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to a YAML file in the `.github/workflows` directory in your GitHub repository.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your GitHub pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to a YAML file in the `.github/workflows` directory in your GitHub repository.
 
 Each time the pipeline runs, the Postman CLI runs the collections that contain your tests. You can view the results of your tests in Postman. You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
@@ -83,7 +83,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for GitHub Actions
 
-With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your GitHub pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to a YAML file in the `.github/workflows` directory in your GitHub repository.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests as part of your GitHub pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to a YAML file in the `.github/workflows` directory in your GitHub repository.
 
 Each time the pipeline runs, the Postman CLI runs the collections that contain your tests. You can view the results of your tests in Postman. You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
@@ -55,7 +55,7 @@ To view build jobs, open an API and select **Test and Automation**. The most rec
 Select **View All Builds** to view the full list of build jobs. From here you can take the following actions:
 
 * Use the dropdown lists to filter jobs by branch or build status.
-* To view a build in GitLab, select the build name.
+* To open a build in GitLab, select the build name.
 * To start a new build, select **Run Build**. Select or enter the name of the branch to use, and then select **Run Build**. To cancel a running build, select **Cancel** next to the build.
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px">.
@@ -82,7 +82,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for GitLab CI/CD
 
-With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your GitLab pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `.gitlab-ci.yml` file in your GitLab repository.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your GitLab pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `.gitlab-ci.yml` file in your GitLab repository.
 
 Each time the pipeline runs, the Postman CLI runs the collections that contain your tests. You can view the results of your tests in Postman. You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
@@ -82,7 +82,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for GitLab CI/CD
 
-With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your GitLab pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `.gitlab-ci.yml` file in your GitLab repository.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests as part of your GitLab pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `.gitlab-ci.yml` file in your GitLab repository.
 
 Each time the pipeline runs, the Postman CLI runs the collections that contain your tests. You can view the results of your tests in Postman. You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
@@ -88,7 +88,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for Jenkins
 
-With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your Jenkins pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to your Jenkins pipeline.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests as part of your Jenkins pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to your Jenkins pipeline.
 
 Each time a build runs, the Postman CLI runs the collections that contain your tests. You can view the results of your tests in Postman. You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
@@ -61,7 +61,7 @@ To view build jobs, open an API and select **Test and Automation**. The most rec
 Select **View Builds** to view the full list of build jobs. From here you can take the following actions:
 
 * Use the dropdown list to filter jobs by build status.
-* To view a build in Jenkins, hover over a build and select **View build details**.
+* To open a build in Jenkins, hover over a build and select **View build details**.
 * To start a new build, select **Run Build**.
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg#icon" width="18px">.
@@ -88,7 +88,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for Jenkins
 
-With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your Jenkins pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to your Jenkins pipeline.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your Jenkins pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to your Jenkins pipeline.
 
 Each time a build runs, the Postman CLI runs the collections that contain your tests. You can view the results of your tests in Postman. You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
@@ -66,7 +66,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for Travis CI
 
-With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your Travis CI pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `.travis.yml` file in your Travis CI project.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests as part of your Travis CI pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `.travis.yml` file in your Travis CI project.
 
 You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
@@ -49,7 +49,7 @@ To view build jobs, open an API and select **Test and Automation**. The most rec
 Select **View All Builds** to view the full list of build jobs. From here you can take the following actions:
 
 * Use the dropdown lists to filter jobs by branch or build status.
-* To view a build in Travis CI, hover over a build and select **View build details**.
+* To open a build in Travis CI, hover over a build and select **View build details**.
 * To start a new build, select **Run Build**. Select or enter the name of the branch to use and select **Run Build**.
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px">.
@@ -66,7 +66,7 @@ To view the results of API Governance and API Security checks that ran as part o
 
 ## Configuring the Postman CLI for Travis CI
 
-With the help of the Postman CLI and the Postman API, you can run API tests created in Postman as part of your Travis CI pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `.travis.yml` file in your Travis CI project.
+With the help of the Postman CLI and the Postman API, you can run Postman collections with your API tests created in Postman as part of your Travis CI pipeline. First generate the Postman CLI configuration code in Postman. Then add the configuration code to the `.travis.yml` file in your Travis CI project.
 
 You an also enforce [API Governance and API Security rules each time the pipeline runs](/docs/api-governance/api-definition/api-definition-warnings/#tracking-governance-and-security-rule-violations-in-cicd) ([Enterprise teams only](https://www.postman.com/pricing/)).
 


### PR DESCRIPTION
* Updated `To view a build...` to `To open a build...` because "open" clarifies that the user will open the build in the CI tool, not in Postman.
* Clarified in the "Configuring the Postman CLI" section that Postman CLI runs Postman collections with API tests, not API tests.