### PR TITLE
[TW-839] Select build name in CI integrations

### DIFF
--- a/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
@@ -54,7 +54,7 @@ To view build jobs, open an API and select **Test and Automation**. The most rec
 Select **View All Builds** to view the full list of build jobs. From here you can take the following actions:
 
 * Use the dropdown lists to filter jobs by branch or build status.
-* To open a build in CircleCI, hover over a build and select **View build details**.
+* To open a build in CircleCI, select the build name.
 * To start a new build, select **Run Build**. Select or enter the name of the branch to use and select **Run Build**.
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px">.

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
@@ -61,7 +61,7 @@ To view build jobs, open an API and select **Test and Automation**. The most rec
 Select **View Builds** to view the full list of build jobs. From here you can take the following actions:
 
 * Use the dropdown list to filter jobs by build status.
-* To open a build in Jenkins, hover over a build and select **View build details**.
+* To open a build in Jenkins, select the build name.
 * To start a new build, select **Run Build**.
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-three-dots-v9.jpg#icon" width="18px">.

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
@@ -49,7 +49,7 @@ To view build jobs, open an API and select **Test and Automation**. The most rec
 Select **View All Builds** to view the full list of build jobs. From here you can take the following actions:
 
 * Use the dropdown lists to filter jobs by branch or build status.
-* To open a build in Travis CI, hover over a build and select **View build details**.
+* To open a build in Travis CI, select the build name.
 * To start a new build, select **Run Build**. Select or enter the name of the branch to use and select **Run Build**.
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px">.


### PR DESCRIPTION
Instructions mentioned that you can open a build in the CI tool by hovering over a build and selecting "View build details", which isn't correct.

I confirmed with the Integrations squad that users only need to select the build name in Postman.