### PR TITLE
[TW-684] Add "Viewing collection run details" sections to all CI/CD integrations

### DIFF
--- a/src/pages/docs/integrations/available-integrations/ci-integrations/azure-pipelines.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/azure-pipelines.md
@@ -72,8 +72,6 @@ Using the Postman CLI, you can run Postman collections with your API tests as pa
 
 To view details for collections that were run as part of a build, first [configure the Postman CLI for Azure Pipelines](#configuring-the-postman-cli-for-azure-pipelines) and then start a new build in Azure DevOps. To learn more about starting builds, see [the Azure Pipelines documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops). After the build is complete, use the arrows to expand a build and expand **Collection Runs**. Then expand a collection to view details about a collection run.
 
-<img alt="View Azure Pipelines collection runs" src="https://assets.postman.com/postman-docs/v10/azure-collection-runs-v10.jpg">
-
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/collections/running-collections/intro-to-collection-runs/).
 
 ## Viewing API Governance and API Security rule violations

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/bitbucket-pipelines.md
@@ -49,8 +49,6 @@ Using the Postman CLI, you can run Postman collections with your API tests as pa
 
 To view details for collections that were run as part of a build, first [configure the Postman CLI for Bitbucket Pipelines](#configuring-the-postman-cli-for-bitbucket-pipelines) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand a collection to view details about a collection run.
 
-<img alt="View collection runs" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
-
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/collections/running-collections/intro-to-collection-runs/).
 
 ## Viewing API Governance and API Security rule violations

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/circleci.md
@@ -54,7 +54,15 @@ Select **View All Builds** to view the full list of build jobs. From here you ca
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px">.
 
-<img alt="View all CircleCI builds" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+<img alt="View all CircleCI builds" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-16-2.jpg">
+
+## Viewing collection run details
+
+Using the Postman CLI, you can run Postman collections with your API tests as part of a CircleCI pipeline.
+
+To view details for collections that were run as part of a build, first [configure the Postman CLI for CircleCI](#configuring-the-postman-cli-for-circleci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand a collection to view details about a collection run.
+
+> Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/collections/running-collections/intro-to-collection-runs/).
 
 ## Viewing API Governance and API Security rule violations
 
@@ -62,7 +70,7 @@ Using the Postman CLI, you can enforce [Postman API Governance and API Security 
 
 To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for CircleCI](#configuring-the-postman-cli-for-circleci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
-<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-v10.jpg">
+<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-v10-16.jpg">
 
 ## Configuring the Postman CLI for CircleCI
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/github-actions.md
@@ -63,8 +63,6 @@ Using the Postman CLI, you can run Postman collections with your API tests as pa
 
 To view details for collections that were run as part of a build, first [configure the Postman CLI for GitHub](#configuring-the-postman-cli-for-github-actions) and then start a new build in GitHub. To learn more about starting builds, see [the GitHub Actions documentation](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow). After the build is complete, use the arrows to expand a build and expand a collection to view details about a collection run.
 
-<img alt="View GitHub Actions collection runs" src="https://assets.postman.com/postman-docs/v10/github-actions-collection-runs-v10.jpg">
-
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/collections/running-collections/intro-to-collection-runs/).
 
 ## Viewing API Governance and API Security rule violations

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/gitlab-ci.md
@@ -70,8 +70,6 @@ Using the Postman CLI, you can run Postman collections with your API tests as pa
 
 To view details for collections that were run as part of a build, first [configure the Postman CLI for GitLab](#configuring-the-postman-cli-for-gitlab-cicd) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand a collection to view details about a collection run.
 
-<img alt="View collection runs" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
-
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/collections/running-collections/intro-to-collection-runs/).
 
 ## Viewing API Governance and API Security rule violations

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/jenkins.md
@@ -69,8 +69,6 @@ Using the Postman CLI, you can run Postman collections with your API tests as pa
 
 To view details for collections that were run as part of a build, first [configure the Postman CLI for Jenkins](#configuring-the-postman-cli-for-jenkins) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand a collection to view details about a collection run.
 
-<img alt="View collection runs" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
-
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/collections/running-collections/intro-to-collection-runs/).
 
 ## Viewing API Governance and API Security rule violations

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
@@ -55,7 +55,7 @@ Select **View All Builds** to view the full list of build jobs. From here you ca
 
 Using the Postman CLI, you can run Postman collections with your API tests as part of a Travis CI pipeline.
 
-To view details for collections that were run as part of a build, first [configure the Postman CLI for Travis CI](#configuring-the-postman-cli-for-travisci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand a collection to view details about a collection run.
+To view details for collections that were run as part of a build, first [configure the Postman CLI for Travis CI](#configuring-the-postman-cli-for-travis-ci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand a collection to view details about a collection run.
 
 > Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/collections/running-collections/intro-to-collection-runs/).
 

--- a/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
+++ b/src/pages/docs/integrations/available-integrations/ci-integrations/travis-ci.md
@@ -49,7 +49,15 @@ Select **View All Builds** to view the full list of build jobs. From here you ca
 * To get the latest build status information, select <img alt="Refresh icon" src="https://assets.postman.com/postman-docs/icon-refresh-v9-5.jpg#icon" width="14px"> **Refresh**.
 * To edit or delete the integration, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px">.
 
-<img alt="View all Travis CI builds" src="https://assets.postman.com/postman-docs/v10/collection-runs-v10-2.jpg">
+<img alt="View all Travis CI builds" src="https://assets.postman.com/postman-docs/v10/collection-runs-travisci-v10-16.jpg">
+
+## Viewing collection run details
+
+Using the Postman CLI, you can run Postman collections with your API tests as part of a Travis CI pipeline.
+
+To view details for collections that were run as part of a build, first [configure the Postman CLI for Travis CI](#configuring-the-postman-cli-for-travisci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand a collection to view details about a collection run.
+
+> Select **View Report** to view a collection run report in the Postman **History**. Learn more about using the [Collection Runner](/docs/collections/running-collections/intro-to-collection-runs/).
 
 ## Viewing API Governance and API Security rule violations
 
@@ -57,7 +65,7 @@ Using the Postman CLI, you can enforce [Postman API Governance and API Security 
 
 To view the results of API Governance and API Security checks that ran as part of the build, first [configure the Postman CLI for Travis CI](#configuring-the-postman-cli-for-travis-ci) and then [start a new build](#viewing-build-status). After the build is complete, use the arrows to expand a build and expand an API definition to view any rule violations.
 
-<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-v10.jpg">
+<img alt="View API Governance and API Security results" src="https://assets.postman.com/postman-docs/v10/api-governance-and-security-results-travisci-v10-16.jpg">
 
 ## Configuring the Postman CLI for Travis CI
 


### PR DESCRIPTION
Adds a step about viewing collection runs/updates screenshots based on CircleCI/Travis CI demos. Removes duplicate screenshots.

[Preview](https://tw-684-collection-run.learning.postman-beta.com/docs/integrations/ci-integrations/)