### PR TITLE
Add links for Firefox, Safari, and Edge Interceptor extensions

### DIFF
--- a/src/pages/docs/sending-requests/capturing-request-data/interceptor.md
+++ b/src/pages/docs/sending-requests/capturing-request-data/interceptor.md
@@ -36,12 +36,9 @@ After you install the Interceptor extension, you can start an _Interceptor sessi
 Use the links below to download and install the latest version of the Interceptor extension for your web browser. Interceptor is available for the following browsers:
 
 * [Google Chrome](https://go.pstmn.io/interceptor-chrome)
-
-<!--
 * [Apple Safari](https://go.pstmn.io/interceptor-safari)
 * [Mozilla Firefox](https://go.pstmn.io/interceptor-firefox)
 * [Microsoft Edge](https://go.pstmn.io/interceptor-edge)
--->
 
 To open the Interceptor extension, select the Interceptor icon in your browser's toolbar.
 


### PR DESCRIPTION
Add download links for Firefox, Safari, and Edge Interceptor extensions in addition to Chrome