### PR TITLE
[MARKENG-2381][c] remove gtag

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -119,8 +119,6 @@ setTimeout(function(){
           function gtag(){dataLayer.push(arguments);}
           window.gtag = gtag;
           gtag('js', new Date());
-          gtag('config', 'AW-821881030');
-          window.pmt('log', ['gtag: AW-821881030']);
           window.pmt('ga', ['${UACode}', sitename]);
           window.pmt('log', ['initialized GA: ' + sitename + ' (' + '${UACode}' + ')']);
           window._iaq = window._iaq || {};


### PR DESCRIPTION
### What are the changes? 
_Branched from `develop`_, this remove the tag call..  

### Why make these changes? 
It's cruft, meant for www

   *no-visuals