### PR TITLE
[TW-1503] Full doc view and import collections in VS Code

### DIFF
--- a/src/pages/docs/getting-started/basics/about-vs-code-extension.md
+++ b/src/pages/docs/getting-started/basics/about-vs-code-extension.md
@@ -1,6 +1,6 @@
 ---
 title: "About the Postman VS Code extension"
-updated: 2023-11-15
+updated: 2023-12-15
 search_keyword: "vs code extension, vs code plugin, vs code rest client, vs code api, VSC extension, visual studio extension"
 contextual_links:
   - type: section
@@ -27,7 +27,8 @@ The Postman VS Code extension enables you to develop and test your APIs in Postm
 The VS Code extension enables you to:
 
 * Create and send HTTP, raw WebSocket, and gRPC requests.
-* Import data with cURL commands.
+* Import collections exported from Postman and requests from cURL commands.
+* Write and view collection documentation.
 * Edit and send requests from a workspace's request history.
 * Create cookies and send them with requests.
 * Create and manage collections and environments.

--- a/src/pages/docs/getting-started/basics/about-vs-code-extension.md
+++ b/src/pages/docs/getting-started/basics/about-vs-code-extension.md
@@ -39,4 +39,4 @@ The VS Code extension enables you to:
 
 To install and learn more about the VS Code extension, visit the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Postman.postman-for-vscode).
 
-![Postman VS Code extension](https://assets.postman.com/postman-docs/postman-vs-code-extension-v0-14-3.jpg)
+![Postman VS Code extension](https://assets.postman.com/postman-docs/postman-vs-code-extension-v0-16-0.jpg)

--- a/src/pages/docs/getting-started/basics/about-vs-code-extension.md
+++ b/src/pages/docs/getting-started/basics/about-vs-code-extension.md
@@ -27,7 +27,7 @@ The Postman VS Code extension enables you to develop and test your APIs in Postm
 The VS Code extension enables you to:
 
 * Create and send HTTP, raw WebSocket, and gRPC requests.
-* Import collections exported from Postman and requests from cURL commands.
+* Import collections exported from Postman, and import requests from cURL commands.
 * Write and view collection documentation.
 * Edit and send requests from a workspace's request history.
 * Create cookies and send them with requests.

--- a/src/pages/docs/getting-started/importing-and-exporting/importing-and-exporting-overview.md
+++ b/src/pages/docs/getting-started/importing-and-exporting/importing-and-exporting-overview.md
@@ -38,4 +38,6 @@ Postman can import and export Postman data, including collections, environments,
 
 * You can [import a cURL command](/docs/getting-started/importing-and-exporting/importing-curl-commands/#import-a-curl-command-into-postman) as a new Postman request or [convert a Postman request to a cURL command](/docs/getting-started/importing-and-exporting/importing-curl-commands/#convert-a-postman-request-to-curl). You can also [import Swagger APIs](/docs/getting-started/importing-and-exporting/importing-from-swagger/) or [import OpenAPI definitions](/docs/integrations/available-integrations/working-with-openAPI/).
 
+* You can use the [Postman VS Code extension](/docs/getting-started/basics/about-vs-code-extension/) to import collections into Postman, and import a cURL command as a new request.
+
 * You can [export collections and environments](/docs/getting-started/importing-and-exporting/exporting-data/) from Postman as JSON files. You can also [export a data dump](/docs/getting-started/importing-and-exporting/exporting-data/#exporting-data-dumps) with all of your Postman collections, environments, globals, and header presets. After exporting, you can import the files into any Postman instance or use them with [Newman](/docs/collections/using-newman-cli/command-line-integration-with-newman/).


### PR DESCRIPTION
* Added new bullet points about importing collections, and collection documentation.
* Mentioned on the importing and exporting overview that you can also import using the VS Code extension.
* Updated the hero image screenshot.

[Beta site](https://tw-1503-vs-code-doc-view-import-collections.learning.postman-beta.com/docs/getting-started/basics/about-vs-code-extension/)