### PR TITLE
[TW-805] console clear method

### DIFF
--- a/src/pages/docs/monitoring-your-api/faqs-monitors.md
+++ b/src/pages/docs/monitoring-your-api/faqs-monitors.md
@@ -62,7 +62,7 @@ The provided static IP addresses are fixed to their specified region and shared 
 
 ### How do I troubleshoot problems?
 
-For collection-based monitors, you can view the full console output for every monitor run, including any errors. You can also use methods such as `console.log()` and `console.warn()` to output your own debugging information. To learn more, see [Troubleshooting monitors](/docs/monitoring-your-api/troubleshooting-monitors/).
+For collection-based monitors, you can view the full console output for every monitor run, including any errors. You can also use methods such as `console.log()` and `console.warn()` to output your own debugging information. You can use the `console.clear()` method to clear information from the console. To learn more, see [Troubleshooting monitors](/docs/monitoring-your-api/troubleshooting-monitors/).
 
 > For your security and privacy, Postman doesn't log request or response bodies in the console. Postman also doesn't log headers, as they may include items like cookies and authorization keys.
 

--- a/src/pages/docs/running-collections/viewing-scheduled-collection-runs.md
+++ b/src/pages/docs/running-collections/viewing-scheduled-collection-runs.md
@@ -36,7 +36,7 @@ You can run collections at specific times each day or week. For example, you may
 
 You can view your scheduled collection runs in Postman by navigating to your workspace and selecting **Collections > Your collection > Runs > Scheduled runs**.
 
-<img src="https://assets.postman.com/postman-docs/v10/scheduled-runs-tab-3-v10.jpg" alt="View scheduled collection run in tab"/>
+<img src="https://assets.postman.com/postman-docs/v10/scheduled-runs-tab-5-v10.jpg" alt="View scheduled collection run in tab"/>
 
 Hover over your scheduled collection run and select **View**.
 

--- a/src/pages/docs/sending-requests/troubleshooting-api-requests.md
+++ b/src/pages/docs/sending-requests/troubleshooting-api-requests.md
@@ -86,6 +86,7 @@ Using log statements at appropriate locations in your test scripts can help you 
 * `console.info()`
 * `console.warn()`
 * `console.error()`
+* `console.clear()`
 
 [![Console info](https://assets.postman.com/postman-docs/console-logs-in-pane-v8.jpg)](https://assets.postman.com/postman-docs/console-logs-in-pane-v8.jpg)
 

--- a/src/pages/docs/writing-scripts/script-references/test-examples.md
+++ b/src/pages/docs/writing-scripts/script-references/test-examples.md
@@ -417,7 +417,7 @@ pm.test("Check the active environment", () => {
 
 ## Troubleshooting common test errors
 
-When you encounter errors or unexpected behavior in your test scripts, the Postman [Console](/docs/sending-requests/troubleshooting-api-requests/) can help you to identify the source. By combining `console.log()`, `console.info()`, `console.warn()` and `console.error()` debug statements with your test assertions, you can examine the content of the HTTP requests and responses, as well as Postman data items such as variables. Select <img alt="Console icon" src="https://assets.postman.com/postman-docs/icon-console-v9.jpg#icon" width="16px"> **Console** from the Postman footer to open it.
+When you encounter errors or unexpected behavior in your test scripts, the Postman [Console](/docs/sending-requests/troubleshooting-api-requests/) can help you to identify the source. By combining `console.log()`, `console.info()`, `console.warn()` and `console.error()` debug statements with your test assertions, you can examine the content of the HTTP requests and responses, as well as Postman data items such as variables. You can also use the `console.clear()` method to clear information from the console. Select <img alt="Console icon" src="https://assets.postman.com/postman-docs/icon-console-v9.jpg#icon" width="16px"> **Console** from the Postman footer to open it.
 
 [![Console info](https://assets.postman.com/postman-docs/console-logs-in-pane-v8.jpg)](https://assets.postman.com/postman-docs/console-logs-in-pane-v8.jpg)
 


### PR DESCRIPTION
I added information about the new `console.clear()` method. Users can now add this method to their pre-request or test scripts to clear the console. I searched the documentation for sections that already explain/mention the `console.*` methods, and added a line about the `console.clear()` method.

There are other sections that mention console-related logs, such as `/docs/monitoring-your-api/troubleshooting-monitors/#viewing-failed-monitors`, `/docs/monitoring-your-api/viewing-monitor-results/#console-log`, and `/docs/running-collections/viewing-scheduled-collection-runs/#console-log`. Since these sections focus on viewing logs for scheduled collection runs and monitors, I chose to exclude any mentions of the clear method. Please let me know if you think we should still mention the clear method in these sections.

I also fixed a screenshot title that wasn't displaying correctly.