### PR TITLE
[MARKENG-2419][c] Update LC to gtag UA-43979731-4

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -119,6 +119,8 @@ setTimeout(function(){
           function gtag(){dataLayer.push(arguments);}
           window.gtag = gtag;
           gtag('js', new Date());
+          gtag('config', 'UA-43979731-4');
+          window.pmt('log', ['gtag: UA-43979731-4']);
           window.pmt('ga', ['${UACode}', sitename]);
           window.pmt('log', ['initialized GA: ' + sitename + ' (' + '${UACode}' + ')']);
           window._iaq = window._iaq || {};


### PR DESCRIPTION
### What are the changes? 
_Branched from `main`_, this cherry-pick the commit that updates the gtag  to UA-43979731-4

### Why make these changes?  So we can deploy it to production ahead of other commits

*no-visuals