### PR TITLE
[TW-1134] Update Run in Postman button, and instructions

### DIFF
--- a/src/pages/docs/publishing-your-api/run-in-postman/creating-run-button.md
+++ b/src/pages/docs/publishing-your-api/run-in-postman/creating-run-button.md
@@ -56,8 +56,7 @@ Make sure you're signed in to your Postman account, and that you have a collecti
 > Note: If the collection is present in a public workspace, you can directly embed the copied code where you would like the button to display. If the collection is present in a team or a personal workspace, [share the collection to a public workspace](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#changing-workspace-visibility) to create the **Run in Postman** button.
 
 1. Select **Collections** in the sidebar and select the collection you want to share.
-1. Next to the collection name, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> and then select **Share**.
-
+1. Select <img alt="Share icon" src="https://assets.postman.com/postman-docs/icon-share.jpg#icon" width="16px"> **Share**.
 1. Select the **Via Run in Postman** tab.
 1. Choose a live or static button:
 

--- a/src/pages/docs/sending-requests/visualizer.md
+++ b/src/pages/docs/sending-requests/visualizer.md
@@ -72,11 +72,11 @@ The `pm.visualizer.set()` method accepts a [Handlebars](https://handlebarsjs.com
 
 ### Rendering HTML
 
-For an example of a basic visualizer in action, open the first request in the following collection in Postman:
+For an example of a basic visualizer in action, open the following collection in Postman:
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/7865888-07101503-1e33-4f29-b845-d94e726751c8?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D7865888-07101503-1e33-4f29-b845-d94e726751c8%26entityType%3Dcollection%26workspaceId%3D34f3a42c-18a7-4ad6-83fb-2c05767d63a7)
 
-The example endpoint responds with a list of names and email addresses with the following JSON response body structure:
+In the first request, the example endpoint responds with a list of names and email addresses with the following JSON response body structure:
 
 ```js
 [

--- a/src/pages/docs/sending-requests/visualizer.md
+++ b/src/pages/docs/sending-requests/visualizer.md
@@ -72,9 +72,9 @@ The `pm.visualizer.set()` method accepts a [Handlebars](https://handlebarsjs.com
 
 ### Rendering HTML
 
-For an example of a basic visualizer in action, open the following request in Postman:
+For an example of a basic visualizer in action, open the first request in the following collection in Postman:
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/4e3ee3d03f6e2e7fc250)
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/7865888-07101503-1e33-4f29-b845-d94e726751c8?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D7865888-07101503-1e33-4f29-b845-d94e726751c8%26entityType%3Dcollection%26workspaceId%3D34f3a42c-18a7-4ad6-83fb-2c05767d63a7)
 
 The example endpoint responds with a list of names and email addresses with the following JSON response body structure:
 


### PR DESCRIPTION
* Updated the Run in Postman button in the Visualizing responses page, which wasn't working correctly
* Clarified that the button points to a collection, not a request
* Updated instructions about creating a Run in Postman button, which now requires you to select different icons