### PR TITLE
Update roles-and-permissions.md

### DIFF
--- a/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
+++ b/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
@@ -95,7 +95,7 @@ Team roles offer high-level access control:
 
 &ast;&ast;&ast; Enterprise plans only. Teams that don't use the [optional approval process workflow](/docs/collaborating-in-postman/adding-private-network/#using-the-approval-process-workflow) for the Private API Network can allow users with [an API Editor role](/docs/collaborating-in-postman/roles-and-permissions/#element-based-roles) to add APIs to the Private API Network instead.
 
-> **Postman support users**. Team members with a Developer or Super Admin role consume a paid seat on your team. Team members who have only Admin or Billing roles become support users and don’t consume paid seats. Each team can have two support users.
+> **Postman support users**. Team members with a Developer or Super Admin role consume a paid seat on your team. Team members who have only Admin and/or Billing roles become support users and don’t consume paid seats. Each team can have two support users.
 
 ### Managing team roles
 


### PR DESCRIPTION
Clarify that a support user can have
- Admin role
- Billing role
- Admin and Billing role