### PR TITLE
[TW-1069] Maintenance review cycle 4/23 11-15

### DIFF
--- a/src/pages/docs/getting-started/troubleshooting-inapp.md
+++ b/src/pages/docs/getting-started/troubleshooting-inapp.md
@@ -3,7 +3,7 @@ title: "Troubleshooting app issues"
 order: 9
 page_id: "troubleshooting_in_app"
 warning: false
-updated: 2022-03-29
+updated: 2023-04-18
 ---
 
 Sometimes things go wrong! If you're having trouble with the Postman app, there are several resources that can help you diagnose and fix the problem.

--- a/src/pages/docs/sending-requests/grpc/understanding-grpc-types.md
+++ b/src/pages/docs/sending-requests/grpc/understanding-grpc-types.md
@@ -1,6 +1,6 @@
 ---
 title: "Understanding gRPC types"
-updated: 2022-09-15
+updated: 2023-04-18
 contextual_links:
   - type: section
     name: "Prerequisites"
@@ -21,18 +21,18 @@ When sending or receiving a gRPC request or response, the messages being sent ba
 
 ## JSON interface
 
-| Protobuf type                    | JSON type                                                | JSON example                 | Notes                                                                                                            |
-| ---------------------------------------- | -------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| message                                  | object                                                   | `{ "field": 123 }`           | `null` is an accepted value for all field types and treated as the default value of the corresponding field type |
-| enum                                     | string _or_ number                                       | `"FOO_BAR"`                  | Both enum names and integer values are accepted                                                                  |
-| repeated V                               | array                                                    | `[v, ...]`                   |                                                                                                                  |
-| map<K, V>                                | object                                                   | `{ "k": v }`                 | All keys are converted to strings                                                                                |
-| bool                                     | boolean                                                  | `true`, `false`              |                                                                                                                  |
-| string                                   | string                                                   | `"Hello World!"`             |                                                                                                                  |
-| bytes                                    | base64 string _or_ array of bytes (numbers [0, 255])     | `"SGVsbG8gZ1JQQw=="`         |                                                                                                                  |
-| int32, sint32, uint32, fixed32, sfixed32 | number                                                   | `1`, `-10`, `0`              |                                                                                                                  |
-| int64, sint64, uint64, fixed64, sfixed64 | number _or_ string                                       | `"-1152921504606847254"`     | Decimal strings are used to increase compatibility with languages that lack a 64-bit integer                     |
-| float, double                            | number _or_ `"NaN"` _or_ `"Infinity"` _or_ `"-Infinity"` | `1.1`, `-10.0`, `0`, `"NaN"` |                                                                                                                  |
+| Protobuf type | JSON type | JSON example | Notes |
+| ------------- | --------- | ------------ | ----- |
+| message | object | `{ "field": 123 }` | `null` is an accepted value for all field types and treated as the default value of the corresponding field type. |
+| enum | string _or_ number | `"FOO_BAR"` | Both enum names and integer values are accepted. |
+| repeated V | array | `[v, ...]` | |
+| map<K, V> | object | `{ "k": v }` | All keys are converted to strings. | |
+| bool | boolean | `true`, `false` | |
+| string | string | `"Hello World!"` | |
+| bytes | base64 string _or_ array of bytes (numbers [0, 255]) | `"SGVsbG8gZ1JQQw=="` | |
+| int32, sint32, uint32, fixed32, sfixed32 | number | `1`, `-10`, `0` | |
+| int64, sint64, uint64, fixed64, sfixed64 | number _or_ string | `"-1152921504606847254"` | Decimal strings are used to increase compatibility with languages that lack a 64-bit integer. |
+| float, double | number _or_ `"NaN"` _or_ `"Infinity"` _or_ `"-Infinity"` | `1.1`, `-10.0`, `0`, `"NaN"` | |
 
 ## Inspecting fields and types
 


### PR DESCRIPTION
This PR addresses the following:

**/docs/getting-started/troubleshooting-inapp/**
- Updated the `update` field, as there were nothing that appeared in need of fixing.

**/docs/sending-requests/grpc/understanding-grpc-types/**
- Should the **Protofbuf type** table entries be in code format?
- The table notes did not end with a period (`.`), so I updated this because they are complete sentences.
- The table formatting was really hard to read/manage, so I cleaned it up to make it more manageable.
- Updated the `updated` field.

I opened tickets for the following because they need a (screenshot) refresh:
- /docs/integrations/available-integrations/splunk-on-call/ — https://postmanlabs.atlassian.net/browse/TW-1075
- /docs/integrations/available-integrations/keen/ — https://postmanlabs.atlassian.net/browse/TW-1074
- /docs/administration/sso/onelogin/ — https://postmanlabs.atlassian.net/browse/TW-1073