### PR TITLE
[MARKENG-0001][c] hardcode api url when envvar is unavailable

### DIFF
--- a/build/bffData.js
+++ b/build/bffData.js
@@ -10,7 +10,7 @@ sh.exec("mkdir -p bff-data")
 sh.config.silent = false
 
 const TIME = new Date().getTime()
-const api = process.env.MKAPI_URL || null
+const api = process.env.MKAPI_URL || 'https://www.postman.com/mkapi'
 const url = `${api}/worker.json?${TIME}`
 
 const bffData = () =>


### PR DESCRIPTION
### What are the changes?
_Branched from `develop`_, this hardcodes MKAPI_URL envvar when it is unavailable.

### Why make these changes?
Otherwise contributors may not have data necessary to build the web app.

*no-visuals
