### PR TITLE
[markeng-2488] add catch to Agolia for index switching

### DIFF
--- a/src/components/Search/searchPreview.jsx
+++ b/src/components/Search/searchPreview.jsx
@@ -32,8 +32,8 @@ const Hits = ({ hits }) => {
       const excerpt = hit._snippetResult && hit._snippetResult.excerpt.value ? hit._snippetResult.excerpt.value : hit.excerpt
       return (
       <li key={uuidv4()}>
-        { !!hit && hit.slug !== 'undefined' && hit.title && hit.excerpt ? (
-          <a href={hit.slug}>
+        { !!hit && hit.fields.slug && hit.title && hit.excerpt ? (
+          <a href={hit.fields.slug}>
             <span className="search-title" dangerouslySetInnerHTML={{ __html: hit._highlightResult.title.value }} />
             <p dangerouslySetInnerHTML={{ __html: excerpt }} />
           </a>

--- a/src/components/Search/searchPreview.jsx
+++ b/src/components/Search/searchPreview.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connectSearchBox, connectHits } from 'react-instantsearch-dom';
+const { v4: uuidv4 } = require('uuid');
 
 
 
@@ -30,11 +31,15 @@ const Hits = ({ hits }) => {
       // handles develop and prod Algolia index
       const excerpt = hit._snippetResult && hit._snippetResult.excerpt.value ? hit._snippetResult.excerpt.value : hit.excerpt
       return (
-      <li key={hit.title}>
-        <a href={hit.fields.slug}>
-          <span className="search-title" dangerouslySetInnerHTML={{ __html: hit._highlightResult.title.value }} />
-          <p dangerouslySetInnerHTML={{ __html: excerpt }} />
-        </a>
+      <li key={uuidv4()}>
+        { !!hit && hit.slug !== 'undefined' && hit.title && hit.excerpt ? (
+          <a href={hit.slug}>
+            <span className="search-title" dangerouslySetInnerHTML={{ __html: hit._highlightResult.title.value }} />
+            <p dangerouslySetInnerHTML={{ __html: excerpt }} />
+          </a>
+        ) : (
+          <p>Search is currently not available.</p>
+        )}
       </li>
     )})}
   </ul>


### PR DESCRIPTION
This PR adds a catch to display a message to the user if a index endpoint cannot be found and prevent the app from breaking.

<img width="632" alt="Screenshot 2023-06-06 at 3 56 25 PM" src="https://github.com/postmanlabs/postman-docs/assets/36343528/8ec0cd69-cd95-4d90-9ff0-6c067f28e747">




