### PR TITLE
[MARKENG-2749][c] Reinstate munchkin.js

### DIFF
--- a/build/marketo.munchkin.js
+++ b/build/marketo.munchkin.js
@@ -1,0 +1,28 @@
+const marketo = () => {
+  const munchkinId = process.env.MUNCHKIN_ID || '';
+
+  if (typeof document === 'object' && munchkinId) {
+    /* eslint-disable */
+    var didInit = false;
+    function initMunchkin() {
+      if (didInit === false) {
+        didInit = true;
+        Munchkin.init(munchkinId);
+      }
+    }
+    var s = document.createElement('script');
+    s.type = 'text/javascript';
+    s.async = true;
+    s.src = '//munchkin.marketo.net/munchkin.js';
+    s.onreadystatechange = function() {
+      if (this.readyState == 'complete' || this.readyState == 'loaded') {
+        initMunchkin();
+      }
+    };
+    s.onload = initMunchkin;
+    document.getElementsByTagName('head')[0].appendChild(s);
+    /* eslint-enable */
+  }
+};
+
+module.exports = marketo;

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import Header from './Header/Header';
 import Footer from './Footer/Footer';
+import marketo from '../../build/marketo.munchkin';
 import '../../styles/config/normalize.css';
 import GlobalStyle  from '../../styles/globalStyle';
 import Theme from '../../styles/theme.jsx';
@@ -92,6 +93,7 @@ class Layout extends React.Component {
           <Header />
           {children}
           <Footer />
+          {marketo()}
         </Theme>
         </main>
       </>


### PR DESCRIPTION
### What are the changes?
_Branched from `develop`_, this reinstates munchkin.js from the LC web app.

### Why make these changes?
 High priority task to reenable the library to see how it affects the reporting of signups.

*no visuals