### PR TITLE
[TW-1392] migration guide swagger

### DIFF
--- a/src/components/LeftNav/LeftNavItems.jsx
+++ b/src/components/LeftNav/LeftNavItems.jsx
@@ -197,6 +197,14 @@ export const leftNavItems = [
             url: '/docs/getting-started/importing-and-exporting/importing-from-insomnia/',
           },
           {
+            name: 'Importing cURL commands',
+            url: '/docs/getting-started/importing-and-exporting/importing-curl-commands/',
+          },
+          {
+            name: 'Importing Swagger APIs',
+            url: '/docs/getting-started/importing-and-exporting/importing-from-swagger/',
+          },
+          {
             name: 'Exporting data from Postman',
             url: '/docs/getting-started/importing-and-exporting/exporting-data/',
           },

--- a/src/pages/docs/getting-started/importing-and-exporting/importing-from-swagger.md
+++ b/src/pages/docs/getting-started/importing-and-exporting/importing-from-swagger.md
@@ -1,0 +1,44 @@
+---
+title: 'Importing Swagger APIs'
+updated: 2023-09-29
+contextual_links:
+  - type: section
+    name: "Additional resources"
+  - type: subtitle
+    name: "Videos"
+  - type: link
+    name: "Import and Export Data in Postman"
+    url: "https://youtu.be/KdaiVdNMgL4"
+  - type: link
+    name: "Collection Format | Postman Level Up"
+    url: "https://youtu.be/cRXSblrGrao"
+  - type: subtitle
+    name: "Blog posts"
+  - type: link
+    name: "Postman Essentials: Exploring the Collection Format"
+    url: "https://blog.postman.com/postman-essentials-exploring-the-collection-format/"
+  - type: link
+    name: "Differences between Postman Collections and the collection format"
+    url: "https://blog.postman.com/differences-between-postman-collections-and-collection-format/"
+---
+
+Postman can import APIs created with the Swagger toolset and any API that follows the OpenAPI specification. You can import your API as a standard collection (described below), or you can use the [Postman API Builder](/docs/designing-and-developing-your-api/the-api-workflow/) to import both the definition and a linked collection.
+
+The terms "Swagger" and "OpenAPI" can be confusing because the OpenAPI specification was previously named SwaggerAPI, and people sometimes use the terms interchangeably. To clarify, in this document, "Swagger API" refers to an API created with the Swagger toolset.
+
+## Import a Swagger API
+
+To import a Swagger API, do the following:
+
+1. Select **Import**.
+1. Select files, folders, enter a link to the API, or paste your raw text.
+
+    > You can also import an API definition from a code repository. Learn more about [importing and exporting](/docs/getting-started/importing-and-exporting/importing-and-exporting-overview/).
+
+1. Confirm the name, format, and what you would like your data to import as.
+
+    > Select **View Import Settings** for more configuration options. These options will vary depending on your API specification.
+
+1. Select **Import** to bring your API into Postman.
+
+> To learn more ways to import APIs, read [Importing an API](/docs/designing-and-developing-your-api/importing-an-api/)

--- a/src/pages/docs/getting-started/importing-and-exporting/importing-from-swagger.md
+++ b/src/pages/docs/getting-started/importing-and-exporting/importing-from-swagger.md
@@ -22,7 +22,7 @@ contextual_links:
     url: "https://blog.postman.com/differences-between-postman-collections-and-collection-format/"
 ---
 
-Postman can import APIs created with the Swagger toolset and any API that follows the OpenAPI specification. You can import your API as a standard collection (described below), or you can use the [Postman API Builder](/docs/designing-and-developing-your-api/the-api-workflow/) to import both the definition and a linked collection.
+Postman can import APIs created with the Swagger toolset and any API that follows a [supported version of the OpenAPI specification](/docs/designing-and-developing-your-api/importing-an-api/#supported-api-definitions-formats).
 
 The terms "Swagger" and "OpenAPI" can be confusing because the OpenAPI specification was previously named SwaggerAPI, and people sometimes use the terms interchangeably. To clarify, in this document, "Swagger API" refers to an API created with the Swagger toolset.
 
@@ -35,7 +35,7 @@ To import a Swagger API, do the following:
 
     > You can also import an API definition from a code repository. Learn more about [importing and exporting](/docs/getting-started/importing-and-exporting/importing-and-exporting-overview/).
 
-1. Confirm the name, format, and what you would like your data to import as.
+1. Choose to import your API as a **Postman Collection** or as **OpenAPI 3.0 with a Postman Collection**.
 
     > Select **View Import Settings** for more configuration options. These options will vary depending on your API specification.
 


### PR DESCRIPTION
Added a new doc on importing a Swagger API. Included a leftnav item for a separate doc from TW-1391 to avoid a merge conflict.