### PR TITLE
Domain verification is self-serve

### DIFF
--- a/src/pages/docs/administration/managing-your-team/configuring-domain-capture.md
+++ b/src/pages/docs/administration/managing-your-team/configuring-domain-capture.md
@@ -80,7 +80,7 @@ It's recommended that you enable [SSO provisioning](/docs/administration/scim-pr
 
     > Instead, you can select **Verify Later** if you're not ready to add the **TXT Record** to your domain's DNS configuration. To verify your domain later, see [Verifying a domain later](#verifying-a-domain-later).
 
-1. Select the **I have added the TXT record to the DNS tool** checkbox, and then select **Verify Domain**. Postman's team will check your requested domain and update its status to `VERIFIED` in your domain dashboard. Team Admins will receive an email notification when the domain is verified.
+1. Select the **I have added the TXT record to the DNS tool** checkbox, and then select **Verify Domain**. Note that it may take up to 24 hours for the   TXT changes to take effect to enable successfully verification of the domain. Team Admins will receive an email notification when the domain is verified.
 
     <img alt="Add domain TXT record" src="https://assets.postman.com/postman-docs/v10/add-domain-verification-record-v10.jpg" width="450px"/>
 

--- a/src/pages/docs/administration/managing-your-team/configuring-domain-capture.md
+++ b/src/pages/docs/administration/managing-your-team/configuring-domain-capture.md
@@ -80,7 +80,7 @@ It's recommended that you enable [SSO provisioning](/docs/administration/scim-pr
 
     > Instead, you can select **Verify Later** if you're not ready to add the **TXT Record** to your domain's DNS configuration. To verify your domain later, see [Verifying a domain later](#verifying-a-domain-later).
 
-1. Select the **I have added the TXT record to the DNS tool** checkbox, and then select **Verify Domain**. Note that it may take up to 24 hours for the   TXT changes to take effect to enable successfully verification of the domain. Team Admins will receive an email notification when the domain is verified.
+1. Select the **I have added the TXT record to the DNS tool** checkbox, and then select **Verify Domain**. Note that it may take up to 24 hours for the TXT changes to take effect to enable successful verification of the domain. Team Admins will receive an email notification when the domain is verified.
 
     <img alt="Add domain TXT record" src="https://assets.postman.com/postman-docs/v10/add-domain-verification-record-v10.jpg" width="450px"/>
 


### PR DESCRIPTION
The user can verify their domain without the need to contact support. Only enabling domain capture requires the user to contact support. Also, added a note to set expectations that it may take up to 24 hours for the successful verification of a TXT record.