### PR TITLE
[TW-1153] Maintenance 5/23 updates

### DIFF
--- a/src/pages/docs/integrations/available-integrations/azure-devops.md
+++ b/src/pages/docs/integrations/available-integrations/azure-devops.md
@@ -18,7 +18,7 @@ Postman enables you to sync your Postman APIs to Git repositories hosted in Micr
 
 ## API sync with Azure DevOps
 
-You can connect an Azure DevOps repository to an API in Postman's [API Builder](https://learning.postman.com/docs/designing-and-developing-your-api/the-api-workflow/). Once connected, you can sync your API's definition and associated collections between Postman and Azure DevOps. You can switch branches, pull changes from the repository, and push changes to the repository, all from within Postman. To learn more about syncing your API with Azure DevOps, see [Using a remote Git repository](/docs/designing-and-developing-your-api/versioning-an-api/using-external-git-repo/).
+With Postman v10, you can connect an Azure DevOps repository to an API in Postman's [API Builder](https://learning.postman.com/docs/designing-and-developing-your-api/the-api-workflow/). Once connected, you can sync your API's definition and associated collections between Postman and Azure DevOps. You can switch branches, pull changes from the repository, and push changes to the repository, all from within Postman. To learn more about syncing your API with Azure DevOps, see [Using a remote Git repository](/docs/designing-and-developing-your-api/versioning-an-api/using-external-git-repo/).
 
 > **To connect your API to Azure DevOps, make sure to enable third-party application access for your organization.** If you don't enable third-party access, Postman won't be able to connect to your repository.
 >

--- a/src/pages/docs/integrations/available-integrations/azure-devops.md
+++ b/src/pages/docs/integrations/available-integrations/azure-devops.md
@@ -1,12 +1,12 @@
 ---
 title: "Azure DevOps"
-order: 169
-page_id: "azure-devops"
-updated: 2021-12-20
-warning: false
+updated: 2023-05-19
 contextual_links:
   - type: section
     name: "Prerequisites"
+  - type: link
+    name: "Using a remote Git repository"
+    url: "/docs/designing-and-developing-your-api/versioning-an-api/using-external-git-repo/"
   - type: link
     name: "Grouping requests in collections"
     url: "/docs/sending-requests/intro-to-collections/"
@@ -14,10 +14,12 @@ contextual_links:
 
 > **[Azure DevOps Server (hosted on-premises) integrations are available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
-Postman enables you to sync your Postman APIs to Git repositories hosted in Microsoft Azure DevOps with the [Postman to Azure DevOps integration](/docs/designing-and-developing-your-api/versioning-an-api/using-external-git-repo/).
+Postman enables you to sync your Postman APIs to Git repositories hosted in Microsoft Azure DevOps with the [Postman to Azure DevOps integration](/docs/designing-and-developing-your-api/versioning-an-api/using-external-git-repo/#connecting-to-an-on-premises-repository).
 
 ## API sync with Azure DevOps
 
-With Postman v10, you can connect an Azure DevOps repository to an API in the API Builder. Once connected, you can sync your API's definition and associated collections between Postman and Azure DevOps. You can switch branches, pull changes from the repository, and push changes to the repository, all from within Postman. To learn more about syncing your API with Azure DevOps, see [Using a remote Git repository](/docs/designing-and-developing-your-api/versioning-an-api/using-external-git-repo/).
+You can connect an Azure DevOps repository to an API in Postman's [API Builder](https://learning.postman.com/docs/designing-and-developing-your-api/the-api-workflow/). Once connected, you can sync your API's definition and associated collections between Postman and Azure DevOps. You can switch branches, pull changes from the repository, and push changes to the repository, all from within Postman. To learn more about syncing your API with Azure DevOps, see [Using a remote Git repository](/docs/designing-and-developing-your-api/versioning-an-api/using-external-git-repo/).
 
-> **To connect your API to Azure DevOps, make sure to enable third-party application access for your organization.** If you don't enable third-party access, Postman won't be able to connect to your repository. In Azure DevOps, go to your [organization settings](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/change-application-access-policies?view=azure-devops), select **Policies**, and turn on the toggle next to **Third-party application access via OAuth**. (Enabling third-party access isn't required for connecting to an Azure DevOps Server repository hosted on-premises.)
+> **To connect your API to Azure DevOps, make sure to enable third-party application access for your organization.** If you don't enable third-party access, Postman won't be able to connect to your repository.
+>
+> In Azure DevOps, go to your [organization settings](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/change-application-access-policies?view=azure-devops), select **Policies**, and turn on the toggle next to **Third-party application access via OAuth**. (Enabling third-party access isn't required for connecting to an Azure DevOps Server repository hosted on-premises.)

--- a/src/pages/docs/integrations/available-integrations/azure-devops.md
+++ b/src/pages/docs/integrations/available-integrations/azure-devops.md
@@ -14,7 +14,7 @@ contextual_links:
 
 > **[Azure DevOps Server (hosted on-premises) integrations are available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
-Postman enables you to sync your Postman APIs to Git repositories hosted in Microsoft Azure DevOps with the [Postman to Azure DevOps integration](/docs/designing-and-developing-your-api/versioning-an-api/using-external-git-repo/#connecting-to-an-on-premises-repository).
+Postman enables you to sync your Postman APIs to Git repositories hosted in Microsoft Azure DevOps with the Postman to Azure DevOps integration.
 
 ## API sync with Azure DevOps
 


### PR DESCRIPTION
This updates the `/docs/integrations/available-integrations/azure-devops` documentation. Namely:
- Cleaning up the frontmatter.
- Added new frontmatter prereq link to the "Using a remote Git repository" doc.
- Changing the link for "Postman to Azure DevOps" integration to point at the on-prem section of the "Using a remote Git repository" doc. It seems like it makes more sense since the Azure DevOps document focuses on an on-premises integration.
- Updated the "API sync with Azure DevOps":
    - Removed the v10 specific mention — I'm not sure if that is necessary any longer?
    - Linked out to the API Builder at its mention.
    - Split the note into two paragraphs so it was a little easier to read.