### PR TITLE
Update creating-dynamic-responses.md

### DIFF
--- a/src/pages/docs/designing-and-developing-your-api/mocking-data/creating-dynamic-responses.md
+++ b/src/pages/docs/designing-and-developing-your-api/mocking-data/creating-dynamic-responses.md
@@ -83,6 +83,8 @@ When you call the mock server endpoint, the response data will change to somethi
 
 With template support, Postman mock servers can generate responses that vary based on the incoming request. Template helpers give you access to data from the incoming request, such as the body, query parameters, path segments, and headers. You can include that data in the response sent by the mock server.
 
+> To use Contextual Simulated Response Generation on a server with Response Matching for the Request body enabled, you need to set the `x-mock-match-request-body` header set to `false`. Otherwise you will get the mockRequestNotFoundError error.
+
 ### Using template helpers
 
 To create contextual responses, add one or more template helpers to an example in the mocked collection. You can use the following template helpers in your examples:


### PR DESCRIPTION
Annotation is added so that the Contextual Mock Response Generation can be executed without generating the mockRequestNotFoundError error.