### PR TITLE
[TW-1050] Removed mentions of team activity on Homepage

### DIFF
--- a/src/pages/docs/collaborating-in-postman/manage-public-elements.md
+++ b/src/pages/docs/collaborating-in-postman/manage-public-elements.md
@@ -43,8 +43,6 @@ To manage public elements, you need to have a Community Manager role in a Postma
 
 To access the **Manage public elements** dashboard, select **Team** in the header, then select **Manage Public Elements**.
 
-> You can also access this dashboard from the **Home** page. Go to the **Manage public elements** section and select **Manage** to go to the dashboard view.
-
 #### Workspaces
 
 In the dashboard's **Workspaces** tab, you have access to all the public workspaces created by your team. You can also view and respond to requests to make workspaces public. Along with workspace name, the request date and the requester details are displayed.

--- a/src/pages/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections.md
@@ -29,7 +29,7 @@ Each Postman Collection has a changelog that covers create, update, transfer, an
 
 ## Contents
 
-* Viewing changes to a [collection](#viewing-the-collection-changelog), [workspace](#viewing-workspace-activity), or [team](#viewing-team-activity)
+* Viewing changes to a [collection](#viewing-the-collection-changelog) or [workspace](#viewing-workspace-activity)
 * [Hiding diffs in the changelog](#hiding-diffs-in-the-changelog)
 * [Restoring collections](#restoring-collections)
 * [Exporting team activity](#exporting-team-activity-to-other-platforms)
@@ -78,10 +78,6 @@ Filtering by element will display the actions carried out on the selected elemen
 To filter by element, select **Elements** at the top of the activity feed and select the element or elements. You can search for a specific element by typing its name in the search field.
 
 > You can access the changelog of a specific collection by selecting **View Changelog** next to actions on collections.
-
-## Viewing team activity
-
-You can review your team's activity with a Postman Basic, Professional, or Enterprise account. To do so, select **Home** in the upper-left. You can view your team **Activity Feed** on the right.
 
 ## Hiding diffs in the changelog
 

--- a/src/pages/docs/getting-started/navigating-postman.md
+++ b/src/pages/docs/getting-started/navigating-postman.md
@@ -59,7 +59,7 @@ The header enables you to create workspaces, access reports, explore the public 
 <img alt="Postman header left side" src="https://assets.postman.com/postman-docs/postman-desktop-app-header-v10.10.jpg" width="350px"/>
 
 * **&#8592; &#8594;** - Navigate backward and forward through pages you've visited within Postman. _(Postman desktop app only)_
-* **Home** - Go to your personal home page, which includes alerts, announcements, your recently visited workspaces, and links to resources for [your team](/docs/collaborating-in-postman/working-with-your-team/collaboration-overview/) if applicable.
+* **Home** - Go to your personal home page, which includes your recently visited workspaces, and links to resources for [your team](/docs/collaborating-in-postman/working-with-your-team/collaboration-overview/) if applicable.
 * **Workspaces** - Search for workspaces, view your recently visited workspaces, or [create a new workspace](/docs/getting-started/creating-your-first-workspace/).
 * **API Network** - Explore the [Public API Network](/docs/getting-started/exploring-public-api-network/) and access your team's [Private API Network](/docs/collaborating-in-postman/adding-private-network/).
 * **Explore** - Browse public APIs, teams, workspaces, and collections on Postman.

--- a/src/pages/docs/getting-started/navigating-postman.md
+++ b/src/pages/docs/getting-started/navigating-postman.md
@@ -59,7 +59,7 @@ The header enables you to create workspaces, access reports, explore the public 
 <img alt="Postman header left side" src="https://assets.postman.com/postman-docs/postman-desktop-app-header-v10.10.jpg" width="350px"/>
 
 * **&#8592; &#8594;** - Navigate backward and forward through pages you've visited within Postman. _(Postman desktop app only)_
-* **Home** - Go to your personal home page, which includes alerts, announcements, your activity feed, your recently visited workspaces, and links to resources for [your team](/docs/collaborating-in-postman/working-with-your-team/collaboration-overview/) if applicable.
+* **Home** - Go to your personal home page, which includes alerts, announcements, your recently visited workspaces, and links to resources for [your team](/docs/collaborating-in-postman/working-with-your-team/collaboration-overview/) if applicable.
 * **Workspaces** - Search for workspaces, view your recently visited workspaces, or [create a new workspace](/docs/getting-started/creating-your-first-workspace/).
 * **API Network** - Explore the [Public API Network](/docs/getting-started/exploring-public-api-network/) and access your team's [Private API Network](/docs/collaborating-in-postman/adding-private-network/).
 * **Explore** - Browse public APIs, teams, workspaces, and collections on Postman.

--- a/src/pages/docs/sending-requests/requests.md
+++ b/src/pages/docs/sending-requests/requests.md
@@ -83,7 +83,7 @@ If you have never sent a request before, check out [sending your first request](
 
 Your requests can include multiple details determining the data Postman will send to the API you are working with. Enter a URL and choose a method, then optionally specify a variety of other details.
 
-You can create a new request from the Postman home screen, by using **New > HTTP Request**, or by selecting **+** to open a new tab.
+You can create a new request from a workspace, by using **New > HTTP Request**, or by selecting **+** to open a new tab.
 
 ![Create New Screen](https://assets.postman.com/postman-docs/v10/new-request-v10.jpg)
 


### PR DESCRIPTION
Users can no longer view their team's activity from the Homepage