### PR TITLE
[TW-1490] Add note about the Workspace roles API

### DIFF
--- a/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
+++ b/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
@@ -1,7 +1,7 @@
 ---
 title: "Define roles and permissions within a Postman team"
 order: 72
-updated: 2022-12-19
+updated: 2023-12-15
 page_id: "roles_and_permissions"
 warning: false
 contextual_links:
@@ -116,6 +116,8 @@ You can [assign](/docs/collaborating-in-postman/using-workspaces/managing-worksp
 * **Partner Lead** (External, [Enterprise Ultimate plans only](https://www.postman.com/pricing)) - Can invite other partners from their organization to join a [Partner Workspace](/docs/collaborating-in-postman/using-workspaces/partner-workspaces/). To learn more, see [Partner team and Partner Workspace roles](#partner-team-and-partner-workspace-roles).
 
 Partners have different permissions for Workspace Editor and Viewer roles in Partner Workspaces ([Enterprise Ultimate plans only](https://www.postman.com/pricing)). To learn more, see [Partner team and Partner Workspace roles](#partner-team-and-partner-workspace-roles).
+
+> You can use the Postman API to programmatically manage users and user groups for workspaces. For more information, see the [Postman API collection](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a).
 
 The following roles control access at a workspace level:
 

--- a/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
+++ b/src/pages/docs/collaborating-in-postman/roles-and-permissions.md
@@ -1,7 +1,7 @@
 ---
 title: "Define roles and permissions within a Postman team"
 order: 72
-updated: 2023-12-15
+updated: 2022-12-19
 page_id: "roles_and_permissions"
 warning: false
 contextual_links:

--- a/src/pages/docs/collaborating-in-postman/user-groups.md
+++ b/src/pages/docs/collaborating-in-postman/user-groups.md
@@ -111,6 +111,8 @@ Select the team roles you'd like to assign to the group, or deselect team roles 
 
 You can control a group's access to individual workspaces, collections, APIs, environments, mock servers, and monitors. For more information on managing workspaces, see [Sharing workspaces](/docs/collaborating-in-postman/using-workspaces/managing-workspaces/#sharing-workspaces).
 
+> You can use the Postman API to programmatically manage users and user groups for workspaces. For more information, see the [Postman API collection](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a).
+
 For collections, APIs, environments, mock servers, and monitors, go to the element you'd like to edit roles for. In the sidebar, select the more actions icon <img alt="More actions icon" src="https://assets.postman.com/postman-docs/icon-more-actions-v9.jpg#icon" width="16px"> then select **Manage roles**.
 
 <img alt="Invite group to collection" src="https://assets.postman.com/postman-docs/v10/add-group-to-collection-v10.15.jpg" width="500px"/>


### PR DESCRIPTION
This adds a small callout on `collaborating-in-postman/user-groups.md` and `collaborating-in-postman/roles-and-permissions.md` that mention the Postman API.

This actually links to the main landing page of the Postman API in the Postman Public Workspace because the API doesn't exist yet. I can provide a subsequent update at a later date if needed that points directly to the specific collection folder (it will be Workspaces -> Roles).

**Note:**

I wasn't sure about updating the `updated` field in the frontmatter because it was such a minor update that I did not want to push the pages down the line for a refresh update.