### PR TITLE
Add overflow css to <pre> tag

### DIFF
--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -111,6 +111,9 @@ pre {
   font-family: 'IBM Plex Mono',SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace !important;
   line-height: 24px;
   margin-bottom: 0px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 .code-ref-table {


### PR DESCRIPTION
Fixes issue where long lines overflow to the right in code reference tables when using the `<pre>` tag.

![image](https://github.com/postmanlabs/postman-docs/assets/87772944/3ac3e77c-b744-447f-bfe4-f6ced823cbdd)

Solution is to add the following css to the `<pre>` tag in `/src/templates/doc.jsx`:

```
overflow-x: auto;
white-space: pre-wrap;
word-wrap: break-word;
```

Tested the fix in Chrome, Safari, and Firefox.

Source of this solution: https://www.w3docs.com/snippets/css/how-to-wrap-text-in-a-pre-tag-with-css.html