### PR TITLE
[MARKENG-1813] update print CSS file for icons that were too small

### DIFF
--- a/styles/config/print.css
+++ b/styles/config/print.css
@@ -114,8 +114,8 @@
     img[src$='#icon'] {
         margin-bottom: 0;
         display: inline;
-        width: 18pt;
-        height: auto;
+        width: auto !important;
+        height: 16pt !important;
       }
         
     /* Adding custom messages before and after the content */


### PR DESCRIPTION
* updated print CSS file to keep `#icons` from showing up too small
<img width="981" alt="Screenshot 2023-04-10 at 13 26 18" src="https://user-images.githubusercontent.com/4358288/230992520-7785eabf-79f2-4919-8134-4d2b4ceee086.png">

Use `/docs/collections/running-collections/working-with-data-files/` or `/docs/publishing-your-api/run-in-postman/introduction-run-button/` and cmd-p to print to verify. Icons should be of a good readable size, like screen.