### PR TITLE
[PAPI-2306] Update Postman API rate limit statements

### DIFF
--- a/src/pages/docs/collaborating-in-postman/private-api-network/publish-private-network-elements-with-api.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/publish-private-network-elements-with-api.md
@@ -1,6 +1,6 @@
 ---
 title: "Automate publishing to the Private API Network using the Postman API"
-updated: 2023-11-27
+updated: 2023-08-02
 contextual_links:
   - type: section
     name: "Additional resources"

--- a/src/pages/docs/collaborating-in-postman/private-api-network/publish-private-network-elements-with-api.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/publish-private-network-elements-with-api.md
@@ -1,6 +1,6 @@
 ---
 title: "Automate publishing to the Private API Network using the Postman API"
-updated: 2023-08-02
+updated: 2023-11-27
 contextual_links:
   - type: section
     name: "Additional resources"

--- a/src/pages/docs/collaborating-in-postman/private-api-network/publish-private-network-elements-with-api.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/publish-private-network-elements-with-api.md
@@ -59,7 +59,7 @@ You can get started by [forking the Postman API collection](https://www.postman.
 
 You will also need an API key to use the Postman API. For information, see [Generate a Postman API key](/docs/developer/postman-api/authentication/#generate-a-postman-api-key).
 
-> Access rate limits for your Postman API key depend on your Postman plan. For more information, see [Postman API rate limits](/docs/developer/postman-api/postman-api-rate-limits/).
+> Access rate limits for your Postman account depend on your Postman plan. For more information, see [Postman API rate limits](/docs/developer/postman-api/postman-api-rate-limits/).
 
 ## Create a Private API Network folder
 

--- a/src/pages/docs/developer/postman-api/make-postman-api-call.md
+++ b/src/pages/docs/developer/postman-api/make-postman-api-call.md
@@ -1,6 +1,6 @@
 ---
 title: "Access Postman data programmatically"
-updated: 2023-11-27
+updated: 2023-06-22
 search_keyword: "postman-api"
 contextual_links:
   - type: section

--- a/src/pages/docs/developer/postman-api/make-postman-api-call.md
+++ b/src/pages/docs/developer/postman-api/make-postman-api-call.md
@@ -1,6 +1,6 @@
 ---
 title: "Access Postman data programmatically"
-updated: 2023-06-22
+updated: 2023-11-27
 search_keyword: "postman-api"
 contextual_links:
   - type: section

--- a/src/pages/docs/developer/postman-api/make-postman-api-call.md
+++ b/src/pages/docs/developer/postman-api/make-postman-api-call.md
@@ -36,7 +36,7 @@ contextual_links:
 
 The Postman API enables you to programmatically access data stored in your Postman account. You can use the API to perform actions such as managing your collections, APIs, workspaces, and more.
 
-> The access rate limits for your Postman API key depend on your Postman plan. For more information, see [Postman API rate limits](/docs/developer/postman-api/postman-api-rate-limits/).
+> The access rate limits for your Postman account depend on your Postman plan. For more information, see [Postman API rate limits](/docs/developer/postman-api/postman-api-rate-limits/).
 
 This tutorial shows you how to make your first call to the Postman API. You can also learn more about the Postman API by reading the [Postman API documentation](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a). There you will find information to help you get started and information about each endpoint and operation.
 

--- a/src/pages/docs/developer/postman-api/postman-api-rate-limits.md
+++ b/src/pages/docs/developer/postman-api/postman-api-rate-limits.md
@@ -1,6 +1,6 @@
 ---
 title: "Track Postman API call limits"
-updated: 2023-11-27
+updated: 2022-11-30
 search_keyword: "postman-api, api-rate-limits, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset"
 contextual_links:
   - type: section

--- a/src/pages/docs/developer/postman-api/postman-api-rate-limits.md
+++ b/src/pages/docs/developer/postman-api/postman-api-rate-limits.md
@@ -1,6 +1,6 @@
 ---
 title: "Track Postman API call limits"
-updated: 2022-11-30
+updated: 2023-11-27
 search_keyword: "postman-api, api-rate-limits, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset"
 contextual_links:
   - type: section
@@ -34,7 +34,7 @@ contextual_links:
     url:  "https://www.postman.com/postman/workspace/postman-public-workspace/api/72a32ca3-f06a-4e83-a933-2821a0e6616f/definition/d429098b-1789-4c62-b77b-cf02024aba53?view=documentation"
 ---
 
-Postman's API access rate limits are applied at a per-key basis in unit time.
+Postman's API access rate limits are applied at a per-user basis in unit time.
 
 Access to the API using a key is limited to **300 requests per minute**. Every API response includes the following set of headers to identify the status of your consumption:
 


### PR DESCRIPTION
The previous phrasing did not make it clear that the limit applies to a specific api-key/users. After developer analysis, we want to support only the rate limit by user. This PR updates the phrasing to reference account/users instead of API keys. Further information/details are available in [PAPI-2306](https://postmanlabs.atlassian.net/browse/PAPI-2306).

[PAPI-2306]: https://postmanlabs.atlassian.net/browse/PAPI-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ