### PR TITLE
[TW-1376] update slack integrations

### DIFF
--- a/src/pages/docs/integrations/available-integrations/slack.md
+++ b/src/pages/docs/integrations/available-integrations/slack.md
@@ -35,7 +35,7 @@ The Postman to Slack integration enables you to send Postman notifications to a 
 1. From the **[Home](https://go.postman.co/home)** page, select **[Integrations](https://go.postman.co/integrations)**.
 1. Select **Browse All Integrations**.
 1. Search for and select **[Slack](https://go.postman.co/integrations/service/slack)**.
-1. There are four available Slack integrations. Select **Add Integration** next to the integration you want to add:
+1. There are three available Slack integrations. Select **Add Integration** next to the integration you want to add:
 
     * **[Post monitoring results](#post-monitoring-results)** - Send the results from a monitor run to a specified Slack channel.
 

--- a/src/pages/docs/integrations/available-integrations/slack.md
+++ b/src/pages/docs/integrations/available-integrations/slack.md
@@ -27,9 +27,9 @@ The Postman to Slack integration enables you to send Postman notifications to a 
 ## Contents
 
 * [Configure Postman with Slack](#configure-postman-with-slack)
-* [Send your monitor run results to Slack](#send-your-monitor-run-results-to-slack)
-* [Receive Postman notifications in Slack](#receive-postman-notifications-in-slack)
-* [Add an activity feed to Slack](#add-an-activity-feed-to-slack)
+* [Post monitoring results](#post-monitoring-results)
+* [Post team activity](#post-team-activity)
+* [Post uptime monitoring notifications](#post-uptime-monitoring-notifications)
 
 ## Configure Postman with Slack
 
@@ -38,11 +38,11 @@ The Postman to Slack integration enables you to send Postman notifications to a 
 1. Search for and select **[Slack](https://go.postman.co/integrations/service/slack)**.
 1. There are four available Slack integrations. Select **Add Integration** next to the integration you want to add:
 
-    * **[Post monitoring results](#send-your-monitor-run-results-to-slack)** - Send the results from a monitor run to a specified Slack channel.
+    * **[Post monitoring results](#post-monitoring-results)** - Send the results from a monitor run to a specified Slack channel.
 
-    * **[Receive Postman Notification](#receive-postman-notifications-in-slack)** - Send notifications received in the Postman notification center to a specified Slack channel.
+    * **[Receive Postman notifications](#receive-postman-notifications)** - Send notifications received in the Postman notification center to a specified Slack channel.
 
-    * **[Post team activity](#add-an-activity-feed-to-slack)** - Send your team's [activity feed](/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections/#accessing-the-activity-feed-from-postman) to a specified Slack channel.
+    * **[Post team activity](#post-team-activity)** - Send your team's [activity feed](/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections/#accessing-the-activity-feed-from-postman) to a specified Slack channel.
 
     * **[Post uptime monitoring notifications](#post-uptime-monitoring-notifications)**
 
@@ -65,18 +65,18 @@ The Postman to Slack integration enables you to send Postman notifications to a 
 
 > **You can view your configured integrations on the [Browse Integrations](https://go.postman.co/integrations/browse) page.** You can also view integrations that have been configured for a monitor by opening the monitor and selecting the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the right sidebar. Learn more about [viewing or editing integrations](/docs/integrations/intro-integrations/#viewing-or-editing-integrations).
 
-## Send your monitor run results to Slack
+## Post monitoring results
 
 > This integration works with collection-based monitors. Before you begin, make sure you've [created at least one collection-based monitor](/docs/monitoring-your-api/setting-up-monitor/).
 
 1. Enter the following on the **Add integration** window:
 
-    * **Nickname** -   A nickname for your integration.
-    * **Workspace** -  The workspace that contains your monitor.
-    * **Monitor** -   The collection-based monitor which will send its results to Slack.
-    * **Slack Webhook URL** - The webhook URL. This field will be pre-filled from the authorization process.
-    * **Slack Channel** - The channel where the integration will post. This field will be pre-filled from the authorization process.
-    * **Advanced Options** - Select the Advanced Options link to specify if you want notifications for all completed monitor runs, or notifications for three failed monitor runs and then the first successful monitor run.
+    * **Nickname** - A nickname for your integration.
+    * **Workspace** - The workspace that contains your monitor.
+    * **Monitor** - The collection-based monitor which will send its results to Slack.
+    * **Channel name** - The channel where the integration will post. This field will be pre-filled from the authorization process.
+    * **Configure when monitor runs must be notified** - Specify if you want notifications for all completed monitor runs, or notifications for three failed monitor runs and then the first successful monitor run.
+    * **Add Slack for your team** - Check this box to enable members of your team to access channels from your organization’s Slack workspace within Postman.
 
 1. Select **Add Integration**.
 
@@ -84,9 +84,9 @@ The following is an example of a set of monitor results when sent to Slack:
 
 ![configured_slack_example](https://assets.postman.com/postman-docs/slack-post-monitoring-results-example-v9.jpg)
 
-## Receive Postman notifications in Slack
+## Receive Postman notifications
 
-For the **Receive Postman Notification** integration, after allowing Slack permissions, your integration will be configured.
+For the **Receive Postman notification** integration, after allowing Slack permissions, your integration will be configured.
 
 After adding the integration, you can specify which notifications are sent to Slack. Update your [notification preferences](https://go.postman.co/settings/me/notifications) by selecting your avatar in the upper-right corner > **Settings > Notifications**.
 
@@ -96,7 +96,7 @@ In the Slack column, you can opt in to or out of notifications such as security,
 
 > You can't receive notifications in Slack when team members modify pull requests. You can receive notifications in Slack when you're mentioned in pull request comments. Select **I’m mentioned in a comment** in the **On Slack** column. To learn more about adding comments to pull requests, see [Adding comments](/docs/collaborating-in-postman/using-version-control/reviewing-pull-requests/#adding-comments).
 
-## Add an activity feed to Slack
+## Post team activity
 
 For the **Post team activity** integration, after allowing Slack permissions, your integration will be configured. Your team's [activity feed](/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections/#accessing-the-activity-feed-from-postman) will send updates to the specified channel.
 

--- a/src/pages/docs/integrations/available-integrations/slack.md
+++ b/src/pages/docs/integrations/available-integrations/slack.md
@@ -52,7 +52,7 @@ The Postman to Slack integration enables you to send Postman notifications to a 
 1. On the **Permission request** page:
 
     * Postman will request permission from Slack to view content and information about you, and to perform actions in Slack.
-    * For the **Post team activity** integrations, select the Slack channel where the integration will post its messages. Note that you can't change this channel after you set it up. If you need to change channels later, delete the integration and create a new one.
+    * For the **Post team activity** integration, select the Slack channel where the integration will post its messages. Note that you can't change this channel after you set it up. If you need to change channels later, delete the integration and create a new one.
 
 1. Select **Allow**.
 

--- a/src/pages/docs/integrations/available-integrations/slack.md
+++ b/src/pages/docs/integrations/available-integrations/slack.md
@@ -1,6 +1,6 @@
 ---
 title: "Integrate Postman with Slack"
-updated: 2022-05-26
+updated: 2023-10-25
 contextual_links:
   - type: section
     name: "Additional resources"
@@ -22,9 +22,16 @@ contextual_links:
     url:  "https://www.postman.com/postman/workspace/4be86d9c-6576-4369-b74f-43991df7a4bd"
 ---
 
-The Postman to Slack integration enables you to send Postman notifications to a Slack channel. You can send the results of a Postman monitor run, notifications received in the Postman notification center, or activity in your Team Activity Feed.
+The Postman to Slack integration enables you to send Postman notifications to a Slack channel. You can send the results of a Postman monitor run, notifications received in the Postman notification center, or activity in your team activity feed.
 
-## Configuring Postman with Slack
+## Contents
+
+* [Configure Postman with Slack](#configure-postman-with-slack)
+* [Send your monitor run results to Slack](#send-your-monitor-run-results-to-slack)
+* [Receive Postman notifications in Slack](#receive-postman-notifications-in-slack)
+* [Add an activity feed to Slack](#add-an-activity-feed-to-slack)
+
+## Configure Postman with Slack
 
 1. From the **[Home](https://go.postman.co/home)** page, select **[Integrations](https://go.postman.co/integrations)**.
 1. Select **Browse All Integrations**.

--- a/src/pages/docs/integrations/available-integrations/slack.md
+++ b/src/pages/docs/integrations/available-integrations/slack.md
@@ -29,7 +29,6 @@ The Postman to Slack integration enables you to send Postman notifications to a 
 * [Configure Postman with Slack](#configure-postman-with-slack)
 * [Post monitoring results](#post-monitoring-results)
 * [Post team activity](#post-team-activity)
-* [Post uptime monitoring notifications](#post-uptime-monitoring-notifications)
 
 ## Configure Postman with Slack
 
@@ -44,9 +43,7 @@ The Postman to Slack integration enables you to send Postman notifications to a 
 
     * **[Post team activity](#post-team-activity)** - Send your team's [activity feed](/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections/#accessing-the-activity-feed-from-postman) to a specified Slack channel.
 
-    * **[Post uptime monitoring notifications](#post-uptime-monitoring-notifications)**
-
-        ![select Slack integration](https://assets.postman.com/postman-docs/v10/slack-select-integration-v10-16.jpg)
+        ![Select Slack integration](https://assets.postman.com/postman-docs/v10/slack-select-integration-v10-16.jpg)
 
 1. After you select the integration type, a browser tab opens asking you to sign in to Slack. If you aren't signed in to a Slack workspace, enter your workspace URL and sign in with your email and password or SSO. If you're already signed in to a Slack workspace, select **Continue**.
 
@@ -86,7 +83,7 @@ The following is an example of a set of monitor results when sent to Slack:
 
 ## Receive Postman notifications
 
-For the **Receive Postman notification** integration, after allowing Slack permissions, your integration will be configured.
+For the **Receive Postman notifications** integration, after allowing Slack permissions, your integration will be configured.
 
 After adding the integration, you can specify which notifications are sent to Slack. Update your [notification preferences](https://go.postman.co/settings/me/notifications) by selecting your avatar in the upper-right corner > **Settings > Notifications**.
 
@@ -101,5 +98,3 @@ In the Slack column, you can opt in to or out of notifications such as security,
 For the **Post team activity** integration, after allowing Slack permissions, your integration will be configured. Your team's [activity feed](/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections/#accessing-the-activity-feed-from-postman) will send updates to the specified channel.
 
 [![configured_slack](https://assets.postman.com/postman-docs/slack-activity-feed.jpg)](https://assets.postman.com/postman-docs/slack-activity-feed.jpg)
-
-## Post uptime monitoring notifications

--- a/src/pages/docs/integrations/available-integrations/slack.md
+++ b/src/pages/docs/integrations/available-integrations/slack.md
@@ -36,7 +36,7 @@ The Postman to Slack integration enables you to send Postman notifications to a 
 1. From the **[Home](https://go.postman.co/home)** page, select **[Integrations](https://go.postman.co/integrations)**.
 1. Select **Browse All Integrations**.
 1. Search for and select **[Slack](https://go.postman.co/integrations/service/slack)**.
-1. There are three available Slack integrations. Select **Add Integration** next to the integration you want to add:
+1. There are four available Slack integrations. Select **Add Integration** next to the integration you want to add:
 
     * **[Post monitoring results](#send-your-monitor-run-results-to-slack)** - Send the results from a monitor run to a specified Slack channel.
 
@@ -44,17 +44,18 @@ The Postman to Slack integration enables you to send Postman notifications to a 
 
     * **[Post team activity](#add-an-activity-feed-to-slack)** - Send your team's [activity feed](/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections/#accessing-the-activity-feed-from-postman) to a specified Slack channel.
 
-        ![select Slack integration](https://assets.postman.com/postman-docs/v10/slack-select-integration-v10-14.jpg)
+    * **[Post uptime monitoring notifications](#post-uptime-monitoring-notifications)**
 
-1. After you select the integration type, a browser tab opens asking you to sign in to Slack. If you aren't signed in to a Slack workplace, enter your workspace URL and sign in with your email and password or SSO.
+        ![select Slack integration](https://assets.postman.com/postman-docs/v10/slack-select-integration-v10-16.jpg)
+
+1. After you select the integration type, a browser tab opens asking you to sign in to Slack. If you aren't signed in to a Slack workspace, enter your workspace URL and sign in with your email and password or SSO. If you're already signed in to a Slack workspace, select **Continue**.
 
     > If someone on your team created an [installed app](/docs/integrations/installed-apps/) for Slack, a message and green checkmark let you know you're already authenticated with your Slack workspace. You don't need to sign in or review permissions. If you want to connect to a different Slack workspace, select the link.
 
 1. On the **Permission request** page:
 
-    * Postman will request permission from Slack to view content and information about you. Select the level of security from the list.
-    * The **Receive Postman Notification** integration will configure a Slack bot. Confirm that the actions it asks permission for are acceptable in your Slack workplace.
-    * For the **Post monitoring results** and **Post team activity** integrations, select the Slack channel where the integration will post its messages. Note that you can't change this channel after you set it up. If you need to change channels later, delete the integration and create a new one.
+    * Postman will request permission from Slack to view content and information about you, and to perform actions in Slack.
+    * For the **Post team activity** integrations, select the Slack channel where the integration will post its messages. Note that you can't change this channel after you set it up. If you need to change channels later, delete the integration and create a new one.
 
 1. Select **Allow**.
 
@@ -100,3 +101,5 @@ In the Slack column, you can opt in to or out of notifications such as security,
 For the **Post team activity** integration, after allowing Slack permissions, your integration will be configured. Your team's [activity feed](/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections/#accessing-the-activity-feed-from-postman) will send updates to the specified channel.
 
 [![configured_slack](https://assets.postman.com/postman-docs/slack-activity-feed.jpg)](https://assets.postman.com/postman-docs/slack-activity-feed.jpg)
+
+## Post uptime monitoring notifications

--- a/src/pages/docs/integrations/available-integrations/slack.md
+++ b/src/pages/docs/integrations/available-integrations/slack.md
@@ -43,7 +43,7 @@ The Postman to Slack integration enables you to send Postman notifications to a 
 
     * **[Post team activity](#post-team-activity)** - Send your team's [activity feed](/docs/collaborating-in-postman/using-workspaces/changelog-and-restoring-collections/#accessing-the-activity-feed-from-postman) to a specified Slack channel.
 
-        ![Select Slack integration](https://assets.postman.com/postman-docs/v10/slack-select-integration-v10-16.jpg)
+        ![Select Slack integration](https://assets.postman.com/postman-docs/v10/slack-select-integration-v10-14.jpg)
 
 1. After you select the integration type, a browser tab opens asking you to sign in to Slack. If you aren't signed in to a Slack workspace, enter your workspace URL and sign in with your email and password or SSO. If you're already signed in to a Slack workspace, select **Continue**.
 


### PR DESCRIPTION
- Reworded headings to match options in Postman
- Changed gerunds to imperatives
- Added then removed content for **Post uptime monitor notifications**. The Slack Integrations page includes an option for this, but the feature was canceled after last year's beta and few users have or can create uptime monitors. We decided to ignore this content in the LC.