### PR TITLE
[TW-1522] Updates for the Manage API Key interface

### DIFF
--- a/src/pages/docs/administration/managing-your-team/managing-api-keys.md
+++ b/src/pages/docs/administration/managing-your-team/managing-api-keys.md
@@ -29,7 +29,7 @@ You must be a [Team Admin or Super Admin](/docs/collaborating-in-postman/roles-a
 
 To open the [Postman API key management dashboard](http://go.postman.co/manage-postman-keys), select **Team > Manage Postman Keys** in the Postman header.
 
-<img alt="Manage Postman keys dashboard" src="https://assets.postman.com/postman-docs/v10/manage-postman-api-keys-dashboard-v10.18.jpg"/>
+<img alt="Manage Postman keys dashboard" src="https://assets.postman.com/postman-docs/v10/manage-postman-api-keys-dashboard-v10.19.jpg"/>
 
 The dashboard lists all of the Postman API keys created by your team. To filter the list by enabled, disabled, or revoked keys, select or clear the checkboxes next to **View**.
 
@@ -39,9 +39,9 @@ Tags next to the API key's name specify when it is disabled or revoked. You can 
 
 ### Exposed API keys
 
-If the [Postman Secret Scanner](https://learning.postman.com/docs/administration/token-scanner/) detects exposed Postman API keys in public Postman workspaces or [GitHub](/docs/administration/token-scanner/#protecting-postman-api-keys-in-github) and [GitLab](/docs/administration/token-scanner/#protecting-postman-api-keys-in-gitlab) repositories, the dashboard displays them in the **Exposed API keys** section. This section provides details about the exposed key, such as the date of its exposure detection, the last time it was used, and the location of the exposed API key.
+If the [Postman Secret Scanner](https://learning.postman.com/docs/administration/token-scanner/) detects exposed Postman API keys in public Postman workspaces, Postman documentation, or [GitHub](/docs/administration/token-scanner/#protecting-postman-api-keys-in-github) and [GitLab](/docs/administration/token-scanner/#protecting-postman-api-keys-in-gitlab) repositories, the dashboard displays them in the **Exposed API keys** section. This section provides details about the exposed key, such as the date of its exposure detection, the last time it was used, and the location of the exposed API key.
 
-<img alt="Exposed keys section" src="https://assets.postman.com/postman-docs/v10/manage-postman-exposed-api-keys-v10.18.jpg"/>
+<img alt="Exposed keys section" src="https://assets.postman.com/postman-docs/v10/manage-postman-exposed-api-keys-v10.19.jpg"/>
 
 You can manage how Postman automatically handles exposed API keys in the [API key settings](#revoking) section of the Postman API key management dashboard.
 
@@ -49,7 +49,7 @@ You can manage how Postman automatically handles exposed API keys in the [API ke
 
 You can revoke an API key in the [Postman API key management dashboard](http://go.postman.co/manage-postman-keys) by hovering over it and selecting **Revoke**. To revoke multiple API keys at once, select the checkboxes next to each key, then select **Revoke** above the list.
 
-<img alt="Revoke multiple keys" src="https://assets.postman.com/postman-docs/v10/manage-postman-api-keys-revoke-v10.18.jpg"/>
+<img alt="Revoke multiple keys" src="https://assets.postman.com/postman-docs/v10/manage-postman-api-keys-revoke-v10.19.jpg"/>
 
 Postman notifies users by email when their API keys are revoked. For exposed keys, revoking also resolves the Secret Scanner finding in the [Secret Scanner dashboard](https://learning.postman.com/docs/administration/token-scanner/#secret-scanner-dashboard).
 
@@ -67,7 +67,7 @@ You can set the expiration settings for all API keys that your team creates with
 
 #### Revoking
 
-Enable the **Auto revoke exposed Postman API keys** setting to allow Postman to automatically revoke any publicly exposed API keys found in publicly accessible Postman resources, [GitHub repositories](/docs/administration/managing-your-team/secret-scanner/#protect-postman-api-keys-in-github), and [Gitlab repositories](/docs/administration/token-scanner/#protect-postman-api-keys-in-gitlab). When the Postman Secret Scanner detects any exposed keys in public GitHub or GitLab repositories or public Postman workspaces, it revokes the key and notifies the key's owner by email.
+Enable the **Auto revoke exposed Postman API keys** setting to allow Postman to automatically revoke any publicly exposed API keys found in publicly accessible Postman resources or documentation, [GitHub repositories](/docs/administration/managing-your-team/secret-scanner/#protect-postman-api-keys-in-github), and [Gitlab repositories](/docs/administration/token-scanner/#protect-postman-api-keys-in-gitlab). When the Postman Secret Scanner detects any exposed keys in public GitHub or GitLab repositories or public Postman resources, it revokes the key and notifies the key's owner by email.
 
 If there are any exposed API keys present when you enable this setting, a warning appears.
 

--- a/src/pages/docs/administration/managing-your-team/managing-api-keys.md
+++ b/src/pages/docs/administration/managing-your-team/managing-api-keys.md
@@ -39,7 +39,7 @@ Tags next to the API key's name specify when it is disabled or revoked. You can 
 
 ### Exposed API keys
 
-If the [Postman Secret Scanner](https://learning.postman.com/docs/administration/token-scanner/) detects exposed Postman API keys in public Postman workspaces, public Postman documentation, or [GitHub](/docs/administration/token-scanner/#protecting-postman-api-keys-in-github) and [GitLab](/docs/administration/token-scanner/#protecting-postman-api-keys-in-gitlab) repositories, the dashboard displays them in the **Exposed API keys** section. This section provides details about the exposed key, such as the date of its exposure detection, the last time it was used, and the location of the exposed API key.
+If the [Postman Secret Scanner](/docs/administration/managing-your-team/secret-scanner/) detects exposed Postman API keys in public Postman workspaces, public Postman documentation, or [GitHub](/docs/administration/managing-your-team/secret-scanner/#protect-postman-api-keys-in-github) and [GitLab](/docs/administration/managing-your-team/secret-scanner/#protect-postman-api-keys-in-gitlab) repositories, the dashboard displays them in the **Exposed API keys** section. This section provides details about the exposed key, such as the date of its exposure detection, the last time it was used, and the location of the exposed API key.
 
 <img alt="Exposed keys section" src="https://assets.postman.com/postman-docs/v10/manage-postman-exposed-api-keys-v10.19.jpg"/>
 

--- a/src/pages/docs/administration/managing-your-team/managing-api-keys.md
+++ b/src/pages/docs/administration/managing-your-team/managing-api-keys.md
@@ -1,6 +1,6 @@
 ---
 title: "Manage API keys"
-updated: 2023-09-15
+updated: 2023-12-15
 contextual_links:
   - type: section
     name: "Additional resources"

--- a/src/pages/docs/administration/managing-your-team/managing-api-keys.md
+++ b/src/pages/docs/administration/managing-your-team/managing-api-keys.md
@@ -39,7 +39,7 @@ Tags next to the API key's name specify when it is disabled or revoked. You can 
 
 ### Exposed API keys
 
-If the [Postman Secret Scanner](https://learning.postman.com/docs/administration/token-scanner/) detects exposed Postman API keys in public Postman workspaces, Postman documentation, or [GitHub](/docs/administration/token-scanner/#protecting-postman-api-keys-in-github) and [GitLab](/docs/administration/token-scanner/#protecting-postman-api-keys-in-gitlab) repositories, the dashboard displays them in the **Exposed API keys** section. This section provides details about the exposed key, such as the date of its exposure detection, the last time it was used, and the location of the exposed API key.
+If the [Postman Secret Scanner](https://learning.postman.com/docs/administration/token-scanner/) detects exposed Postman API keys in public Postman workspaces, public Postman documentation, or [GitHub](/docs/administration/token-scanner/#protecting-postman-api-keys-in-github) and [GitLab](/docs/administration/token-scanner/#protecting-postman-api-keys-in-gitlab) repositories, the dashboard displays them in the **Exposed API keys** section. This section provides details about the exposed key, such as the date of its exposure detection, the last time it was used, and the location of the exposed API key.
 
 <img alt="Exposed keys section" src="https://assets.postman.com/postman-docs/v10/manage-postman-exposed-api-keys-v10.19.jpg"/>
 

--- a/src/pages/docs/administration/managing-your-team/managing-api-keys.md
+++ b/src/pages/docs/administration/managing-your-team/managing-api-keys.md
@@ -67,7 +67,7 @@ You can set the expiration settings for all API keys that your team creates with
 
 #### Revoking
 
-Enable the **Auto revoke exposed Postman API keys** setting to allow Postman to automatically revoke any publicly exposed API keys found in publicly accessible Postman resources, [GitHub repositories](/docs/administration/managing-your-team/secret-scanner/#protect-postman-api-keys-in-github), and [Gitlab repositories](/docs/administration/token-scanner/#protect-postman-api-keys-in-gitlab). When the Postman Secret Scanner detects any exposed keys in public GitHub or GitLab repositories or public Postman resources, it revokes the key and notifies the key's owner by email.
+Enable the **Auto revoke exposed Postman API keys** setting to allow Postman to automatically revoke any publicly exposed API keys found in publicly accessible Postman resources, [GitHub repositories](/docs/administration/managing-your-team/secret-scanner/#protect-postman-api-keys-in-github), and [Gitlab repositories](/docs/administration/managing-your-team/secret-scanner/#protect-postman-api-keys-in-gitlab). When the Postman Secret Scanner detects any exposed keys in public GitHub or GitLab repositories or public Postman resources, it revokes the key and notifies the key's owner by email.
 
 If there are any exposed API keys present when you enable this setting, a warning appears.
 

--- a/src/pages/docs/administration/managing-your-team/managing-api-keys.md
+++ b/src/pages/docs/administration/managing-your-team/managing-api-keys.md
@@ -67,7 +67,7 @@ You can set the expiration settings for all API keys that your team creates with
 
 #### Revoking
 
-Enable the **Auto revoke exposed Postman API keys** setting to allow Postman to automatically revoke any publicly exposed API keys found in publicly accessible Postman resources or documentation, [GitHub repositories](/docs/administration/managing-your-team/secret-scanner/#protect-postman-api-keys-in-github), and [Gitlab repositories](/docs/administration/token-scanner/#protect-postman-api-keys-in-gitlab). When the Postman Secret Scanner detects any exposed keys in public GitHub or GitLab repositories or public Postman resources, it revokes the key and notifies the key's owner by email.
+Enable the **Auto revoke exposed Postman API keys** setting to allow Postman to automatically revoke any publicly exposed API keys found in publicly accessible Postman resources, [GitHub repositories](/docs/administration/managing-your-team/secret-scanner/#protect-postman-api-keys-in-github), and [Gitlab repositories](/docs/administration/token-scanner/#protect-postman-api-keys-in-gitlab). When the Postman Secret Scanner detects any exposed keys in public GitHub or GitLab repositories or public Postman resources, it revokes the key and notifies the key's owner by email.
 
 If there are any exposed API keys present when you enable this setting, a warning appears.
 


### PR DESCRIPTION
This PR updates the **Manage API Keys** interface documentation around the updates to now include exposed keys in Postman documentation. This primarily updates:
- Screenshots to reflect the UI updates.
- Minor phrasing revisions to include Postman documentation as a scanned resource.