### PR TITLE
Remove script to load OneTrust

### DIFF
--- a/src/components/Header/HeaderStyles.jsx
+++ b/src/components/Header/HeaderStyles.jsx
@@ -2,13 +2,13 @@ import styled from 'styled-components';
 
 export const PrimaryNavbarV6 = styled.div`
     background-color: ${(props) => props.theme.colors.grey_00};
-    z-index: 2147483647;
+    z-index: 2147483646;
     border-bottom: 1px solid ${(props) => props.theme.colors.grey_30};
     .activeMenu {
       background-color: ${(props) => props.theme.colors.grey_00};
       position: relative;
       border-bottom: 1px solid ${(props) => props.theme.colors.grey_30};
-      z-index: 2147483647;
+      z-index: 2147483646;
     }
 
     .navbar {

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -107,7 +107,7 @@
       />
       <noscript>{`<link href="https://voyager.postman.com/font/fonts.css" rel="stylesheet" type="text/css" />`}</noscript>
        {/* OneTrust */}
-       <script type="text/javascript" src="https://cdn.cookielaw.org/consent/1cef3369-6d07-4928-b977-2d877eb670c4/OtAutoBlock.js" />
+
        <script async src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" type="text/javascript" charset="UTF-8" data-domain-script="1cef3369-6d07-4928-b977-2d877eb670c4" />
        <link rel="canonical" href={`https://learning.postman.com${slug}`} />
        {/* Algolia Instantsearch IE11 support v3 */}


### PR DESCRIPTION
This removes the OneTrust load script in seo.jsx since it is already being loaded from the bff. 
https://onetrust-fix.learning.postman-beta.com/

Discovered it was loading twice.
![Screenshot 2023-06-27 at 2 34 03 PM](https://github.com/postmanlabs/postman-docs/assets/42796716/6a473e86-918d-4294-bb6c-248a36cdc6b3)
