### PR TITLE
[TW-894] Update version prerequisite for domain capture

### DIFF
--- a/src/pages/docs/administration/managing-your-team/configuring-domain-capture.md
+++ b/src/pages/docs/administration/managing-your-team/configuring-domain-capture.md
@@ -36,7 +36,7 @@ Domain capture allows you to identify and manage all user accounts in Postman th
 You must be a [Postman Team Admin](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) to enable domain capture for your team. In addition, domain capture requires the following:
 
 * Your team must be on the [Postman Enterprise](https://www.postman.com/pricing) plan.
-* Your team must be on [Postman version 9](/docs/administration/updating/).
+* Your team must be on [Postman version 9 or later](/docs/administration/updating/).
 * [SSO](/docs/administration/sso/admin-sso/) must be configured and enabled.
     * Alternative authentication methods (Postman or Google sign in) must be deactivated.
 


### PR DESCRIPTION
Currently, we document that teams must be on version 9 to use domain capture. Since v10 is released, I updated the text to explain that teams can be on version 9 or later.