### PR TITLE
TW 821 Clarify workplace roles availability

### DIFF
--- a/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
+++ b/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
@@ -1,7 +1,7 @@
 ---
 title: "Defining roles"
 order: 72
-updated: 2022-05-11
+updated: 2022-12-19
 page_id: "roles_and_permissions"
 warning: false
 contextual_links:

--- a/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
+++ b/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
@@ -103,9 +103,9 @@ To learn how to manage team roles in Postman, see [Managing your team](/docs/adm
 
 You can [assign](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#managing-workspace-roles) three role types in Postman workspaces: **Admin**, **Editor**, and **Viewer**. Partner Workspaces offer an additional role type: **Partner Lead**.
 
-* **Admin** - Can manage workspace resources and settings
-* **Editor** - Can create and edit workspace resources
-* **Viewer** - Can view, fork, and export workspace resources
+* **Admin** - Can manage workspace resources and settings.
+* **Editor** ([Paid plans only](https://www.postman.com/pricing)) - Can create and edit workspace resources.
+* **Viewer** ([Paid plans only](https://www.postman.com/pricing)) - Can view, fork, and export workspace resources.
 * **Partner Lead** (External, [Enterprise plans only](https://www.postman.com/pricing)) - Can invite other partners from their organization to join a [Partner Workspace](/docs/collaborating-in-postman/using-workspaces/partner-workspaces/). To learn more, see [Partner roles](#partner-roles).
 
 The following roles control access at a workspace level:


### PR DESCRIPTION
Question for the group - Since the availability for these workspace roles is on Basic, Professional, and Enterprise plans and that's pretty lengthy for a list entry, I used "Paid plans only" as shorthand for that, with a link to the [pricing page](https://www.postman.com/pricing/). In your opinions, is that clear enough? Or should I use "Basic, Professional, and Enterprise plans only" instead? 🤔 