### PR TITLE
[TW-823] Doc history is going to be accessible only to the user who made the request

### DIFF
--- a/src/pages/docs/collaborating-in-postman/using-workspaces/creating-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/creating-workspaces.md
@@ -51,7 +51,7 @@ With a [Postman account](/docs/getting-started/postman-account/) you can create 
 
 By adding an element to a workspace, collaborators with access to the workspace will also be able to access the element by default with read-only permissions. You can [configure access settings](/docs/collaborating-in-postman/roles-and-permissions/) for the workspace on an individual basis to give permissions depending on the account.
 
-Workspaces can also create visibility for the projects within a team, as collections in a workspace are visible to all team members with access to the workspace. Request history is also saved to a workspace, which can aid collaborative debugging efforts.
+Workspaces can also create visibility for the projects within a team, as collections in a workspace are visible to all team members with access to the workspace.
 
 _Workspace as an element_ represents a whole container where being an Admin gives you full access to the workspace. This concept works like the inheritance property where you will have Editor access to all the elements within that particular workspace.
 

--- a/src/pages/docs/getting-started/navigating-postman.md
+++ b/src/pages/docs/getting-started/navigating-postman.md
@@ -133,6 +133,8 @@ Your history also includes [collection runs](/docs/running-collections/intro-to-
 * Select the delete icon <img alt="Delete icon" src="https://assets.postman.com/postman-docs/icon-delete-v9.jpg#icon" width="12px"> to remove the request from your history.
 * Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg#icon" width="18px"> to access other actions, including creating a monitor, documentation, or mock server for the request.
 
+> When you make requests in a [shared workspace](http://localhost:8000/docs/collaborating-in-postman/using-workspaces/creating-workspaces/), your request history is visible to you but not to other team members in the workspace.
+
 #### Clearing your history
 
 To remove all requests from your history, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg#icon" width="18px"> next to the History search bar, then select **Clear all**.


### PR DESCRIPTION
- Removed reference to using history collaboratively
- Added note stating that your request history is only visible to you