### PR TITLE
Fixing leftnav accordion hard load

### DIFF
--- a/src/components/LeftNav/LeftNav.jsx
+++ b/src/components/LeftNav/LeftNav.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect }  from 'react';
-import { Link } from 'gatsby';
+import { Link, navigate } from 'gatsby';
 import styled from 'styled-components';
 
 const { v4: uuidv4 } = require('uuid');
 
 const sectionHandler = (e) => {
-  document.location.href = e.target.getAttribute('data-section');
+  navigate(e.target.getAttribute('data-section'));
 };
 
 const NavWrapper = styled.ul`
@@ -122,7 +122,7 @@ const ChildItemsWrapper = styled.ul`
 
 `
 
-const CaretWrapper = styled.a`
+const CaretWrapper = styled(Link)`
    .caret-wrapper {
       width: 24px;
     &:hover {
@@ -158,7 +158,7 @@ const renderTwoLevelList = (item, runtime) => {
         <li className="parent">
           <div className="container">
             <div className="row">
-              <CaretWrapper className="caret-wrapper" href={item.url}>
+              <CaretWrapper className="caret-wrapper" to={item.url} data-click={item.name}>
                 {runtime && <svg className={`caret${active ? ' active-caret' : ''}`} xmlns="http://www.w3.org/2000/svg" fill="none" height="24" viewBox="0 0 24 24" width="24"><path clipRule="evenodd" d="m16.5303 8.96967c.2929.29289.2929.76777 0 1.06063l-4 4c-.2929.2929-.7677.2929-1.0606 0l-4.00003-4c-.29289-.29286-.29289-.76774 0-1.06063s.76777-.29289 1.06066 0l3.46967 3.46963 3.4697-3.46963c.2929-.29289.7677-.29289 1.0606 0z" fill="#707070" fillRule="evenodd" /></svg>}
               </CaretWrapper>
               <div className="col caret-sibling first-parent">
@@ -187,7 +187,11 @@ const renderTwoLevelList = (item, runtime) => {
                     >
                       <div className="container">
                         <div className="row">
-                          <CaretWrapper className="caret-wrapper" href={sItem.slug}>
+                          <CaretWrapper 
+                            className="caret-wrapper"
+                            to={sItem.slug}
+                            data-click={sItem.name}
+                          >
                             <svg className={`caret${(document.location.pathname.match(sItem.subParentSlug)) ? 'active-caret' : ''}`} xmlns="http://www.w3.org/2000/svg" fill="none" height="24" viewBox="0 0 24 24" width="24"><path clipRule="evenodd" d="m16.5303 8.96967c.2929.29289.2929.76777 0 1.06063l-4 4c-.2929.2929-.7677.2929-1.0606 0l-4.00003-4c-.29289-.29286-.29289-.76774 0-1.06063s.76777-.29289 1.06066 0l3.46967 3.46963 3.4697-3.46963c.2929-.29289.7677-.29289 1.0606 0z" fill="#707070" fillRule="evenodd" /></svg>
                           </CaretWrapper>
                           <div className="col caret-sibling second-parent">


### PR DESCRIPTION
Current implementation of the LeftNav in the /docs/ paths causes a hard browser navigation when an accordion is clicked to expand.

Current Implementation:
![current](https://user-images.githubusercontent.com/3507287/228973581-b7b9327e-6c18-4c4a-8fbc-2b1c9f775d59.gif)

This MR modifies the CaretWrapper styled component to be a `Link` instead of an `a`, which does a proper in-app navigation.

It also changes the sectionHandler function to use Gatsby's built in `navigate` feature rather than the browser api for changing current url.

Improved Implementation:

![improved](https://user-images.githubusercontent.com/3507287/228973921-81691ee4-f19d-455b-828b-bd1ee42bf516.gif)
