### PR TITLE
[TW-1234] Workspace template fixes

### DIFF
--- a/src/pages/docs/collaborating-in-postman/using-workspaces/creating-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/creating-workspaces.md
@@ -54,7 +54,7 @@ _Workspace as an element_ represents a whole container where being an Admin give
 
     <img alt="Create new workspace" src="https://assets.postman.com/postman-docs/v10/workspace-switcher-v10.14.jpg" width="300px"/>
 
-1. ([Free, Basic, and Professional plans only](https://www.postman.com/pricing)) You can use [workspace templates](#creating-workspaces-with-a-template) to help you set up a new workspace. Select a workspace template to populate the workspace with helpful information and sample collections, or select **Blank workspace** to create an empty workspace. Then select **Next**.
+1. You can use [workspace templates](#creating-workspaces-with-a-template) to help you set up a new workspace. Select a workspace template to populate the workspace with helpful information and sample collections, or select **Blank workspace** to create an empty workspace. Then select **Next**.
 
     > You can also apply a workspace template to a newly created workspace. To learn more, see [Creating workspaces with a template](#creating-workspaces-with-a-template).
 
@@ -64,7 +64,7 @@ _Workspace as an element_ represents a whole container where being an Admin give
 
     <img alt="Create new workspace" src="https://assets.postman.com/postman-docs/v10/create-workspace-v10-2.jpg" width="400px"/>
 
-1. Select **Create** or **Create Workspace** and Postman will open your new workspace. You can add elements to the workspace. Select __Invite__ in the Postman header to add other users to the workspace.
+1. Select **Create** and Postman will open your new workspace. You can add elements to the workspace. Select __Invite__ in the Postman header to add other users to the workspace.
 
 To create a new workspace, you can also select __New__ in the sidebar, then select __Workspace__ and follow the same steps.
 
@@ -85,7 +85,7 @@ You can use workspace templates to help you set up a new workspace. Workspace te
 * Incident Response
 * Infrastructure
 
-When you apply a workspace template, it will populate the workspace description with an introduction and information to help you get started. Each workspace template also includes sample collections that you can use and change as needed. To use a template, [create a new workspace](#creating-a-new-workspace) ([Free, Basic, and Professional plans only](https://www.postman.com/pricing)) or open a newly created workspace.
+When you apply a workspace template, it will populate the workspace description with an introduction and information to help you get started. Each workspace template also includes sample collections that you can use and change as needed. To use a template, [create a new workspace](#creating-a-new-workspace) or open a newly created workspace.
 
 To use a template in a newly created workspace, do the following:
 

--- a/src/pages/docs/collaborating-in-postman/using-workspaces/public-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/public-workspaces.md
@@ -72,7 +72,7 @@ To create a public workspace, do the following:
 
     <img alt="Workspace menu" src="https://assets.postman.com/postman-docs/v10/workspace-switcher-v10.jpg" width="300px"/>
 
-1. ([Free, Basic, and Professional plans only](https://www.postman.com/pricing)) You can use [workspace templates](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/#creating-workspaces-with-a-template) to help you set up a new workspace. Select a workspace template to populate the workspace with helpful information and sample collections, or select **Blank workspace** to create an empty workspace. Then select **Next**.
+1. You can use [workspace templates](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/#creating-workspaces-with-a-template) to help you set up a new workspace. Select a workspace template to populate the workspace with helpful information and sample collections, or select **Blank workspace** to create an empty workspace. Then select **Next**.
 
     > You can also apply a workspace template to a newly created workspace. To learn more, see [Creating workspaces with a template](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/#creating-workspaces-with-a-template).
 
@@ -82,11 +82,9 @@ To create a public workspace, do the following:
     > Within a team, you can't have two public workspaces with the same name.
 1. Under **Visibility**, select **Public**.
 
-1. Select **Create** or **Create Workspace**.
+1. Select **Create**.
 
     <img alt="Create public workspace" src="https://assets.postman.com/postman-docs/v10/create-public-workspace-v10.jpg" width="400px"/>
-
-> You can set up your new public workspace using a template. For more information, see [Creating workspaces with a template](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/#creating-workspaces-with-a-template).
 
 ## Converting an existing workspace to a public workspace
 

--- a/src/pages/docs/getting-started/first-steps/creating-your-first-workspace.md
+++ b/src/pages/docs/getting-started/first-steps/creating-your-first-workspace.md
@@ -21,7 +21,7 @@ To create a new workspace, do the following:
 
     <img alt="Change workspace or create new" src="https://assets.postman.com/postman-docs/workspace-switcher-v9.1.jpg" width="300px"/>
 
-1. ([Free, Basic, and Professional plans only](https://www.postman.com/pricing)) You can use [workspace templates](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/#creating-workspaces-with-a-template) to help you set up a new workspace. Select a workspace template to populate the workspace with helpful information and sample collections, or select **Blank workspace** to create an empty workspace. Then select **Next**.
+1. You can use [workspace templates](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/#creating-workspaces-with-a-template) to help you set up a new workspace. Select a workspace template to populate the workspace with helpful information and sample collections, or select **Blank workspace** to create an empty workspace. Then select **Next**.
 
     > You can also apply a workspace template to a newly created workspace. To learn more, see [Creating workspaces with a template](/docs/collaborating-in-postman/using-workspaces/creating-workspaces/#creating-workspaces-with-a-template).
 
@@ -33,7 +33,7 @@ To create a new workspace, do the following:
     * A **Private** workspace is visible to you and to any team members you invite to it ([Professional and Enterprise plans only](https://www.postman.com/pricing)).
     * A **Team** workspace is visible to everyone on your team.
     * A **Public** workspace is visible to all Postman users.
-1. Select **Create** or **Create Workspace**.
+1. Select **Create**.
 
     <img alt="Create new workspace" src="https://assets.postman.com/postman-docs/v10/create-workspace-v10-2.jpg" width="400px"/>
 


### PR DESCRIPTION
In the initial release (July), we mentioned that users can select a workspace template (during workspace creation) only for Free, Basic, and Professional plans. This feature will be applied to Enterprise plans in the next release. For features like this, we typically don't include a pricing note, so we're removing the pricing notes in this PR.

* Removed pricing note from mentions about selecting a workspace template during workspace creation
* Updated the workspace creation CTA to "Create", which is the label used in this new workspace template flow
* Removed an extra note about adding a workspace template to a new workspace, which was redundant information