### PR TITLE
Refresh token limitations

### DIFF
--- a/src/pages/docs/sending-requests/authorization.md
+++ b/src/pages/docs/sending-requests/authorization.md
@@ -319,7 +319,7 @@ To turn this feature off or on, select **Auto-refresh access token**.
 
 To manually refresh a token, select **Refresh** next to the token expiration time.
 
-> Note that this feature is available only when manually sending the request and functionality has not been extended for scheduled runs or monitors on the same collection.
+> Auto-refresh is only available when manually sending the request, and not for scheduled runs or monitors on the same collection.
 
 #### Sharing an OAuth 2.0 access token
 

--- a/src/pages/docs/sending-requests/authorization.md
+++ b/src/pages/docs/sending-requests/authorization.md
@@ -319,6 +319,8 @@ To turn this feature off or on, select **Auto-refresh access token**.
 
 To manually refresh a token, select **Refresh** next to the token expiration time.
 
+> Note that this feature is available only when manually sending the request and functionality has not been extended for scheduled runs or monitors on the same collection.
+
 #### Sharing an OAuth 2.0 access token
 
 To enable other Postman users to view and use an OAuth 2.0 access token, select **Share access token**.


### PR DESCRIPTION
Based on user report, reference: https://community.postman.com/t/schedule-and-monitor-cause-401-when-manual-collection-run-works/42392/2