### PR TITLE
[TW-1410] Flows - update links

### DIFF
--- a/src/pages/docs/postman-flows/gs/flows-overview.md
+++ b/src/pages/docs/postman-flows/gs/flows-overview.md
@@ -51,13 +51,13 @@ Flows are the ultimate way to take data from an API-enabled product, manipulate 
 
 Check out these Flows Workspaces filled with examples:
 
-* [Business Flows](https://www.postman.com/postman/workspace/business-flows)
-* [Integration Flows](https://www.postman.com/postman/workspace/integration-flows)
-* [Natural Language Processing (NLP) Flows](https://www.postman.com/postman/workspace/natural-language-processing-nlp-flows)
-* [Slack Integration Flows](https://www.postman.com/postman/workspace/slack-integration-flows)
-* [DevOps Flows](https://www.postman.com/postman/workspace/devops-flows)
-* [Utility Flows](https://www.postman.com/postman/workspace/utility-flows)
-* [Miscellaneous Flows](https://www.postman.com/postman/workspace/miscellaneous-flows)
+* [Business Flows](https://www.postman.com/postman/workspace/business-flows/flows)
+* [Integration Flows](https://www.postman.com/postman/workspace/integration-flows/flows)
+* [Natural Language Processing (NLP) Flows](https://www.postman.com/postman/workspace/natural-language-processing-nlp-flows/flows)
+* [Slack Integration Flows](https://www.postman.com/postman/workspace/slack-integration-flows/flows)
+* [DevOps Flows](https://www.postman.com/postman/workspace/devops-flows/flows)
+* [Utility Flows](https://www.postman.com/postman/workspace/utility-flows/flows)
+* [Miscellaneous Flows](https://www.postman.com/postman/workspace/miscellaneous-flows/flows)
 
 These workspaces include example Flows utilizing a multitude of APIs for different products and tools, plus all the related collections and environments needed. You can [fork](/docs/collaborating-in-postman/using-version-control/forking-entities/) the Flows to your own workspace, try them out, and then make your own changes and customizations.
 
@@ -73,7 +73,7 @@ To get started, check out the following resources:
 
 * [Navigating a Flow and the Flows interface](/docs/postman-flows/gs/the-flows-interface/)
 * [First Flows concept: blocks and connections](/docs/postman-flows/concepts/blocks-and-connections/)
-* [Flows Snippets: examples for how to use every block](https://www.postman.com/postman/workspace/flows-snippets/)
+* [Flows Snippets: examples for how to use every block](https://www.postman.com/postman/workspace/flows-snippets/flows)
 
 ## Contribute
 

--- a/src/pages/docs/postman-flows/tutorials/creating-a-dashboard-in-flows.md
+++ b/src/pages/docs/postman-flows/tutorials/creating-a-dashboard-in-flows.md
@@ -37,7 +37,7 @@ Create a Flow that quantifies a stock's performance by comparing it to a market 
 
 ## Creating the Flow
 
-1. Begin by [forking](/docs/collaborating-in-postman/using-version-control/forking-entities/) (copying) the [**stocks** collection](https://www.postman.com/postman/workspace/utility-flows/collection/23919558-b45b34a3-8289-42f2-98e5-df043c863ea1?action=share&creator=21580188) and the [**stocks-tutorial** environment](https://www.postman.com/postman/workspace/utility-flows/environment/21580188-07226525-53d7-40ca-b9d3-6cac35c39306) from the [**Utility Flows**](https://www.postman.com/postman/workspace/utility-flows/overview) workspace to your workspace. In your fork of the **stocks-tutorial** environment, replace `<your-api-key>` with your Polygon.io API key and select **Save**.
+1. Begin by [forking](/docs/collaborating-in-postman/using-version-control/forking-entities/) (copying) the [**stocks** collection](https://www.postman.com/postman/workspace/utility-flows/collection/23919558-b45b34a3-8289-42f2-98e5-df043c863ea1?action=share&creator=21580188) and the [**stocks-tutorial** environment](https://www.postman.com/postman/workspace/utility-flows/environment/21580188-07226525-53d7-40ca-b9d3-6cac35c39306) from the [**Utility Flows**](https://www.postman.com/postman/workspace/utility-flows/flows/overview) workspace to your workspace. In your fork of the **stocks-tutorial** environment, replace `<your-api-key>` with your Polygon.io API key and select **Save**.
 
     * Create a new Flow and connect three **Send Request** blocks to the **Start** block.
 

--- a/src/pages/docs/postman-flows/tutorials/send-information-from-one-system-to-another.md
+++ b/src/pages/docs/postman-flows/tutorials/send-information-from-one-system-to-another.md
@@ -34,7 +34,7 @@ Create a Flow that gets a list of customer profiles from [Stripe](http://www.str
 
 ## Creating the Flow
 
-The first step is to [fork](/docs/collaborating-in-postman/using-version-control/forking-entities/) (copy) the collections and the environment the Flow will use, then add your API keys to the environment. You could create these requests, collections, and environment, but using existing ones saves time. From the [**Integration Flows** public workspace](https://www.postman.com/postman/workspace/integration-flows), fork the **Brevo API** collection, the **Stripe API** collection, and the **Stripe + Brevo** environment to your workspace.
+The first step is to [fork](/docs/collaborating-in-postman/using-version-control/forking-entities/) (copy) the collections and the environment the Flow will use, then add your API keys to the environment. You could create these requests, collections, and environment, but using existing ones saves time. From the [**Integration Flows** public workspace](https://www.postman.com/postman/workspace/integration-flows/flows), fork the **Brevo API** collection, the **Stripe API** collection, and the **Stripe + Brevo** environment to your workspace.
 
 > Creating requests is beyond the scope of this tutorial, but you can learn more about creating requests [here](/docs/getting-started/first-steps/sending-the-first-request/).
 


### PR DESCRIPTION
The Flows team added a new route `/flows` and asked that we add it to LC links that point to Flows-centric workspaces (not specific flows).

Beta docs can be reviewed [here](https://tw-1410-flows-update-links.learning.postman-beta.com/docs/postman-flows/gs/flows-overview/).