### PR TITLE
Bugfix: Add environment check to hide develop mode blurb in production

### DIFF
--- a/src/components/ContextualLinks/ContextualLinks.jsx
+++ b/src/components/ContextualLinks/ContextualLinks.jsx
@@ -81,7 +81,7 @@ const ContextualLinks = ({ links }) => (
           );
         }
         if (item.type === 'dynamic_blog' && item.blog_tag) {
-          if (Object.keys(recentBlogPosts).length === 0) {
+          if (Object.keys(recentBlogPosts).length === 0 && process.env.NODE_ENV === "development") {
             // If recentBlogPosts.length === 0, then either there is no .env.development,
             // it has a bad blog url, or the endpoint returned something bad
             return (


### PR DESCRIPTION
https://update-blog-tag-logic.learning.postman-beta.com/docs/publishing-your-api/documenting-your-api/

This adds a node environment check to prevent the develop mode banner from displaying if blog tags are 0. 

Develop mode
<img width="930" alt="Screenshot 2023-07-24 at 4 05 25 PM" src="https://github.com/postmanlabs/postman-docs/assets/42796716/6c254810-983c-4158-b590-0552b700e71d">

Production
<img width="927" alt="Screenshot 2023-07-24 at 4 05 11 PM" src="https://github.com/postmanlabs/postman-docs/assets/42796716/715ff19e-2ff0-4868-8cad-f0416fc66b6c">

