### PR TITLE
[TW-1188] Break up "Private API Network"

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -504,6 +504,10 @@
     "to": "/docs/collaborating-in-postman/adding-private-network/"
   },
   {
+    "from": "/docs/collaborating-in-postman/adding-private-network/",
+    "to": "/docs/collaborating-in-postman/private-api-network/adding-private-network/"
+  },
+  {
     "from": "/docs/postman/collaboration/audit-logs/",
     "to": "/docs/administration/audit-logs/"
   },

--- a/redirects.json
+++ b/redirects.json
@@ -497,7 +497,7 @@
   },
   {
     "from": "/docs/postman/collaboration/adding-private-network/",
-    "to": "/docs/collaborating-in-postman/adding-private-network/"
+    "to": "/docs/collaborating-in-postman/private-api-network/adding-private-network/"
   },
   {
     "from": "/docs/postman/collaboration/adding_private_network/",

--- a/redirects.json
+++ b/redirects.json
@@ -501,7 +501,7 @@
   },
   {
     "from": "/docs/postman/collaboration/adding_private_network/",
-    "to": "/docs/collaborating-in-postman/adding-private-network/"
+    "to": "/docs/collaborating-in-postman/private-api-network/adding-private-network/"
   },
   {
     "from": "/docs/collaborating-in-postman/adding-private-network/",

--- a/src/components/LeftNav/LeftNavItems.jsx
+++ b/src/components/LeftNav/LeftNavItems.jsx
@@ -684,7 +684,26 @@ export const leftNavItems = [
       },
       {
         name: 'Your Private API Network',
-        url: '/docs/collaborating-in-postman/adding-private-network/',
+        subParentSlug: 'private-api-network',
+        slug: '/docs/collaborating-in-postman/private-api-network/adding-private-network/',
+        subMenuItems2: [
+          {
+            name: 'Your Private API Network',
+            url: '/docs/collaborating-in-postman/private-api-network/adding-private-network/'
+          },
+          {
+            name: 'Organizing your Private API Network',
+            url: '/docs/collaborating-in-postman/private-api-network/organizing-private-network/'
+          },
+          {
+            name: 'Managing your Private API Network',
+            url: '/docs/collaborating-in-postman/private-api-network/managing-private-network/'
+          },
+          {
+            name: 'Private API Network requests',
+            url: '/docs/collaborating-in-postman/private-api-network/private-network-requests/'
+          },
+        ],
       },
       {
         name: 'Using version control',

--- a/src/components/LeftNav/LeftNavItems.jsx
+++ b/src/components/LeftNav/LeftNavItems.jsx
@@ -700,7 +700,7 @@ export const leftNavItems = [
             url: '/docs/collaborating-in-postman/private-api-network/managing-private-network/'
           },
           {
-            name: 'Private API Network requests',
+            name: 'Requesting to add to the Private API Network',
             url: '/docs/collaborating-in-postman/private-api-network/private-network-requests/'
           },
         ],

--- a/src/pages/docs/administration/about-postman-enterprise.md
+++ b/src/pages/docs/administration/about-postman-enterprise.md
@@ -60,7 +60,7 @@ Postman Enterprise plans provide you with advanced [API governance](https://www.
 
 Postman Enterprise plans enable your organization to collaborate internally and with partners:
 
-* **The Private API Network** - Team members with the Enterprise-only API Network Manager role can approve which APIs to add to your Private API Network. For more information, see [Your Private API Network](/docs/collaborating-in-postman/adding-private-network/).
+* **The Private API Network** - Team members with the Enterprise-only API Network Manager role can approve which APIs to add to your Private API Network. For more information, see [Your Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/).
 * **Partner Workspaces** - Your organization can invite partners to a shared workspace to collaborate and build products and services with your APIs. To learn more about Partner Workspaces, see [Partner Workspaces](/docs/collaborating-in-postman/using-workspaces/partner-workspaces/).
 * **Advanced version control** - Manage permissions for reviewers and assign merge checks for forks on Postman elements. For more details, see [Pull request settings](/docs/collaborating-in-postman/using-version-control/creating-pull-requests/#pull-request-settings).
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -1,6 +1,6 @@
 ---
 title: "Private API Network overview"
-updated: 2023-06-15
+updated: 2023-07-07
 contextual_links:
   - type: section
     name: "Additional resources"

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -45,10 +45,10 @@ Workspaces, collections, and APIs in the Private API Network are visible to logg
 ## Contents
 
 * [Navigating the Private API Network](#navigating-the-private-api-network)
-    * [Searching, filtering, and sorting](#searching-filtering-and-sorting)
-    * [Reviewing details about elements](#reviewing-details-about-elements)
-    * [Sharing folders and elements](#sharing-folders-and-elements)
-    * [Watching and forking elements](#watching-and-forking-elements)
+* [Searching, filtering, and sorting](#searching-filtering-and-sorting)
+* [Reviewing details about elements](#reviewing-details-about-elements)
+* [Sharing folders and elements](#sharing-folders-and-elements)
+* [Watching and forking elements](#watching-and-forking-elements)
 
 ## Navigating the Private API Network
 
@@ -59,7 +59,7 @@ There are two ways to access the Private API Network:
 * Select **Home** from the Postman header, then select **Private API Network** in your team information on the left sidebar.
 * Select **API Network** from the Postman header, then select **Private API Network**.
 
-### Searching, filtering, and sorting
+## Searching, filtering, and sorting
 
 There are several ways to search, filter, and sort elements and folders in the Private API Network. You can search and sort all elements and folders from the left sidebar. You can also select a folder to search, filter, and sort elements on the right.
 
@@ -67,7 +67,7 @@ You can search and sort elements and folders from the left sidebar.
 
 <img alt="Create new folder in Private Network" src="https://assets.postman.com/postman-docs/v10/private-api-network-organize-folders-v10-2.jpg" width="300px"/>
 
-Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network. Select a folder in the left sidebar to search, filter, and sort elements only in the selected folder.
+Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network.
 
 * To search by name, enter the full or partial element or folder name into **Search elements and folders**.
 * To sort elements and folders, select the sort icon <img alt="Sort icon" src="https://assets.postman.com/postman-docs/icon-sort.jpg#icon" width="16px">. Options are:
@@ -75,9 +75,16 @@ Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/ico
     * **Date added** - Sort by the date that elements and folders were added.
     * **A to Z** - Sort elements and folders alphabetically.
 
-Select a folder from the left sidebar to search, filter, and sort its elements in the folder overview on the right.
+### Search using the Private API Network overview
+
+You can search, filter, and sort Private API Network folders as well as elements with the overview feature.
+
+- Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network.
+- Select a folder from the left sidebar to search, filter, and sort its elements in the folder overview on the right.
 
 <img alt="Private API List" src="https://assets.postman.com/postman-docs/v10/private-api-network-list-v10-2.jpg"/>
+
+The **All APIs, collections and workspaces** section in the overview lets you search, sort, and filter with the following options:
 
 * To search by name, enter the full or partial element name into **Search elements**.
 * To filter based on the person who added the element, select **Added by**, then select the name of the team member.
@@ -89,7 +96,7 @@ Select a folder from the left sidebar to search, filter, and sort its elements i
     * **Trending this week** - Sort elements by your team's usage this week.
     * **Trending this month** - Sort elements by your team's usage this month.
 
-### Reviewing details about elements
+## Reviewing details about elements
 
 To review information about an element, select it from the left sidebar. On the right, you can view the element's description and the editors who have worked on it.
 
@@ -99,13 +106,13 @@ To learn more about trying an example, see [Trying an example](/docs/sending-req
 
 You can also open the element in its workspace. Select an element from the left sidebar, and then select either **View in Workspace** or **Open Workspace** in the upper-right corner.
 
-### Sharing folders and elements
+## Sharing folders and elements
 
 You can share links to folders and individual elements with other team members. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to a folder or element, then select **Copy link**. This copies the link to your clipboard. You can then share the link with team members.
 
 > You can also select a folder or element in the sidebar. Then select <img alt="Link icon" src="https://assets.postman.com/postman-docs/icon-workspace-link-v9.jpg#icon" width="18px"> **Copy link** in the upper-right corner.
 
-### Watching and forking elements
+## Watching and forking elements
 
 You can watch workspaces, collections, and APIs from the Private API Network. You can also fork collections from the Private API Network.
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -38,7 +38,7 @@ contextual_links:
 
 The _Private API Network_ provides a [central directory](https://www.postman.com/api-platform/api-catalog/) of workspaces, collections, and APIs your team uses internally. Your Postman team can access these resources and start using them right away. By using the Private API Network, you can enable developers across your organization to discover, consume, and track API development in one place.
 
-Workspaces, collections, and APIs in the Private API Network are visible to logged-in users who are on your Postman team. Users who aren't on your team can't find or access these resources. [Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network.
+Workspaces, collections, and APIs in the Private API Network are visible to logged-in users who are on your Postman team. Users who aren't on your team can't find or access these resources. [Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles), [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles), and [Folder Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network.
 
 <img alt="Private API Network overview" src="https://assets.postman.com/postman-docs/v10/private-api-network-overview-v10-3.jpg"/>
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -1,0 +1,112 @@
+---
+title: "Private API Network overview"
+updated: 2023-06-15
+contextual_links:
+  - type: section
+    name: "Additional resources"
+  - type: subtitle
+    name: "Videos"
+  - type: link
+    name: "Private API Network | The Exploratory"
+    url: "https://youtu.be/1SINcytmKsc"
+  - type: link
+    name: "Private API Network"
+    url: "https://youtu.be/cbPT4dMFIDw"
+  - type: link
+    name: "Discovering APIs | Postman Enterprise"
+    url: "https://youtu.be/e1v647ayIBg"
+  - type: subtitle
+    name: "Blog posts"
+  - type: link
+    name: "How to Make Your APIs Available to More Consumers"
+    url: "https://blog.postman.com/how-to-make-your-apis-available-to-more-consumers/"
+  - type: link
+    name: "Introducing an API to manage your Private API Network with more automation"
+    url: "https://blog.postman.com/introducing-api-to-manage-your-private-api-network-with-automation/"
+  - type: link
+    name: "Simplifying API distribution and evaluation with the Private API Network"
+    url: "https://blog.postman.com/simplifying-api-distribution-and-evaluation-with-the-private-api-network/"
+  - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "ChargeHub plans to improve internal discovery with a Private API Network"
+    url: "https://www.postman.com/case-studies/chargehub/"
+
+---
+
+> **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
+
+The _Private API Network_ provides a [central directory](https://www.postman.com/api-platform/api-catalog/) of workspaces, collections, and APIs your team uses internally. Your Postman team can access these resources and start using them right away. By using the Private API Network, you can enable developers across your organization to discover, consume, and track API development in one place.
+
+Workspaces, collections, and APIs in the Private API Network are visible to logged-in users who are on your Postman team. Users who aren't on your team can't find or access these resources. [Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network.
+
+<img alt="Private API Network overview" src="https://assets.postman.com/postman-docs/v10/private-api-network-overview-v10-3.jpg"/>
+
+## Contents
+
+* [Navigating the Private API Network](#navigating-the-private-api-network)
+    * [Searching, filtering, and sorting](#searching-filtering-and-sorting)
+    * [Reviewing details about elements](#reviewing-details-about-elements)
+    * [Sharing folders and elements](#sharing-folders-and-elements)
+    * [Watching and forking elements](#watching-and-forking-elements)
+
+## Navigating the Private API Network
+
+The Private API Network is a good place to learn about workspaces, collections, and APIs shared within your team. Under your team name, you can browse a directory of elements shared within your team in the left sidebar.
+
+There are two ways to access the Private API Network:
+
+* Select **Home** from the Postman header, then select **Private API Network** in your team information on the left side.
+* Select **API Network** from the Postman header, then select **Private API Network**.
+
+### Searching, filtering, and sorting
+
+There are several ways to search, filter, and sort elements and folders in the Private API Network. You can search and sort all elements and folders from the left sidebar. You can also select a folder to search, filter, and sort elements on the right.
+
+You can search and sort elements and folders from the left sidebar.
+
+<img alt="Create new folder in Private Network" src="https://assets.postman.com/postman-docs/v10/private-api-network-organize-folders-v10-2.jpg" width="300px"/>
+
+* To search by name, enter the full or partial element or folder name into **Search elements and folders**.
+* To sort elements and folders, select the sort icon <img alt="Sort icon" src="https://assets.postman.com/postman-docs/icon-sort.jpg#icon" width="16px">. Options are:
+    * **Default** - Sort by type, grouping folders and elements by type.
+    * **Date added** - Sort by the date that elements and folders were added.
+    * **A to Z** - Sort elements and folders alphabetically.
+
+You can select a folder to search, filter, and sort elements on the right. Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network. Select a folder in the left sidebar to search, filter, and sort elements only in the selected folder.
+
+* To search by name, enter the full or partial element name into **Search elements**.
+* To filter based on the person who added the element, select **Added by**, then select the name of the team member.
+* To filter by element type, select **Type**, then select **API**, **Collection**, or **Workspace**.
+* To filter based on element tags, select **Tags**, then select the tags. Learn more about adding tags to [collections](/docs/collections/using-collections/#tagging-a-collection), [APIs](/docs/designing-and-developing-your-api/managing-apis/#tagging-apis), and [workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#tagging-a-workspace).
+* To sort elements, select the **Sort by** dropdown list. Options are:
+    * **Recently added** - Sort elements by the date they were added.
+    * **A to Z** - Sort elements alphabetically.
+    * **Trending this week** - Sort elements by your team's usage this week.
+    * **Trending this month** - Sort elements by your team's usage this month.
+
+<img alt="Private API List" src="https://assets.postman.com/postman-docs/v10/private-api-network-list-v10-2.jpg"/>
+
+### Reviewing details about elements
+
+To review information about an element, select it from the left sidebar. On the right, you can view the element's description and the editors who have worked on it.
+
+For workspaces, you can view all of the collections and APIs inside them. For collections, you can view available documentation; you can select **Try Request** next to a request or **Try Example** next to an example to open it in a new tab. For APIs, you can view definitions and associated collections.
+
+To learn more about trying an example, see [Trying an example](/docs/sending-requests/examples/#trying-an-example).
+
+You can also open the element in its workspace. Select an element from the left sidebar, and then select either **View in Workspace** or **Open Workspace** in the upper-right corner.
+
+### Sharing folders and elements
+
+You can share links to folders and individual elements with other team members. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to a folder or element, then select **Copy link**. This copies the link to your clipboard. You can then share the link with team members.
+
+> You can also select a folder or element in the sidebar. Then select <img alt="Link icon" src="https://assets.postman.com/postman-docs/icon-workspace-link-v9.jpg#icon" width="18px"> **Copy link** in the upper-right corner.
+
+### Watching and forking elements
+
+You can watch workspaces, collections, and APIs from the Private API Network. You can also fork collections from the Private API Network.
+
+To watch a workspace, collection, or API and get notified about any changes, select an element in the left sidebar, then select <img alt="Watch icon" src="https://assets.postman.com/postman-docs/eye.jpg#icon" width="16px"> **Watch** in the upper-right corner. To learn more about watch notifications, see [Watching a workspace](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#watching-a-workspace), [Watching a collection](/docs/collections/using-collections/#watching-a-collection), and [Watching APIs](/docs/designing-and-developing-your-api/managing-apis/#watching-apis).
+
+To fork a collection, select a collection in the left sidebar, then select <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg#icon" width="14px"> **Fork** in the upper-right corner. To learn more about forking collections, see [Forking Postman entities](/docs/collaborating-in-postman/using-version-control/forking-entities/).

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -62,30 +62,32 @@ There are two ways to access the Private API Network:
 
 ## Searching, filtering, and sorting
 
-There are several ways to search, filter, and sort elements and folders in the Private API Network. You can search and sort all elements and folders from the left sidebar. You can also select a folder to search, filter, and sort elements on the right.
+There are several ways to search, filter, and sort elements and folders in the Private API Network. You can search and sort all elements and folders from the left sidebar. You can also select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** or a folder to search, filter, and sort elements on the right.
 
-You can search and sort elements and folders from the left sidebar.
+### Searching for folders and elements in the network
+
+You can search and sort elements and folders in the network from the left sidebar. Then you can select a folder or element to view its details on the right.
 
 <img alt="Create new folder in Private Network" src="https://assets.postman.com/postman-docs/v10/private-api-network-organize-folders-v10-2.jpg" width="300px"/>
 
-Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network.
-
-* To search by name, enter the full or partial element or folder name into **Search elements and folders**.
+* To search by name, select **Search elements and folders** and enter the full or partial element or folder name.
 * To sort elements and folders, select the sort icon <img alt="Sort icon" src="https://assets.postman.com/postman-docs/icon-sort.jpg#icon" width="16px">. Options are:
     * **Default** - Sort by type, grouping folders and elements by type.
     * **Date added** - Sort by the date that elements and folders were added.
     * **A to Z** - Sort elements and folders alphabetically.
 
-### Search using the Private API Network overview
+### Searching for elements in a folder
 
-You can search, filter, and sort Private API Network folders as well as elements with the overview feature.
+You can select a folder to search, filter, and sort elements on the right. Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network. Select a folder in the left sidebar to search, filter, and sort elements only in the selected folder.
 
-* Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network.
-* Select a folder from the left sidebar to search, filter, and sort its elements in the folder overview on the right.
+You can select a folder in the left sidebar to then search, filter, and sort elements on the right.
+
+* Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network on the right.
+* Select a folder from the left sidebar to search, filter, and sort its elements on the right.
 
 <img alt="Private API List" src="https://assets.postman.com/postman-docs/v10/private-api-network-list-v10-2.jpg"/>
 
-The **All APIs, collections and workspaces** section in the overview lets you search, sort, and filter with the following options:
+The **All APIs, collections and workspaces** section enables you to search, sort, and filter elements with the following options:
 
 * To search by name, enter the full or partial element name into **Search elements**.
 * To filter based on the person who added the element, select **Added by**, then select the name of the team member.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -49,6 +49,7 @@ Workspaces, collections, and APIs in the Private API Network are visible to logg
 * [Reviewing details about elements](#reviewing-details-about-elements)
 * [Sharing folders and elements](#sharing-folders-and-elements)
 * [Watching and forking elements](#watching-and-forking-elements)
+* [Private API Network reports](#private-api-network-reports)
 
 ## Navigating the Private API Network
 
@@ -79,8 +80,8 @@ Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/ico
 
 You can search, filter, and sort Private API Network folders as well as elements with the overview feature.
 
-- Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network.
-- Select a folder from the left sidebar to search, filter, and sort its elements in the folder overview on the right.
+* Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network.
+* Select a folder from the left sidebar to search, filter, and sort its elements in the folder overview on the right.
 
 <img alt="Private API List" src="https://assets.postman.com/postman-docs/v10/private-api-network-list-v10-2.jpg"/>
 
@@ -119,3 +120,11 @@ You can watch workspaces, collections, and APIs from the Private API Network. Yo
 To watch a workspace, collection, or API and get notified about any changes, select an element in the left sidebar, then select <img alt="Watch icon" src="https://assets.postman.com/postman-docs/eye.jpg#icon" width="16px"> **Watch** in the upper-right corner. To learn more about watch notifications, see [Watching a workspace](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#watching-a-workspace), [Watching a collection](/docs/collections/using-collections/#watching-a-collection), and [Watching APIs](/docs/designing-and-developing-your-api/managing-apis/#watching-apis).
 
 To fork a collection, select a collection in the left sidebar, then select <img alt="Fork icon" src="https://assets.postman.com/postman-docs/icon-fork.jpg#icon" width="14px"> **Fork** in the upper-right corner. To learn more about forking collections, see [Forking Postman entities](/docs/collaborating-in-postman/using-version-control/forking-entities/).
+
+## Private API Network reports
+
+The report feature makes it easier to govern your internal API landscape through deeper insights into APIs in your Private API Network.
+
+To view Private API Network reports, select [**Home**](https://go.postman.co/) from the Postman header, then select **Reports** on the left side.
+
+To learn more about reports, see [About reports](/docs/reports/reports-overview/).

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -56,7 +56,7 @@ The Private API Network is a good place to learn about workspaces, collections, 
 
 There are two ways to access the Private API Network:
 
-* Select **Home** from the Postman header, then select **Private API Network** in your team information on the left side.
+* Select **Home** from the Postman header, then select **Private API Network** in your team information on the left sidebar.
 * Select **API Network** from the Postman header, then select **Private API Network**.
 
 ### Searching, filtering, and sorting

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -46,6 +46,8 @@ Workspaces, collections, and APIs in the Private API Network are visible to logg
 
 * [Navigating the Private API Network](#navigating-the-private-api-network)
 * [Searching, filtering, and sorting](#searching-filtering-and-sorting)
+    * [Searching for folders and elements in the network](#searching-for-folders-and-elements-in-the-network)
+    * [Searching for elements in a folder](#searching-for-elements-in-a-folder)
 * [Reviewing details about elements](#reviewing-details-about-elements)
 * [Sharing folders and elements](#sharing-folders-and-elements)
 * [Watching and forking elements](#watching-and-forking-elements)

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -67,13 +67,17 @@ You can search and sort elements and folders from the left sidebar.
 
 <img alt="Create new folder in Private Network" src="https://assets.postman.com/postman-docs/v10/private-api-network-organize-folders-v10-2.jpg" width="300px"/>
 
+Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network. Select a folder in the left sidebar to search, filter, and sort elements only in the selected folder.
+
 * To search by name, enter the full or partial element or folder name into **Search elements and folders**.
 * To sort elements and folders, select the sort icon <img alt="Sort icon" src="https://assets.postman.com/postman-docs/icon-sort.jpg#icon" width="16px">. Options are:
     * **Default** - Sort by type, grouping folders and elements by type.
     * **Date added** - Sort by the date that elements and folders were added.
     * **A to Z** - Sort elements and folders alphabetically.
 
-You can select a folder to search, filter, and sort elements on the right. Select <img alt="Home icon" src="https://assets.postman.com/postman-docs/v10/icon-home-v10.jpg#icon" width="16px"> **Home** in the left sidebar to search, filter, and sort all elements in your Private API Network. Select a folder in the left sidebar to search, filter, and sort elements only in the selected folder.
+Select a folder from the left sidebar to search, filter, and sort its elements in the folder overview on the right.
+
+<img alt="Private API List" src="https://assets.postman.com/postman-docs/v10/private-api-network-list-v10-2.jpg"/>
 
 * To search by name, enter the full or partial element name into **Search elements**.
 * To filter based on the person who added the element, select **Added by**, then select the name of the team member.
@@ -84,8 +88,6 @@ You can select a folder to search, filter, and sort elements on the right. Selec
     * **A to Z** - Sort elements alphabetically.
     * **Trending this week** - Sort elements by your team's usage this week.
     * **Trending this month** - Sort elements by your team's usage this month.
-
-<img alt="Private API List" src="https://assets.postman.com/postman-docs/v10/private-api-network-list-v10-2.jpg"/>
 
 ### Reviewing details about elements
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -38,7 +38,9 @@ contextual_links:
 
 The _Private API Network_ provides a [central directory](https://www.postman.com/api-platform/api-catalog/) of workspaces, collections, and APIs your team uses internally. Your Postman team can access these resources and start using them right away. By using the Private API Network, you can enable developers across your organization to discover, consume, and track API development in one place.
 
-Workspaces, collections, and APIs in the Private API Network are visible to logged-in users who are on your Postman team. Users who aren't on your team can't find or access these resources. [Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles), [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles), and [Folder Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network.
+Workspaces, collections, and APIs in the Private API Network are visible to logged-in users who are on your Postman team. Users who aren't on your team can't find or access these resources.
+
+[Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network. You can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) at the folder level, giving them permission to manage specific folders and the elements in them.
 
 <img alt="Private API Network overview" src="https://assets.postman.com/postman-docs/v10/private-api-network-overview-v10-3.jpg"/>
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
@@ -37,6 +37,7 @@ contextual_links:
 > **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
 You can manage folders and elements in the Private API Network. You can edit a collection's summary and environments, move folders and elements, rename folders, and remove folders and elements from the network.
+
 [Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network. You can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) at the folder level, giving them permission to manage specific folders and the elements in them. Users with the Editor role for an element can also manage the element.
 
 > Enterprise teams can also assign the API Network Manager role to a user group. For more information about assigning team roles to groups, see [User groups](/docs/collaborating-in-postman/user-groups/).

--- a/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
@@ -36,7 +36,7 @@ contextual_links:
 
 > **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
-[Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network. You can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) at the folder level, giving them permission to manage specific folders and the elements in them.
+[Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network. You can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) at the folder level, giving them permission to manage specific folders and the elements in them. Users with the Editor role for an element can also manage the element.
 
 > Enterprise teams can also assign this role to a user group. For more information about assigning team roles to groups, see [User groups](/docs/collaborating-in-postman/user-groups/).
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
@@ -51,10 +51,7 @@ contextual_links:
 
 API Network Managers can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles), giving them permission to manage specific folders and the elements in them. Folder Managers can also assign other team members the Folder Manager role in folders they have permission to manage.
 
-1. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder, then select **Edit folder managers**.
-
-    > You can also select a folder in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Edit folder managers**.
-
+1. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder, then select **Edit folder managers**. You can also select a folder in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Edit folder managers**.
 1. Enter the name, email, or group name you want to assign as a Folder Manager for the folder.
 1. Select **Save Changes**.
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
@@ -42,19 +42,16 @@ You can manage folders and elements in the Private API Network. You can edit a c
 
 > Enterprise teams can also assign the API Network Manager role to a user group. For more information about assigning team roles to groups, see [User groups](/docs/collaborating-in-postman/user-groups/).
 
+<!-- -->
+
+> You can manage elements within the [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/#navigating-the-private-api-network) or with the [Postman API](https://www.postman.com/postman/workspace/postman-public-workspace/folder/12959542-b7c02959-88ca-4e2f-9b68-99538eed4533?ctx=documentation).
+
 ## Contents
 
-* [Managing folders and elements](#managing-folders-and-elements)
 * [Editing collections](#editing-collections)
 * [Moving folders and elements](#moving-folders-and-elements)
 * [Renaming folders](#renaming-folders)
 * [Removing folders and elements](#removing-folders-and-elements)
-
-## Managing folders and elements
-
-API Network Managers can manage all folders and elements. Folder Managers can manage folders and elements in folders they have permission to manage. Users with the Editor role for an element can also manage the element.
-
-> You can manage elements within the [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/#navigating-the-private-api-network) or with the [Postman API](https://www.postman.com/postman/workspace/postman-public-workspace/folder/12959542-b7c02959-88ca-4e2f-9b68-99538eed4533?ctx=documentation).
 
 ## Editing collections
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
@@ -38,7 +38,7 @@ contextual_links:
 
 [Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network. You can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) at the folder level, giving them permission to manage specific folders and the elements in them. Users with the Editor role for an element can also manage the element.
 
-> Enterprise teams can also assign this role to a user group. For more information about assigning team roles to groups, see [User groups](/docs/collaborating-in-postman/user-groups/).
+> Enterprise teams can also assign the API Network Manager role to a user group. For more information about assigning team roles to groups, see [User groups](/docs/collaborating-in-postman/user-groups/).
 
 ## Contents
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
@@ -44,10 +44,10 @@ You can manage folders and elements in the Private API Network. You can edit a c
 ## Contents
 
 * [Managing folders and elements](#managing-folders-and-elements)
-    * [Editing collections](#editing-collections)
-    * [Moving folders and elements](#moving-folders-and-elements)
-    * [Renaming folders](#renaming-folders)
-    * [Removing folders and elements](#removing-folders-and-elements)
+* [Editing collections](#editing-collections)
+* [Moving folders and elements](#moving-folders-and-elements)
+* [Renaming folders](#renaming-folders)
+* [Removing folders and elements](#removing-folders-and-elements)
 
 ## Managing folders and elements
 
@@ -55,23 +55,23 @@ API Network Managers can manage all folders and elements. Folder Managers can ma
 
 > You can manage elements within the [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/#navigating-the-private-api-network) or with the [Postman API](https://www.postman.com/postman/workspace/postman-public-workspace/folder/12959542-b7c02959-88ca-4e2f-9b68-99538eed4533?ctx=documentation).
 
-### Editing collections
+## Editing collections
 
 You can change a collection's summary and associated environments in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the collection you would like to edit from the network, then select **Edit collection**. Edit the collection, then select **Edit** to save your changes.
 
 > You can also select a collection in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Edit collection**.
 
-### Moving folders and elements
+## Moving folders and elements
 
 You can move folders and elements in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder or element you would like to move in the network, then select **Move...** or **Move element**. You can move folders and elements to an existing folder or create a new one. Select **Move Folder** or **Move element** to save your changes.
 
 > You can also select a folder or element in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Move...** or **Move element**.
 
-### Renaming folders
+## Renaming folders
 
 You can rename folders in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder you would like to rename, then select **Rename**. Enter a new name, then press **Enter**.
 
-### Removing folders and elements
+## Removing folders and elements
 
 You can remove folders and elements from the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder or element you want to remove from the network, then select **Delete** or **Remove**. To confirm that you want to remove an element from the network, select **Remove**.
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
@@ -1,0 +1,69 @@
+---
+title: "Managing your Private API Network"
+updated: 2023-06-15
+contextual_links:
+  - type: section
+    name: "Additional resources"
+  - type: subtitle
+    name: "Videos"
+  - type: link
+    name: "Private API Network | The Exploratory"
+    url: "https://youtu.be/1SINcytmKsc"
+  - type: link
+    name: "Private API Network"
+    url: "https://youtu.be/cbPT4dMFIDw"
+  - type: link
+    name: "Discovering APIs | Postman Enterprise"
+    url: "https://youtu.be/e1v647ayIBg"
+  - type: subtitle
+    name: "Blog posts"
+  - type: link
+    name: "How to Make Your APIs Available to More Consumers"
+    url: "https://blog.postman.com/how-to-make-your-apis-available-to-more-consumers/"
+  - type: link
+    name: "Introducing an API to manage your Private API Network with more automation"
+    url: "https://blog.postman.com/introducing-api-to-manage-your-private-api-network-with-automation/"
+  - type: link
+    name: "Simplifying API distribution and evaluation with the Private API Network"
+    url: "https://blog.postman.com/simplifying-api-distribution-and-evaluation-with-the-private-api-network/"
+  - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "ChargeHub plans to improve internal discovery with a Private API Network"
+    url: "https://www.postman.com/case-studies/chargehub/"
+
+---
+
+> **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
+
+[Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network. You can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) at the folder level, giving them permission to manage specific folders and the elements in them.
+
+> Enterprise teams can also assign this role to a user group. For more information about assigning team roles to groups, see [User groups](/docs/collaborating-in-postman/user-groups/).
+
+## Contents
+
+* [Editing Folder Managers](#editing-folder-managers)
+* [Private API Network reports](#private-api-network-reports)
+
+## Editing Folder Managers
+
+> You can't add Folder Managers to sub-folders.
+
+API Network Managers can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles), giving them permission to manage specific folders and the elements in them. Folder Managers can also assign other team members the Folder Manager role in folders they have permission to manage.
+
+1. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder, then select **Edit folder managers**.
+
+    > You can also select a folder in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Edit folder managers**.
+
+1. Enter the name, email, or group name you want to assign as a Folder Manager for the folder.
+1. Select **Save Changes**.
+
+    <img alt="Edit Folder Managers in Private Network" src="https://assets.postman.com/postman-docs/v10/edit-folder-managers-v10.jpg"/>
+
+## Private API Network reports
+
+The report feature makes it easier to govern your internal API landscape through deeper insights into APIs in your Private API Network.
+
+To view Private API Network reports, select [**Home**](https://go.postman.co/) from the Postman header, then select **Reports** on the left side.
+
+To learn more about reports, see [About reports](/docs/reports/reports-overview/).

--- a/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
@@ -1,6 +1,6 @@
 ---
 title: "Managing your Private API Network"
-updated: 2023-06-15
+updated: 2023-07-07
 contextual_links:
   - type: section
     name: "Additional resources"

--- a/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
@@ -36,6 +36,7 @@ contextual_links:
 
 > **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
+You can manage folders and elements in the Private API Network. You can edit a collection's summary and environments, move folders and elements, rename folders, and remove folders and elements from the network.
 [Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network. You can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) at the folder level, giving them permission to manage specific folders and the elements in them. Users with the Editor role for an element can also manage the element.
 
 > Enterprise teams can also assign the API Network Manager role to a user group. For more information about assigning team roles to groups, see [User groups](/docs/collaborating-in-postman/user-groups/).

--- a/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/managing-private-network.md
@@ -42,25 +42,42 @@ contextual_links:
 
 ## Contents
 
-* [Editing Folder Managers](#editing-folder-managers)
-* [Private API Network reports](#private-api-network-reports)
+* [Managing folders and elements](#managing-folders-and-elements)
+    * [Editing collections](#editing-collections)
+    * [Moving folders and elements](#moving-folders-and-elements)
+    * [Renaming folders](#renaming-folders)
+    * [Removing folders and elements](#removing-folders-and-elements)
 
-## Editing Folder Managers
+## Managing folders and elements
 
-> You can't add Folder Managers to sub-folders.
+API Network Managers can manage all folders and elements. Folder Managers can manage folders and elements in folders they have permission to manage. Users with the Editor role for an element can also manage the element.
 
-API Network Managers can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles), giving them permission to manage specific folders and the elements in them. Folder Managers can also assign other team members the Folder Manager role in folders they have permission to manage.
+> You can manage elements within the [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/#navigating-the-private-api-network) or with the [Postman API](https://www.postman.com/postman/workspace/postman-public-workspace/folder/12959542-b7c02959-88ca-4e2f-9b68-99538eed4533?ctx=documentation).
 
-1. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder, then select **Edit folder managers**. You can also select a folder in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Edit folder managers**.
-1. Enter the name, email, or group name you want to assign as a Folder Manager for the folder.
-1. Select **Save Changes**.
+### Editing collections
 
-    <img alt="Edit Folder Managers in Private Network" src="https://assets.postman.com/postman-docs/v10/edit-folder-managers-v10.jpg"/>
+You can change a collection's summary and associated environments in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the collection you would like to edit from the network, then select **Edit collection**. Edit the collection, then select **Edit** to save your changes.
 
-## Private API Network reports
+> You can also select a collection in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Edit collection**.
 
-The report feature makes it easier to govern your internal API landscape through deeper insights into APIs in your Private API Network.
+### Moving folders and elements
 
-To view Private API Network reports, select [**Home**](https://go.postman.co/) from the Postman header, then select **Reports** on the left side.
+You can move folders and elements in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder or element you would like to move in the network, then select **Move...** or **Move element**. You can move folders and elements to an existing folder or create a new one. Select **Move Folder** or **Move element** to save your changes.
 
-To learn more about reports, see [About reports](/docs/reports/reports-overview/).
+> You can also select a folder or element in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Move...** or **Move element**.
+
+### Renaming folders
+
+You can rename folders in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder you would like to rename, then select **Rename**. Enter a new name, then press **Enter**.
+
+### Removing folders and elements
+
+You can remove folders and elements from the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder or element you want to remove from the network, then select **Delete** or **Remove**. To confirm that you want to remove an element from the network, select **Remove**.
+
+> You can also select a folder or element in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Delete** or **Remove**.
+
+If you have the Editor role for an element, you can also remove elements in your Private API Network from the workbench. For collections and APIs, open the overview then select **Remove**. For workspaces, open the overview, select <img alt="Workspace settings icon" src="https://assets.postman.com/postman-docs/v10/icon-sliders-v10.jpg#icon" width="24px"> **Workspace Settings**, then select **Remove**. To confirm, select **Remove**.
+
+<img alt="Remove collection in Private API Network from workbench" src="https://assets.postman.com/postman-docs/v10/remove-collection-private-api-network-v10.jpg"/>
+
+After you remove the element, team members won't have access to it through the Private API Network.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
@@ -42,16 +42,13 @@ Organizing your Private API Network with folders and elements helps your team ea
 
 * [Organizing with folders](#organizing-with-folders)
     * [Adding sub-folders](#adding-sub-folders)
+* [Editing Folder Managers](#editing-folder-managers)
 * [Adding elements](#adding-elements)
     * [Adding elements in your Private API Network](#adding-elements-in-your-private-api-network)
     * [Adding a workspace from the workbench](#adding-a-workspace-from-the-workbench)
     * [Adding a collection from the workbench](#adding-a-collection-from-the-workbench)
     * [Adding an API from the workbench](#adding-an-api-from-the-workbench)
-* [Managing folders and elements](#managing-folders-and-elements)
-    * [Editing collections](#editing-collections)
-    * [Moving folders and elements](#moving-folders-and-elements)
-    * [Renaming folders](#renaming-folders)
-    * [Removing folders and elements](#removing-folders-and-elements)
+* [Reviewing requests to add elements](#reviewing-requests-to-add-elements)
 
 ## Organizing with folders
 
@@ -79,6 +76,18 @@ To add a sub-folder to an existing folder, do the following:
 1. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to a folder, then select **Add folder**. You can also select a folder in the sidebar, then select <img alt="Create folder icon" src="https://assets.postman.com/postman-docs/v10/icon-create-folder-v10.jpg#icon" width="20px"> **Create Folder** in the upper-right corner.
 1. Enter a name for the folder. Optionally, you can add a description for the sub-folder.
 1. Select **Create Folder**.
+
+## Editing Folder Managers
+
+> You can't add Folder Managers to sub-folders.
+
+API Network Managers can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles), giving them permission to manage specific folders and the elements in them. Folder Managers can also assign other team members the Folder Manager role in folders they have permission to manage.
+
+1. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder, then select **Edit folder managers**. You can also select a folder in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Edit folder managers**.
+1. Enter the name, email, or group name you want to assign as a Folder Manager for the folder.
+1. Select **Save Changes**.
+
+    <img alt="Edit Folder Managers in Private Network" src="https://assets.postman.com/postman-docs/v10/edit-folder-managers-v10.jpg"/>
 
 ## Adding elements
 
@@ -186,36 +195,24 @@ Learn more about [publishing an API version](/docs/designing-and-developing-your
 
 You can make all your existing APIs discoverable on the Private API Network after you import them from a code repository. Learn more about [importing an API](/docs/designing-and-developing-your-api/importing-an-api/).
 
-## Managing folders and elements
+## Reviewing requests to add elements
 
-API Network Managers can manage all folders and elements. Folder Managers can manage folders and elements in folders they have permission to manage. Users with the Editor role for an element can also manage the element.
+API Network Managers can review requests to add elements to the Private API Network. Folder Managers can review requests to add elements to folders they have permission to manage.
 
-> You can manage elements within the [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/#navigating-the-private-api-network) or with the [Postman API](https://www.postman.com/postman/workspace/postman-public-workspace/folder/12959542-b7c02959-88ca-4e2f-9b68-99538eed4533?ctx=documentation).
+When an Editor requests to add an element to your team's Private API Network, Postman will send you an email and an in-app notification. For the list of all the pending requests, open the [Private API Network](https://go.postman.co/network/private) and select the pending requests icon <img alt="Pending requests icon" src="https://assets.postman.com/postman-docs/v10/icon-pending-request-v10.jpg#icon" width="22px"> in the left sidebar.
 
-### Editing collections
+Pending requests include the element type, the user who submitted the request, the date they submitted it on, a link to view the element in its workspace, and an optional note from the requesting user.
 
-You can change a collection's summary and associated environments in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the collection you would like to edit from the network, then select **Edit collection**. Edit the collection, then select **Edit** to save your changes.
+<img alt="Approve or deny a request" src="https://assets.postman.com/postman-docs/v10/private-api-network-pending-requests-v10-2.jpg"/>
 
-> You can also select a collection in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Edit collection**.
+To approve a request, do the following:
 
-### Moving folders and elements
+1. Select **Approve**.
+1. (Optional) Select a folder or create one to keep elements organized.
+1. Select **Approve Request**.
 
-You can move folders and elements in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder or element you would like to move in the network, then select **Move...** or **Move element**. You can move folders and elements to an existing folder or create a new one. Select **Move Folder** or **Move element** to save your changes.
+To deny a request, do the following:
 
-> You can also select a folder or element in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Move...** or **Move element**.
-
-### Renaming folders
-
-You can rename folders in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder you would like to rename, then select **Rename**. Enter a new name, then press **Enter**.
-
-### Removing folders and elements
-
-You can remove folders and elements from the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder or element you want to remove from the network, then select **Delete** or **Remove**. To confirm that you want to remove an element from the network, select **Remove**.
-
-> You can also select a folder or element in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Delete** or **Remove**.
-
-If you have the Editor role for an element, you can also remove elements in your Private API Network from the workbench. For collections and APIs, open the overview then select **Remove**. For workspaces, open the overview, select <img alt="Workspace settings icon" src="https://assets.postman.com/postman-docs/v10/icon-sliders-v10.jpg#icon" width="24px"> **Workspace Settings**, then select **Remove**. To confirm, select **Remove**.
-
-<img alt="Remove collection in Private API Network from workbench" src="https://assets.postman.com/postman-docs/v10/remove-collection-private-api-network-v10.jpg"/>
-
-After you remove the element, team members won't have access to it through the Private API Network.
+1. Select **Deny**.
+1. Write a note to the Editor who submitted the request explaining why you are denying their request.
+1. Select **Deny Request**.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
@@ -36,7 +36,9 @@ contextual_links:
 
 > **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
-Organizing your Private API Network with folders and elements helps your team easily discover and use your internal workspaces, collections, and APIs.
+Add elements to the Private API Network to help your team discover and use your team's workspaces, collections, and APIs. You can organize related elements into folders.
+
+[Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network. You can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) at the folder level, giving them permission to manage specific folders and the elements in them.
 
 ## Contents
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
@@ -1,5 +1,5 @@
 ---
-title: "Private API Network overview"
+title: "Organizing your Private API Network"
 updated: 2023-06-15
 contextual_links:
   - type: section
@@ -36,9 +36,7 @@ contextual_links:
 
 > **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
-The _Private API Network_ provides a [central directory](https://www.postman.com/api-platform/api-catalog/) of workspaces, collections, and APIs your team uses internally. Your Postman team can access these resources and start using them right away. By using the Private API Network, you can enable developers across your organization to discover, consume, and track API development in one place.
-
-Workspaces, collections, and APIs in the Private API Network are visible to logged-in users who are on your Postman team. Users who aren't on your team can't find or access these resources.
+Organizing your Private API Network with folders and elements helps your team easily discover and use your internal workspaces, collections, and APIs.
 
 ## Contents
 
@@ -64,19 +62,10 @@ The sidebar navigation displays the folder structure for your Private API Networ
 To create a new folder from the Private API Network view, do the following:
 
 1. Open your [Private API Network](https://go.postman.co/network/private).
-1. Select the create folder icon <img alt="Create folder icon" src="https://assets.postman.com/postman-docs/v10/icon-create-folder-v10.jpg#icon" width="20px"> in the left sidebar.
-
-    > You can also select **Create Folders** on the right from the Private API Network overview page.
-
+1. Select the create folder icon <img alt="Create folder icon" src="https://assets.postman.com/postman-docs/v10/icon-create-folder-v10.jpg#icon" width="20px"> in the left sidebar. You can also select **Create Folders** on the right from the Private API Network overview page.
 1. Give the folder a name.
-1. (Optional) Add Folder Managers to the folder.
-
-    > You can also add Folder Managers to a folder later. To learn more, see [Editing Folder Managers](#editing-folder-managers).
-
-1. (Optional) Add more folders.
-
-    > Select <img alt="Create folder icon" src="https://assets.postman.com/postman-docs/v10/icon-create-folder-v10.jpg#icon" width="20px"> **Add Folder** to add another folder. Select the remove icon <img alt="Remove icon" src="https://assets.postman.com/postman-docs/icon-remove-api-element-v9.jpg#icon" width="16px"> next to a folder to remove it.
-
+1. (Optional) Add Folder Managers to the folder. You can also add Folder Managers to a folder later. To learn more, see [Editing Folder Managers](/docs/collaborating-in-postman/private-api-network/managing-private-network/#editing-folder-managers).
+1. (Optional) Add more folders. Select <img alt="Create folder icon" src="https://assets.postman.com/postman-docs/v10/icon-create-folder-v10.jpg#icon" width="20px"> **Add Folder** to add another folder. Select the remove icon <img alt="Remove icon" src="https://assets.postman.com/postman-docs/icon-remove-api-element-v9.jpg#icon" width="16px"> next to a folder to remove it.
 1. Select **Review**.
 
     <img alt="Create folders in Private Network" src="https://assets.postman.com/postman-docs/v10/private-api-network-create-folders-v10.jpg"/>
@@ -87,16 +76,13 @@ To create a new folder from the Private API Network view, do the following:
 
 To add a sub-folder to an existing folder, do the following:
 
-1. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to a folder, then select **Add folder**.
-
-    > You can also select a folder in the sidebar. Then select <img alt="Create folder icon" src="https://assets.postman.com/postman-docs/v10/icon-create-folder-v10.jpg#icon" width="20px"> **Create Folder** in the upper-right corner.
-
+1. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to a folder, then select **Add folder**. You can also select a folder in the sidebar, then select <img alt="Create folder icon" src="https://assets.postman.com/postman-docs/v10/icon-create-folder-v10.jpg#icon" width="20px"> **Create Folder** in the upper-right corner.
 1. Enter a name for the folder. Optionally, you can add a description for the sub-folder.
 1. Select **Create Folder**.
 
 ## Adding elements
 
-API Network Managers can add elements to the Private API Network. Folder Managers can add elements to folders they have permission to manage. Workspace Editors, Collection Editors, and API Editors must [request to add elements](#requesting-to-add-elements) to the Private API Network.
+API Network Managers can add elements to the Private API Network. Folder Managers can add elements to folders they have permission to manage. Workspace Editors, Collection Editors, and API Editors must [request to add elements](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-elements) to the Private API Network.
 
 To add an element to the Private API Network, it must be in a team or public workspace. You can't add an element to the Private API Network unless all team members have at least view access to the element. Learn more about team [roles and permissions](/docs/collaborating-in-postman/roles-and-permissions/).
 
@@ -110,14 +96,14 @@ The collections and APIs you add to the Private API Network include the latest c
 
 ### Adding elements in your Private API Network
 
-You can add elements from inside your team's Private API Network. Workspace Editors, Collection Editors, and API Editors can [request to add elements](#requesting-to-add-elements-in-your-private-api-network) from your Private API Network.
+You can add elements from inside your team's Private API Network. Workspace Editors, Collection Editors, and API Editors can [request to add elements](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-elements-in-your-private-api-network) from your Private API Network.
 
 To add elements from your Private API Network, do the following:
 
 1. Open your [Private API Network](https://go.postman.co/network/private).
 1. Select the **+** icon in the left sidebar to add elements to the root Home folder. To add elements to a specific folder, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to a folder, then select **Add elements**.
 
-    > You can also select **Add** on the right from the Private API Network overview page, or select **Add To Folder** in the upper-right corner.
+    > You can also select **Add** on the right from the Private API Network overview page. In a Private API Network folder, you can select **Add To Folder** in the upper-right corner.
 
 1. Select the collections, APIs, and workspaces you want to add. You can search for elements, and filter elements by tags. Learn more about adding tags to [collections](/docs/collections/using-collections/#tagging-a-collection), [APIs](/docs/designing-and-developing-your-api/managing-apis/#tagging-apis), and [workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#tagging-a-workspace).
 
@@ -139,7 +125,7 @@ To add elements from your Private API Network, do the following:
 
 ### Adding a workspace from the workbench
 
-You can add workspaces from the workbench. Workspace Editors must [request to add a workspace](#requesting-to-add-a-workspace-from-the-api-builder).
+You can add workspaces from the workbench. Workspace Editors must [request to add a workspace](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-a-workspace-from-the-workbench).
 
 To add a workspace to the Private API Network from the workbench, do the following:
 
@@ -156,7 +142,7 @@ To add a workspace to the Private API Network from the workbench, do the followi
 
 ### Adding a collection from the workbench
 
-You can add collections from the workbench. Collection Editors must [request to add a collection](#requesting-to-add-a-collection-from-the-api-builder).
+You can add collections from the workbench. Collection Editors must [request to add a collection](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-a-collection-from-the-workbench).
 
 To add a collection to the Private API Network from the workbench, do the following:
 
@@ -168,16 +154,13 @@ To add a collection to the Private API Network from the workbench, do the follow
     <img alt="Add collection to the Private Network" src="https://assets.postman.com/postman-docs/v10/add-collection-to-private-api-network-v10.jpg"/>
 
 1. (Optional) Add a brief summary about the collection.
-1. (Optional) Select **Select Environments** to make sure users have access to environment variables.
-
-    > You can also edit a collection's summary and environments later. To learn more, see [Editing collections](#editing-collections).
-
+1. (Optional) Select **Select Environments** to make sure users have access to environment variables. You can also edit a collection's summary and environments later. To learn more, see [Editing collections](#editing-collections).
 1. (Optional) Select a folder or create one to keep elements organized.
 1. Select **Add collection**.
 
 ### Adding an API from the workbench
 
-You can add APIs from the workbench. API Editors must [request to add an API](#requesting-to-add-an-api-from-the-api-builder).
+You can add APIs from the workbench. API Editors must [request to add an API](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-an-api-from-the-workbench).
 
 > An API's editor must [publish a version of the API](#publishing-specific-api-versions) before you can add it to your Private API Network.
 
@@ -208,7 +191,7 @@ You can make all your existing APIs discoverable on the Private API Network afte
 
 API Network Managers can manage all folders and elements. Folder Managers can manage folders and elements in folders they have permission to manage. Users with the Editor role for an element can also manage the element.
 
-> You can manage elements within the [Private API Network](#navigating-the-private-api-network) or with the [Postman API](https://www.postman.com/postman/workspace/postman-public-workspace/folder/12959542-b7c02959-88ca-4e2f-9b68-99538eed4533?ctx=documentation).
+> You can manage elements within the [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/#navigating-the-private-api-network) or with the [Postman API](https://www.postman.com/postman/workspace/postman-public-workspace/folder/12959542-b7c02959-88ca-4e2f-9b68-99538eed4533?ctx=documentation).
 
 ### Editing collections
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
@@ -1,6 +1,6 @@
 ---
 title: "Organizing your Private API Network"
-updated: 2023-06-15
+updated: 2023-07-07
 contextual_links:
   - type: section
     name: "Additional resources"

--- a/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
@@ -81,9 +81,9 @@ To add a sub-folder to an existing folder, do the following:
 
 ## Editing Folder Managers
 
-> You can't add Folder Managers to sub-folders.
-
 API Network Managers can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles), giving them permission to manage specific folders and the elements in them. Folder Managers can also assign other team members the Folder Manager role in folders they have permission to manage.
+
+> You can't add Folder Managers to sub-folders.
 
 1. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder, then select **Edit folder managers**. You can also select a folder in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Edit folder managers**.
 1. Enter the name, email, or group name you want to assign as a Folder Manager for the folder.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
@@ -186,7 +186,6 @@ Learn more about [publishing an API version](/docs/designing-and-developing-your
 
 You can make all your existing APIs discoverable on the Private API Network after you import them from a code repository. Learn more about [importing an API](/docs/designing-and-developing-your-api/importing-an-api/).
 
-
 ## Managing folders and elements
 
 API Network Managers can manage all folders and elements. Folder Managers can manage folders and elements in folders they have permission to manage. Users with the Editor role for an element can also manage the element.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
@@ -118,7 +118,7 @@ To add elements from your Private API Network, do the following:
 
 1. Select the collections, APIs, and workspaces you want to add. You can search for elements, and filter elements by tags. Learn more about adding tags to [collections](/docs/collections/using-collections/#tagging-a-collection), [APIs](/docs/designing-and-developing-your-api/managing-apis/#tagging-apis), and [workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#tagging-a-workspace).
 
-    If you're adding collections, you can optionally select environments in their workspace to make sure users have access to environment variables. You can also [edit a collection's environments later](#editing-collections).
+    If you're adding collections, you can optionally select environments in their workspace to make sure users have access to environment variables. You can also [edit a collection's environments later](/docs/collaborating-in-postman/private-api-network/managing-private-network/#editing-collections).
 
     You can select **Added elements** in the upper-right corner to show elements already added to the Private API Network. You can select the **Collections** tab and then **Forks** in the upper-right corner to show [forked collections](/docs/collaborating-in-postman/using-version-control/forking-entities/).
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
@@ -165,7 +165,7 @@ To add a collection to the Private API Network from the workbench, do the follow
     <img alt="Add collection to the Private Network" src="https://assets.postman.com/postman-docs/v10/add-collection-to-private-api-network-v10.jpg"/>
 
 1. (Optional) Add a brief summary about the collection.
-1. (Optional) Select **Select Environments** to make sure users have access to environment variables. You can also edit a collection's summary and environments later. To learn more, see [Editing collections](#editing-collections).
+1. (Optional) Select **Select Environments** to make sure users have access to environment variables. You can also edit a collection's summary and environments later. To learn more, see [Editing collections](/docs/collaborating-in-postman/private-api-network/managing-private-network/#editing-collections).
 1. (Optional) Select a folder or create one to keep elements organized.
 1. Select **Add collection**.
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/organizing-private-network.md
@@ -1,0 +1,239 @@
+---
+title: "Private API Network overview"
+updated: 2023-06-15
+contextual_links:
+  - type: section
+    name: "Additional resources"
+  - type: subtitle
+    name: "Videos"
+  - type: link
+    name: "Private API Network | The Exploratory"
+    url: "https://youtu.be/1SINcytmKsc"
+  - type: link
+    name: "Private API Network"
+    url: "https://youtu.be/cbPT4dMFIDw"
+  - type: link
+    name: "Discovering APIs | Postman Enterprise"
+    url: "https://youtu.be/e1v647ayIBg"
+  - type: subtitle
+    name: "Blog posts"
+  - type: link
+    name: "How to Make Your APIs Available to More Consumers"
+    url: "https://blog.postman.com/how-to-make-your-apis-available-to-more-consumers/"
+  - type: link
+    name: "Introducing an API to manage your Private API Network with more automation"
+    url: "https://blog.postman.com/introducing-api-to-manage-your-private-api-network-with-automation/"
+  - type: link
+    name: "Simplifying API distribution and evaluation with the Private API Network"
+    url: "https://blog.postman.com/simplifying-api-distribution-and-evaluation-with-the-private-api-network/"
+  - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "ChargeHub plans to improve internal discovery with a Private API Network"
+    url: "https://www.postman.com/case-studies/chargehub/"
+
+---
+
+> **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
+
+The _Private API Network_ provides a [central directory](https://www.postman.com/api-platform/api-catalog/) of workspaces, collections, and APIs your team uses internally. Your Postman team can access these resources and start using them right away. By using the Private API Network, you can enable developers across your organization to discover, consume, and track API development in one place.
+
+Workspaces, collections, and APIs in the Private API Network are visible to logged-in users who are on your Postman team. Users who aren't on your team can't find or access these resources.
+
+## Contents
+
+* [Organizing with folders](#organizing-with-folders)
+    * [Adding sub-folders](#adding-sub-folders)
+* [Adding elements](#adding-elements)
+    * [Adding elements in your Private API Network](#adding-elements-in-your-private-api-network)
+    * [Adding a workspace from the workbench](#adding-a-workspace-from-the-workbench)
+    * [Adding a collection from the workbench](#adding-a-collection-from-the-workbench)
+    * [Adding an API from the workbench](#adding-an-api-from-the-workbench)
+* [Managing folders and elements](#managing-folders-and-elements)
+    * [Editing collections](#editing-collections)
+    * [Moving folders and elements](#moving-folders-and-elements)
+    * [Renaming folders](#renaming-folders)
+    * [Removing folders and elements](#removing-folders-and-elements)
+
+## Organizing with folders
+
+The sidebar navigation displays the folder structure for your Private API Network. API Network Managers can drag elements and sub-folders into different folders. You can add descriptions to folders to describe elements within the folders. You can also add Folder Managers to specific folders. To learn more about managing folders, see [Managing folders and elements](#managing-folders-and-elements).
+
+<img alt="Create new folder in Private Network" src="https://assets.postman.com/postman-docs/v10/private-api-network-organize-folders-v10-2.jpg" width="300px"/>
+
+To create a new folder from the Private API Network view, do the following:
+
+1. Open your [Private API Network](https://go.postman.co/network/private).
+1. Select the create folder icon <img alt="Create folder icon" src="https://assets.postman.com/postman-docs/v10/icon-create-folder-v10.jpg#icon" width="20px"> in the left sidebar.
+
+    > You can also select **Create Folders** on the right from the Private API Network overview page.
+
+1. Give the folder a name.
+1. (Optional) Add Folder Managers to the folder.
+
+    > You can also add Folder Managers to a folder later. To learn more, see [Editing Folder Managers](#editing-folder-managers).
+
+1. (Optional) Add more folders.
+
+    > Select <img alt="Create folder icon" src="https://assets.postman.com/postman-docs/v10/icon-create-folder-v10.jpg#icon" width="20px"> **Add Folder** to add another folder. Select the remove icon <img alt="Remove icon" src="https://assets.postman.com/postman-docs/icon-remove-api-element-v9.jpg#icon" width="16px"> next to a folder to remove it.
+
+1. Select **Review**.
+
+    <img alt="Create folders in Private Network" src="https://assets.postman.com/postman-docs/v10/private-api-network-create-folders-v10.jpg"/>
+
+1. Review your folders and Folder Managers, and then select **Create Folders**.
+
+### Adding sub-folders
+
+To add a sub-folder to an existing folder, do the following:
+
+1. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to a folder, then select **Add folder**.
+
+    > You can also select a folder in the sidebar. Then select <img alt="Create folder icon" src="https://assets.postman.com/postman-docs/v10/icon-create-folder-v10.jpg#icon" width="20px"> **Create Folder** in the upper-right corner.
+
+1. Enter a name for the folder. Optionally, you can add a description for the sub-folder.
+1. Select **Create Folder**.
+
+## Adding elements
+
+API Network Managers can add elements to the Private API Network. Folder Managers can add elements to folders they have permission to manage. Workspace Editors, Collection Editors, and API Editors must [request to add elements](#requesting-to-add-elements) to the Private API Network.
+
+To add an element to the Private API Network, it must be in a team or public workspace. You can't add an element to the Private API Network unless all team members have at least view access to the element. Learn more about team [roles and permissions](/docs/collaborating-in-postman/roles-and-permissions/).
+
+The collections and APIs you add to the Private API Network include the latest changes to these elements.
+
+> When you add a workspace, collection, or API to the [Private API Network](https://go.postman.co/network/private), it's visible to your Postman team, but isn't visible to [partners](/docs/collaborating-in-postman/using-workspaces/partner-workspaces/).
+
+<!-- -->
+
+> You can add elements to the Private API Network from the workbench and with the [Postman API](https://www.postman.com/postman/workspace/postman-public-workspace/folder/12959542-b7c02959-88ca-4e2f-9b68-99538eed4533?ctx=documentation).
+
+### Adding elements in your Private API Network
+
+You can add elements from inside your team's Private API Network. Workspace Editors, Collection Editors, and API Editors can [request to add elements](#requesting-to-add-elements-in-your-private-api-network) from your Private API Network.
+
+To add elements from your Private API Network, do the following:
+
+1. Open your [Private API Network](https://go.postman.co/network/private).
+1. Select the **+** icon in the left sidebar to add elements to the root Home folder. To add elements to a specific folder, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to a folder, then select **Add elements**.
+
+    > You can also select **Add** on the right from the Private API Network overview page, or select **Add To Folder** in the upper-right corner.
+
+1. Select the collections, APIs, and workspaces you want to add. You can search for elements, and filter elements by tags. Learn more about adding tags to [collections](/docs/collections/using-collections/#tagging-a-collection), [APIs](/docs/designing-and-developing-your-api/managing-apis/#tagging-apis), and [workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#tagging-a-workspace).
+
+    If you're adding collections, you can optionally select environments in their workspace to make sure users have access to environment variables. You can also [edit a collection's environments later](#editing-collections).
+
+    You can select **Added elements** in the upper-right corner to show elements already added to the Private API Network. You can select the **Collections** tab and then **Forks** in the upper-right corner to show [forked collections](/docs/collaborating-in-postman/using-version-control/forking-entities/).
+
+    > An API's editor must [publish a version of the API](#publishing-specific-api-versions) before you can add it to your Private API Network.
+
+    <!-- -->
+
+    > You can select an element's name to open it in its workspace in a new tab.
+
+1. Select **Review**.
+
+    <img alt="Add elements to the Private Network" src="https://assets.postman.com/postman-docs/v10/private-api-network-add-elements-v10-3.jpg"/>
+
+1. Review your selections, and then select **Add to Network**.
+
+### Adding a workspace from the workbench
+
+You can add workspaces from the workbench. Workspace Editors must [request to add a workspace](#requesting-to-add-a-workspace-from-the-api-builder).
+
+To add a workspace to the Private API Network from the workbench, do the following:
+
+1. Open the workspace you want to add to the Private API Network.
+1. In the workspace overview, select <img alt="Workspace settings icon" src="https://assets.postman.com/postman-docs/v10/icon-sliders-v10.jpg#icon" width="24px"> **Workspace Settings**.
+1. Select **Add to Network**.
+
+    > If you're a Folder Manager, select **Request to Add**. Then select a folder you have permission to manage.
+
+    <img alt="Add workspace to the Private Network" src="https://assets.postman.com/postman-docs/v10/add-workspace-to-private-api-network-v10.jpg" width="500px"/>
+
+1. (Optional) Select a folder or create one to keep elements organized.
+1. Select **Add workspace**.
+
+### Adding a collection from the workbench
+
+You can add collections from the workbench. Collection Editors must [request to add a collection](#requesting-to-add-a-collection-from-the-api-builder).
+
+To add a collection to the Private API Network from the workbench, do the following:
+
+1. Open the collection you want to add to the Private API Network.
+1. In the collection overview, select **Add to API Network**.
+
+    > If you're a Folder Manager, select **Request to Add**. Then select a folder you have permission to manage.
+
+    <img alt="Add collection to the Private Network" src="https://assets.postman.com/postman-docs/v10/add-collection-to-private-api-network-v10.jpg"/>
+
+1. (Optional) Add a brief summary about the collection.
+1. (Optional) Select **Select Environments** to make sure users have access to environment variables.
+
+    > You can also edit a collection's summary and environments later. To learn more, see [Editing collections](#editing-collections).
+
+1. (Optional) Select a folder or create one to keep elements organized.
+1. Select **Add collection**.
+
+### Adding an API from the workbench
+
+You can add APIs from the workbench. API Editors must [request to add an API](#requesting-to-add-an-api-from-the-api-builder).
+
+> An API's editor must [publish a version of the API](#publishing-specific-api-versions) before you can add it to your Private API Network.
+
+To add an API to the Private API Network from the workbench, do the following:
+
+1. Open the API you want to add to the Private API Network.
+1. In the API overview, select **Add to API Network**.
+
+    > If you're a Folder Manager, select **Request to Add**. Then select a folder you have permission to manage.
+
+    <img alt="Add API to the Private Network" src="https://assets.postman.com/postman-docs/v10/add-api-to-private-api-network-v10.jpg"/>
+
+1. (Optional) Select a folder or create one to keep elements organized.
+1. Select **Add API**.
+
+#### Publishing specific API versions
+
+Publishing a version creates a static representation of your API that consumers can view on the Private API Network. If your API is connected to a Git repository, you need to publish an API version to update your team or public workspace with the latest changes. When you publish a version, the API's definition and collections are synced to the Postman cloud.
+
+Learn more about [publishing an API version](/docs/designing-and-developing-your-api/versioning-an-api/api-versions/).
+
+#### Importing APIs from a code repository
+
+You can make all your existing APIs discoverable on the Private API Network after you import them from a code repository. Learn more about [importing an API](/docs/designing-and-developing-your-api/importing-an-api/).
+
+
+## Managing folders and elements
+
+API Network Managers can manage all folders and elements. Folder Managers can manage folders and elements in folders they have permission to manage. Users with the Editor role for an element can also manage the element.
+
+> You can manage elements within the [Private API Network](#navigating-the-private-api-network) or with the [Postman API](https://www.postman.com/postman/workspace/postman-public-workspace/folder/12959542-b7c02959-88ca-4e2f-9b68-99538eed4533?ctx=documentation).
+
+### Editing collections
+
+You can change a collection's summary and associated environments in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the collection you would like to edit from the network, then select **Edit collection**. Edit the collection, then select **Edit** to save your changes.
+
+> You can also select a collection in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Edit collection**.
+
+### Moving folders and elements
+
+You can move folders and elements in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder or element you would like to move in the network, then select **Move...** or **Move element**. You can move folders and elements to an existing folder or create a new one. Select **Move Folder** or **Move element** to save your changes.
+
+> You can also select a folder or element in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Move...** or **Move element**.
+
+### Renaming folders
+
+You can rename folders in the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder you would like to rename, then select **Rename**. Enter a new name, then press **Enter**.
+
+### Removing folders and elements
+
+You can remove folders and elements from the Private API Network. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder or element you want to remove from the network, then select **Delete** or **Remove**. To confirm that you want to remove an element from the network, select **Remove**.
+
+> You can also select a folder or element in the sidebar. Select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> in the upper-right corner, then select **Delete** or **Remove**.
+
+If you have the Editor role for an element, you can also remove elements in your Private API Network from the workbench. For collections and APIs, open the overview then select **Remove**. For workspaces, open the overview, select <img alt="Workspace settings icon" src="https://assets.postman.com/postman-docs/v10/icon-sliders-v10.jpg#icon" width="24px"> **Workspace Settings**, then select **Remove**. To confirm, select **Remove**.
+
+<img alt="Remove collection in Private API Network from workbench" src="https://assets.postman.com/postman-docs/v10/remove-collection-private-api-network-v10.jpg"/>
+
+After you remove the element, team members won't have access to it through the Private API Network.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
@@ -36,7 +36,9 @@ contextual_links:
 
 > **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
-Users with the Editor role can request to add elements to the Private API Network. An API Network Manager or Folder Manager will review your request and either approve or deny it.
+You can request to add elements to the Private API Network. An API Network Manager or Folder Manager will review your request and either approve or deny it.
+
+Users with the Editor role for an element can request to add elements to the Private API Network.
 
 ## Contents
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
@@ -67,7 +67,7 @@ To request to add elements from your Private API network, do the following:
 
 1. Search for and then select collections, APIs, and workspaces you want to request to add. You can also filter elements by tags. Learn more about adding tags to [collections](/docs/collections/using-collections/#tagging-a-collection), [APIs](/docs/designing-and-developing-your-api/managing-apis/#tagging-apis), and [workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#tagging-a-workspace).
 
-    If you're requesting to add collections, you can optionally select environments in their workspace to make sure users have access to environment variables. You can also [edit a collection's environments later](#editing-collections).
+    If you're requesting to add collections, you can optionally select environments in their workspace to make sure users have access to environment variables. You can also [edit a collection's environments later](/docs/collaborating-in-postman/private-api-network/managing-private-network/#editing-collections).
 
     You can select **Added elements** in the upper-right corner to show elements already added to the Private API Network. You can select the **Collections** tab and then **Forks** in the upper-right corner to show [forked collections](/docs/collaborating-in-postman/using-version-control/forking-entities/).
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
@@ -1,5 +1,5 @@
 ---
-title: "Private API Network requests"
+title: "Requesting to add to the Private API Network"
 updated: 2023-07-07
 contextual_links:
   - type: section
@@ -36,7 +36,7 @@ contextual_links:
 
 > **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
-Users with the [Editor role](/docs/collaborating-in-postman/roles-and-permissions/#workspace-roles) for an element can request to add elements to the Private API Network.
+Users with the Editor role can request to add elements to the Private API Network. An API Network Manager or Folder Manager will review your request and either approve or deny it.
 
 ## Contents
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
@@ -1,6 +1,6 @@
 ---
 title: "Private API Network requests"
-updated: 2023-06-15
+updated: 2023-07-07
 contextual_links:
   - type: section
     name: "Additional resources"

--- a/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
@@ -85,7 +85,7 @@ To request to add elements from your Private API network, do the following:
 
 ### Requesting to add a workspace from the workbench
 
-[Workspace Editors](/docs/collaborating-in-postman/roles-and-permissions/#workspace-roles) can request to add workspaces to your Private API Network from the workbench.
+[Workspace Editors](/docs/collaborating-in-postman/roles-and-permissions/#workspace-roles) can request to add workspaces to your Private API Network from the workbench. API Network Managers and Folder Managers can [add a workspace](/docs/collaborating-in-postman/private-api-network/organizing-private-network/#adding-a-workspace-from-the-workbench).
 
 1. Open the workspace you want to add to the Private API Network.
 1. In the workspace overview, select <img alt="Workspace settings icon" src="https://assets.postman.com/postman-docs/v10/icon-sliders-v10.jpg#icon" width="24px"> **Workspace Settings**.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
@@ -99,7 +99,7 @@ To request to add elements from your Private API network, do the following:
 
 ### Requesting to add a collection from the workbench
 
-[Collection Editors](/docs/collaborating-in-postman/roles-and-permissions/#collection-roles) can request to add collections to your Private API Network from the workbench.
+[Collection Editors](/docs/collaborating-in-postman/roles-and-permissions/#collection-roles) can request to add collections to your Private API Network from the workbench. API Network Managers and Folder Managers can [add a collection](/docs/collaborating-in-postman/private-api-network/organizing-private-network/#adding-a-collection-from-the-workbench).
 
 1. Open the collection you want to add to the Private API Network.
 1. In the collection overview, select **Request to Add**.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
@@ -1,0 +1,154 @@
+---
+title: "Private API Network requests"
+updated: 2023-06-15
+contextual_links:
+  - type: section
+    name: "Additional resources"
+  - type: subtitle
+    name: "Videos"
+  - type: link
+    name: "Private API Network | The Exploratory"
+    url: "https://youtu.be/1SINcytmKsc"
+  - type: link
+    name: "Private API Network"
+    url: "https://youtu.be/cbPT4dMFIDw"
+  - type: link
+    name: "Discovering APIs | Postman Enterprise"
+    url: "https://youtu.be/e1v647ayIBg"
+  - type: subtitle
+    name: "Blog posts"
+  - type: link
+    name: "How to Make Your APIs Available to More Consumers"
+    url: "https://blog.postman.com/how-to-make-your-apis-available-to-more-consumers/"
+  - type: link
+    name: "Introducing an API to manage your Private API Network with more automation"
+    url: "https://blog.postman.com/introducing-api-to-manage-your-private-api-network-with-automation/"
+  - type: link
+    name: "Simplifying API distribution and evaluation with the Private API Network"
+    url: "https://blog.postman.com/simplifying-api-distribution-and-evaluation-with-the-private-api-network/"
+  - type: subtitle
+    name: "Case Studies"
+  - type: link
+    name: "ChargeHub plans to improve internal discovery with a Private API Network"
+    url: "https://www.postman.com/case-studies/chargehub/"
+
+---
+
+> **[The Private API Network is available on Postman Enterprise plans.](https://www.postman.com/pricing)**
+
+Users with the [Editor role](/docs/collaborating-in-postman/roles-and-permissions/#workspace-roles) for an element can request to add elements to the Private API Network.
+
+## Contents
+
+* [Requesting to add elements](#requesting-to-add-elements)
+    * [Requesting to add elements in your Private API Network](#requesting-to-add-elements-in-your-private-api-network)
+    * [Requesting to add a workspace from the workbench](#requesting-to-add-a-workspace-from-the-workbench)
+    * [Requesting to add a collection from the workbench](#requesting-to-add-a-collection-from-the-workbench)
+    * [Requesting to add an API from the workbench](#requesting-to-add-an-api-from-the-workbench)
+* [Reviewing requests to add elements](#reviewing-requests-to-add-elements)
+
+## Requesting to add elements
+
+To request to add an element to the Private API Network, it must be in a team or public workspace. You can't request to add an element to the Private API Network unless all team members have at least view access to the element. Learn more about team [roles and permissions](/docs/collaborating-in-postman/roles-and-permissions/).
+
+When you submit a request, Postman notifies the [API Network Manager or Folder Manager](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) who will review your request and either approve or deny it. Postman will notify you of the API Network Manager or Folder Manager's decision. If they deny your request, the notification will include a comment with their reason.
+
+> When you add a workspace, collection, or API to the [Private API Network](https://go.postman.co/network/private), it's visible to your Postman team, but isn't visible to [partners](/docs/collaborating-in-postman/using-workspaces/partner-workspaces/).
+
+### Requesting to add elements in your Private API Network
+
+Editors of an element can request to add elements from inside your team's Private API Network.
+
+To request to add elements from your Private API network, do the following:
+
+1. Open your [Private API Network](https://go.postman.co/network/private).
+1. Select the **+** icon in the left sidebar to request to add elements to the root Home folder. To request to add elements to a specific folder, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the folder, then select **Request to add elements**.
+
+    > You can also select **Add** on the right from the Private API Network overview page, or select **Add To Folder** in the upper-right corner.
+
+1. Search for and then select collections, APIs, and workspaces you want to request to add. You can also filter elements by tags. Learn more about adding tags to [collections](/docs/collections/using-collections/#tagging-a-collection), [APIs](/docs/designing-and-developing-your-api/managing-apis/#tagging-apis), and [workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#tagging-a-workspace).
+
+    If you're requesting to add collections, you can optionally select environments in their workspace to make sure users have access to environment variables. You can also [edit a collection's environments later](#editing-collections).
+
+    You can select **Added elements** in the upper-right corner to show elements already added to the Private API Network. You can select the **Collections** tab and then **Forks** in the upper-right corner to show [forked collections](/docs/collaborating-in-postman/using-version-control/forking-entities/).
+
+    > An API's editor must [publish a version of the API](#publishing-specific-api-versions) before you can add it to your Private API Network.
+
+    <!-- -->
+
+    > You can select an element's name to open it in its workspace in a new tab.
+
+1. Select **Review**.
+
+    <img alt="Add elements to the Private Network" src="https://assets.postman.com/postman-docs/v10/private-api-network-add-elements-v10-3.jpg"/>
+
+1. Review your selections, and then select **Request to add**.
+
+### Requesting to add a workspace from the workbench
+
+[Workspace Editors](/docs/collaborating-in-postman/roles-and-permissions/#workspace-roles) can request to add workspaces to your Private API Network from the workbench.
+
+1. Open the workspace you want to add to the Private API Network.
+1. In the workspace overview, select <img alt="Workspace settings icon" src="https://assets.postman.com/postman-docs/v10/icon-sliders-v10.jpg#icon" width="24px"> **Workspace Settings**.
+1. Select **Request to Add**.
+
+    <img alt="Request to add workspace to the Private Network" src="https://assets.postman.com/postman-docs/v10/request-to-add-workspace-to-private-api-network-v10-2.jpg" width="500px"/>
+
+1. (Optional) Select a folder or create one to keep elements organized.
+1. (Optional) Select **Add comment** to add a note for the API Network Manager or Folder Manager.
+1. Select **Request workspace**.
+
+### Requesting to add a collection from the workbench
+
+[Collection Editors](/docs/collaborating-in-postman/roles-and-permissions/#collection-roles) can request to add collections to your Private API Network from the workbench.
+
+1. Open the collection you want to add to the Private API Network.
+1. In the collection overview, select **Request to Add**.
+
+    <img alt="Request to add collection to the Private Network" src="https://assets.postman.com/postman-docs/v10/request-to-add-collection-to-private-api-network-v10-2.jpg"/>
+
+1. (Optional) Add a brief summary about the collection.
+1. (Optional) Select **Select Environments** to make sure users have access to environment variables.
+
+    > You can also edit a collection's summary and environments later. To learn more, see [Editing collections](#editing-collections).
+
+1. (Optional) Select a folder or create one to keep elements organized.
+1. (Optional) Select **Add comment** to add a note for the API Network Manager or Folder Manager.
+1. Select **Request collection**.
+
+### Requesting to add an API from the workbench
+
+[API Editors](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) can request to add APIs to your Private API Network from the workbench.
+
+> An API's editor must [publish a version of the API](#publishing-specific-api-versions) before you can add it to your Private API Network.
+
+1. Open the API you want to add to the Private API Network.
+1. In the API overview, select **Request to Add**.
+
+    <img alt="Request to add API to the Private Network" src="https://assets.postman.com/postman-docs/v10/request-to-add-api-to-private-api-network-v10-2.jpg"/>
+
+1. (Optional) Select a folder or create one to keep elements organized.
+1. (Optional) Select **Add comment** to add a note for the API Network Manager or Folder Manager.
+1. Select **Request API**.
+
+## Reviewing requests to add elements
+
+API Network Managers can review requests to add elements to the Private API Network. Folder Managers can review requests to add elements to folders they have permission to manage.
+
+When an Editor requests to add an element to your team's Private API Network, Postman will send you an email and an in-app notification. For the list of all the pending requests, open the [Private API Network](https://go.postman.co/network/private) and select the pending requests icon <img alt="Pending requests icon" src="https://assets.postman.com/postman-docs/v10/icon-pending-request-v10.jpg#icon" width="22px"> in the left sidebar.
+
+Pending requests include the element type, the user who submitted the request, the date they submitted it on, a link to view the element in its workspace, and an optional note from the requesting user.
+
+<img alt="Approve or deny a request" src="https://assets.postman.com/postman-docs/v10/private-api-network-pending-requests-v10-2.jpg"/>
+
+To approve a request, do the following:
+
+1. Select **Approve**.
+1. (Optional) Select a folder or create one to keep elements organized.
+1. Select **Approve Request**.
+
+To deny a request, do the following:
+
+1. Select **Deny**.
+1. Write a note to the Editor who submitted the request explaining why you are denying their request.
+1. Select **Deny Request**.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
@@ -109,7 +109,7 @@ To request to add elements from your Private API network, do the following:
 1. (Optional) Add a brief summary about the collection.
 1. (Optional) Select **Select Environments** to make sure users have access to environment variables.
 
-    > You can also edit a collection's summary and environments later. To learn more, see [Editing collections](#editing-collections).
+    > You can also edit a collection's summary and environments later. To learn more, see [Editing collections](/docs/collaborating-in-postman/private-api-network/managing-private-network/#editing-collections).
 
 1. (Optional) Select a folder or create one to keep elements organized.
 1. (Optional) Select **Add comment** to add a note for the API Network Manager or Folder Manager.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
@@ -117,7 +117,7 @@ To request to add elements from your Private API network, do the following:
 
 ### Requesting to add an API from the workbench
 
-[API Editors](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) can request to add APIs to your Private API Network from the workbench.
+[API Editors](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) can request to add APIs to your Private API Network from the workbench. API Network Managers and Folder Managers can [add an API](/docs/collaborating-in-postman/private-api-network/organizing-private-network/#adding-an-api-from-the-workbench).
 
 > An API's editor must [publish a version of the API](#publishing-specific-api-versions) before you can add it to your Private API Network.
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/private-network-requests.md
@@ -45,7 +45,6 @@ Users with the [Editor role](/docs/collaborating-in-postman/roles-and-permission
     * [Requesting to add a workspace from the workbench](#requesting-to-add-a-workspace-from-the-workbench)
     * [Requesting to add a collection from the workbench](#requesting-to-add-a-collection-from-the-workbench)
     * [Requesting to add an API from the workbench](#requesting-to-add-an-api-from-the-workbench)
-* [Reviewing requests to add elements](#reviewing-requests-to-add-elements)
 
 ## Requesting to add elements
 
@@ -130,25 +129,3 @@ To request to add elements from your Private API network, do the following:
 1. (Optional) Select a folder or create one to keep elements organized.
 1. (Optional) Select **Add comment** to add a note for the API Network Manager or Folder Manager.
 1. Select **Request API**.
-
-## Reviewing requests to add elements
-
-API Network Managers can review requests to add elements to the Private API Network. Folder Managers can review requests to add elements to folders they have permission to manage.
-
-When an Editor requests to add an element to your team's Private API Network, Postman will send you an email and an in-app notification. For the list of all the pending requests, open the [Private API Network](https://go.postman.co/network/private) and select the pending requests icon <img alt="Pending requests icon" src="https://assets.postman.com/postman-docs/v10/icon-pending-request-v10.jpg#icon" width="22px"> in the left sidebar.
-
-Pending requests include the element type, the user who submitted the request, the date they submitted it on, a link to view the element in its workspace, and an optional note from the requesting user.
-
-<img alt="Approve or deny a request" src="https://assets.postman.com/postman-docs/v10/private-api-network-pending-requests-v10-2.jpg"/>
-
-To approve a request, do the following:
-
-1. Select **Approve**.
-1. (Optional) Select a folder or create one to keep elements organized.
-1. Select **Approve Request**.
-
-To deny a request, do the following:
-
-1. Select **Deny**.
-1. Write a note to the Editor who submitted the request explaining why you are denying their request.
-1. Select **Deny Request**.

--- a/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
+++ b/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
@@ -276,7 +276,7 @@ You can [assign](/docs/administration/managing-your-team/managing-your-team/) ne
 
 * **API Network Manager** - Manages a team's Private API Network, including adding elements and reviewing requests to add them.
 
-You can also [assign](/docs/collaborating-in-postman/adding-private-network/#editing-folder-managers) network roles at the folder level:
+You can also [assign](/docs/collaborating-in-postman/private-api-network/organizing-private-network/#editing-folder-managers) network roles at the folder level:
 
 * **Folder Manager** - Manages specific folders and the elements in them in a team's Private API Network. Team members with this role can perform all actions that API Network Manager role can perform but only in folders they have permission to manage.
 

--- a/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
+++ b/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
@@ -91,7 +91,7 @@ Team roles offer high-level access control:
 
 There are additional specialized roles for [Enterprise](https://www.postman.com/pricing) teams:
 
-* **API Network Manager** - Manages a team's [Private API Network](/docs/collaborating-in-postman/adding-private-network/). To learn more, see [Network roles](#network-roles).
+* **API Network Manager** - Manages a team's [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/). To learn more, see [Network roles](#network-roles).
 * **API Governance Manager** - Manages [API governance](/docs/api-governance/api-governance-overview/) within a team, including governance [rules](/docs/api-governance/configurable-rules/configuring-api-governance-rules/), [functions](/docs/api-governance/configurable-rules/configuring-custom-governance-functions/), and [workspace groups](/docs/api-governance/configurable-rules/configuring-api-governance-rules/#turning-configured-rules-on-and-off).
 
 &ast; On Postman Basic and Free plans, any developer can change visibility of workspaces.
@@ -270,7 +270,7 @@ All partners are assigned Workspace Editor or Viewer roles when invited to a Par
 
 > **[Network roles are available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
-Network roles related to the [Private API Network](/docs/collaborating-in-postman/adding-private-network/) are applied at the team and folder level.
+Network roles related to the [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/) are applied at the team and folder level.
 
 You can [assign](/docs/administration/managing-your-team/managing-your-team/) network roles at the team level:
 

--- a/src/pages/docs/collaborating-in-postman/using-workspaces/managing-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/managing-workspaces.md
@@ -143,7 +143,7 @@ You can assign a [workspace role](/docs/collaborating-in-postman/roles-and-permi
 
 ### Adding workspaces to the Private API Network
 
-You can also share workspaces with your teammates by adding them to your team's [Private API Network](/docs/collaborating-in-postman/adding-private-network/). To learn more, see [Adding workspaces](/docs/collaborating-in-postman/adding-private-network/#adding-workspaces).
+You can also share workspaces with your teammates by adding them to your team's [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/). To learn more, see [Requesting to add a workspace from the workbench](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-a-workspace-from-the-workbench).
 
 ## Managing workspace roles
 
@@ -170,7 +170,7 @@ You can add tags to workspaces, enabling you to organize and search for workspac
 
 Once you add tags to the workspace, you can select a tag to open search results associated with the tag in a new tab.
 
-To learn more about searching using tag names in Postman, see [Search Postman](/docs/getting-started/navigating-postman/#search-postman). You can also search using tag names in the Private API Network when searching [elements in the network](/docs/collaborating-in-postman/adding-private-network/#searching-filtering-and-sorting), [elements to add to the network](/docs/collaborating-in-postman/adding-private-network/#adding-elements-in-your-private-api-network), and [elements to request to add to the network](/docs/collaborating-in-postman/adding-private-network/#requesting-to-add-elements-in-your-private-api-network).
+To learn more about searching using tag names in Postman, see [Search Postman](/docs/getting-started/navigating-postman/#search-postman). You can also search using tag names in the Private API Network when searching [elements in the network](/docs/collaborating-in-postman/private-api-network/adding-private-network/#searching-filtering-and-sorting), [elements to add to the network](/docs/collaborating-in-postman/private-api-network/organizing-private-network/#adding-elements-in-your-private-api-network), and [elements to request to add to the network](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-elements-in-your-private-api-network).
 
 To add tags to a workspace, do the following:
 

--- a/src/pages/docs/collections/using-collections.md
+++ b/src/pages/docs/collections/using-collections.md
@@ -187,7 +187,7 @@ To share a collection with other users, you can:
 * Invite others to collaborate by selecting the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the collection name, then selecting **Share**. Learn more about [sharing elements in Postman](/docs/collaborating-in-postman/sharing/#sharing-postman-entities).
 * Allow external users who aren't in your Postman team to view collections by selecting the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the collection name, selecting **Share**, then turning on the toggle next to **Allow Guests with the link to join your team and view collection**. Learn more about [allowing external users to view collections](/docs/collaborating-in-postman/sharing/#allowing-external-users-to-view-collections).
 * Move the collection to a shared workspace by selecting the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> next to the collection name, then selecting **Move**. Learn more about [moving Postman elements](/docs/collaborating-in-postman/working-with-your-team/collaborating-in-team-workspaces/#moving-elements-to-team-workspaces).
-* ([Enterprise](https://www.postman.com/pricing/)) Add the collection to your team's [Private API Network](/docs/collaborating-in-postman/adding-private-network/#adding-collections).
+* ([Enterprise](https://www.postman.com/pricing/)) Add the collection to your team's [Private API Network](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-a-collection-from-the-workbench).
 
 ### Tagging a collection
 
@@ -197,7 +197,7 @@ You can add tags to collections, enabling you to organize and search for collect
 
 Once you add tags to the collection, you can select a tag to open search results associated with the tag in a new tab.
 
-To learn more about searching using tag names in Postman, see [Search Postman](/docs/getting-started/navigating-postman/#search-postman). You can also search using tag names in the Private API Network when searching [elements in the network](/docs/collaborating-in-postman/adding-private-network/#searching-filtering-and-sorting), [elements to add to the network](/docs/collaborating-in-postman/adding-private-network/#adding-elements-in-your-private-api-network), and [elements to request to add to the network](/docs/collaborating-in-postman/adding-private-network/#requesting-to-add-elements-in-your-private-api-network).
+To learn more about searching using tag names in Postman, see [Search Postman](/docs/getting-started/navigating-postman/#search-postman). You can also search using tag names in the Private API Network when searching [elements in the network](/docs/collaborating-in-postman/private-api-network/adding-private-network/#searching-filtering-and-sorting), [elements to add to the network](/docs/collaborating-in-postman/private-api-network/organizing-private-network/#adding-elements-in-your-private-api-network), and [elements to request to add to the network](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-elements-in-your-private-api-network).
 
 To add tags to a collection, do the following:
 

--- a/src/pages/docs/designing-and-developing-your-api/managing-apis.md
+++ b/src/pages/docs/designing-and-developing-your-api/managing-apis.md
@@ -65,7 +65,7 @@ You can add tags to APIs, enabling you to organize and search for APIs using sha
 
 Once you add tags to the API, you can select a tag to open search results associated with the tag in a new tab.
 
-To learn more about searching using tag names in Postman, see [Search Postman](/docs/getting-started/navigating-postman/#search-postman). You can also search using tag names in the Private API Network when searching [elements in the network](/docs/collaborating-in-postman/adding-private-network/#searching-filtering-and-sorting), [elements to add to the network](/docs/collaborating-in-postman/adding-private-network/#adding-elements-in-your-private-api-network), and [elements to request to add to the network](/docs/collaborating-in-postman/adding-private-network/#requesting-to-add-elements-in-your-private-api-network).
+To learn more about searching using tag names in Postman, see [Search Postman](/docs/getting-started/navigating-postman/#search-postman). You can also search using tag names in the Private API Network when searching [elements in the network](/docs/collaborating-in-postman/private-api-network/adding-private-network/#searching-filtering-and-sorting), [elements to add to the network](/docs/collaborating-in-postman/private-api-network/organizing-private-network/#adding-elements-in-your-private-api-network), and [elements to request to add to the network](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-elements-in-your-private-api-network).
 
 To add tags to an API, do the following:
 

--- a/src/pages/docs/designing-and-developing-your-api/versioning-an-api/api-versions.md
+++ b/src/pages/docs/designing-and-developing-your-api/versioning-an-api/api-versions.md
@@ -16,7 +16,7 @@ contextual_links:
     url: "https://blog.postman.com/how-to-make-your-apis-available-to-more-consumers/"
 ---
 
-When you're ready to share the latest changes to your API with consumers, you can publish a _version_. Publishing a version creates a static representation of your API's current state. Consumers can view the API version in your workspace. You can also choose to add the version to your [Private API Network](/docs/collaborating-in-postman/adding-private-network/).
+When you're ready to share the latest changes to your API with consumers, you can publish a _version_. Publishing a version creates a static representation of your API's current state. Consumers can view the API version in your workspace. You can also choose to add the version to your [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/).
 
 You can select the elements to publish with your API, such as the definition and collections, to help consumers test and evaluate your API. After you publish a version, you can keep working on your API and make more changes. Your consumers will continue to see the published version of your API until you publish a new version.
 
@@ -54,7 +54,7 @@ To publish an API version, do the following:
 
     <img alt="Publishing an API version" src="https://assets.postman.com/postman-docs/v10/api-builder-publish-v10-3.jpg" width="442px" />
 
-> If you aren't assigned the API Network Manager or Folder Manager role, you can [request to add](/docs/collaborating-in-postman/adding-private-network/#requesting-to-add-elements) the published API to the Private API Network. Your team's API Network Manager or Folder Manager will review the request.
+> If you aren't assigned the API Network Manager or Folder Manager role, you can [request to add](/docs/collaborating-in-postman/private-api-network/private-network-requests/#requesting-to-add-elements) the published API to the Private API Network. Your team's API Network Manager or Folder Manager will review the request.
 
 ## Editing and deleting an API version
 
@@ -79,4 +79,4 @@ To view an API version on the Private API Network, do the following:
 1. Select **API Network** in the Postman header, then select **Private API Network**.
 1. Search or browse for an API, then select an API to view the available versions.
 
-> Learn more about viewing APIs on the [Private API Network](/docs/collaborating-in-postman/adding-private-network/).
+> Learn more about viewing APIs on the [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/).

--- a/src/pages/docs/getting-started/navigating-postman.md
+++ b/src/pages/docs/getting-started/navigating-postman.md
@@ -52,7 +52,7 @@ The header enables you to create workspaces, access reports, explore the public 
 * **&#8592; &#8594;** - Navigate backward and forward through pages you've visited within Postman. _(Postman desktop app only)_
 * **Home** - Go to your personal home page, which includes your recently visited workspaces, and links to resources for [your team](/docs/collaborating-in-postman/working-with-your-team/collaboration-overview/) if applicable.
 * **Workspaces** - Search for workspaces, view your recently visited workspaces, or [create a new workspace](/docs/getting-started/creating-your-first-workspace/).
-* **API Network** - Explore the [Public API Network](/docs/getting-started/exploring-public-api-network/) and access your team's [Private API Network](/docs/collaborating-in-postman/adding-private-network/).
+* **API Network** - Explore the [Public API Network](/docs/getting-started/exploring-public-api-network/) and access your team's [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/).
 * **Explore** - Browse public APIs, teams, workspaces, and collections on Postman.
 
 <img alt="Expanded view of the Search Postman field" src="https://assets.postman.com/postman-docs/v10/navigating-postman-search-v10.jpg">

--- a/src/pages/docs/reports/api-gov-reports.md
+++ b/src/pages/docs/reports/api-gov-reports.md
@@ -17,7 +17,7 @@ The **API Governance** report dashboard provides metrics relevant to your team's
 * [Public APIs](#public-apis)
 * [Private Network APIs](#private-network-apis)
 
-You can use these reports to answer API governance questions about APIs owned by your team that are part of the [Public API Network](/docs/getting-started/exploring-public-api-network/) and your team's [Private API Network](/docs/collaborating-in-postman/adding-private-network/).
+You can use these reports to answer API governance questions about APIs owned by your team that are part of the [Public API Network](/docs/getting-started/exploring-public-api-network/) and your team's [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/).
 
 ## API Governance
 
@@ -45,7 +45,7 @@ For specific details about the APIs in the **Current API landscape** and **Top 3
 
 ## Private Network APIs
 
-The **Private Network APIs** report provides the following information for APIs in your team's [Private API Network](/docs/collaborating-in-postman/adding-private-network/) over the past 30 days:
+The **Private Network APIs** report provides the following information for APIs in your team's [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/) over the past 30 days:
 
 * **Conformance** - The number of APIs in your team's Private API Network that don't have any API Governance rule violations.
 * **Non-conformance** - The average number of API Governance rule violations per API in your team's Private API Network.

--- a/src/pages/docs/reports/api-security-reports.md
+++ b/src/pages/docs/reports/api-security-reports.md
@@ -17,7 +17,7 @@ The **API Security** report dashboard provides metrics relevant to the [API Secu
 * [Public APIs](#public-apis)
 * [Private Network APIs](#private-network-apis)
 
-You can use these reports to answer questions about the security posture of APIs owned by your team that are part of the [Public API Network](/docs/getting-started/exploring-public-api-network/) and your team's [Private API Network](/docs/collaborating-in-postman/adding-private-network/).
+You can use these reports to answer questions about the security posture of APIs owned by your team that are part of the [Public API Network](/docs/getting-started/exploring-public-api-network/) and your team's [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/).
 
 ## API Security
 
@@ -45,7 +45,7 @@ For specific details about the APIs in the **Current API landscape** and **Top 3
 
 ## Private Network APIs
 
-The **Private Network APIs** report provides the following information for APIs in your team's [Private API Network](/docs/collaborating-in-postman/adding-private-network/) over the past 30 days:
+The **Private Network APIs** report provides the following information for APIs in your team's [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/) over the past 30 days:
 
 * **Conformance** - The number of APIs in your team's Private API Network that don't have any API Security rule violations.
 * **Non-conformance** - The average number of API Security rule violations per API in your team's Private API Network.

--- a/src/pages/docs/reports/content-activity-reports.md
+++ b/src/pages/docs/reports/content-activity-reports.md
@@ -133,7 +133,7 @@ The **View report by API** dashboard provides a report for each individual API. 
 
 ## Private Network APIs
 
-The **Private Network APIs** dashboard provides metrics about APIs in your [Private API Network](/docs/collaborating-in-postman/adding-private-network/), including an overview of your total APIs, a visualization of APIs categorized by schema type, and a separate view of your APIs with and without mocks, monitors, tests, and documentation.
+The **Private Network APIs** dashboard provides metrics about APIs in your [Private API Network](/docs/collaborating-in-postman/private-api-network/adding-private-network/), including an overview of your total APIs, a visualization of APIs categorized by schema type, and a separate view of your APIs with and without mocks, monitors, tests, and documentation.
 
 The **Private Network APIs** report provides the following information:
 


### PR DESCRIPTION
This PR reorganizes the **Your Private API Network** document by splitting it up into separate pages:

![Screenshot 2023-07-07 at 1 45 23 PM](https://github.com/postmanlabs/postman-docs/assets/113702138/4e4c9797-0b2e-4502-ac71-59d9edfa723e)

For the most part I just took the existing content and moved it to the new articles.

The **Organizing your Private API Network** article is the bulkiest of these documents, but I didn't think that the information contained needed further splitting. I tried to keep the articles contained as follows:

- **Organizing your Private API Network** — Adding, editing, and managing folders and elements.
- **Managing your Private API Network** — Managing user permissions, reporting.
- **Private API Network requests** — Requests (making and managing) to the Private API Network.

For the naming of these articles, I borrowed a little from the **Sharing to the Public API Network** section:

<img width="308" alt="image" src="https://github.com/postmanlabs/postman-docs/assets/113702138/672e37af-7d36-4e5b-b884-1f14af9ed96f">

## Notable updates

While reviewing the docs, I noticed and fixed some things:

- In the **Organizing your Private API Network** article, the links in the “Adding an API/collection/workspace from the workbench” were referencing the wrong info (they don't work in the live article because they all point at `/adding-private-network/#requesting-to-add-elements-in-your-private-api-network`).
- The "Searching, filtering, and sorting" section was a little confusing in its previous state, so I rearranged and revised some of the information (and rearranged images) presented in this section (here's [the link](https://learning.postman.com/docs/collaborating-in-postman/adding-private-network/#searching-filtering-and-sorting) to the live article for context).
- I moved some of the callout info inline on some steps — for example, in the "Organizing with folders" section in the **Organizing your Private API Network** article (for context, [here's the live article](https://learning.postman.com/docs/collaborating-in-postman/adding-private-network/#organizing-with-folders)). It felt a little cluttered up and that info that works just as easily inline with the other instructions.