### PR TITLE
added anchor link styling

### DIFF
--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -211,6 +211,24 @@ const DocContent = styled.div`
       list-style: lower-alpha;
     }
   } 
+  //  anchor link tag styling
+  a.anchor.before {
+    top: 0.2em;
+    padding-right: 8px;
+
+    svg {
+      width: auto;
+      height: 0.9em;
+      display: block;
+    }
+  }
+
+  a.anchor:hover {
+    display: block;
+    border: none !important;
+  }
+
+  
 `
 
 const RightColumnWrapper = styled.aside`


### PR DESCRIPTION
anchor link size is now relative to the text size it sits next to.

Check any doc page that has anchor links next to it's headings