### PR TITLE
[MARKENG-2419][c] Update LC to gtag UA-43979731-4

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -119,6 +119,8 @@ setTimeout(function(){
           function gtag(){dataLayer.push(arguments);}
           window.gtag = gtag;
           gtag('js', new Date());
+          gtag('config', 'UA-43979731-4');
+          window.pmt('log', ['gtag: UA-43979731-4']);
           window.pmt('ga', ['${UACode}', sitename]);
           window.pmt('log', ['initialized GA: ' + sitename + ' (' + '${UACode}' + ')']);
           window._iaq = window._iaq || {};


### PR DESCRIPTION
### What are the changes?
_ Branched from `develop`_, this uses Google’s suggested syntax to tag “UA-43979731-4”.

  ### Why make these changes? 
  The updates the web app’s to GA code for GA4

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/56083362/234983445-75ff5b62-d80b-4c76-8423-c47ab3b82641.png">
