### PR TITLE
add async to OneTrust script to keep from blocking rendering

### DIFF
--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -104,7 +104,7 @@
       <link href="https://voyager.postman.com/font/fonts.css" rel="stylesheet" />
        {/* OneTrust */}
        <script type="text/javascript" src="https://cdn.cookielaw.org/consent/1cef3369-6d07-4928-b977-2d877eb670c4/OtAutoBlock.js" />
-       <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" type="text/javascript" charset="UTF-8" data-domain-script="1cef3369-6d07-4928-b977-2d877eb670c4" />
+       <script async src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" type="text/javascript" charset="UTF-8" data-domain-script="1cef3369-6d07-4928-b977-2d877eb670c4" />
        <link rel="canonical" href={`https://learning.postman.com${slug}`} />
        {/* Algolia Instantsearch IE11 support v3 */}
        {/* <script src="https://polyfill.io/v3/polyfill.min.js?features=default,Array.prototype.find,Array.prototype.includes" /> */}


### PR DESCRIPTION
* added `async` to the OneTrust script
* suggested by page speed insights tool
* OT banner should still render as it has been—no changes
<img width="302" alt="Screenshot 2023-06-09 at 12 19 16" src="https://github.com/postmanlabs/postman-docs/assets/4358288/801a7faa-323e-449f-871b-9658ffcfd51c">
