### PR TITLE
[TW-1567] Doc Private network read/write separation for new enterprise packaging

### DIFF
--- a/src/pages/docs/administration/managing-your-team/managing-your-team.md
+++ b/src/pages/docs/administration/managing-your-team/managing-your-team.md
@@ -270,8 +270,8 @@ You can add team members to the [Internal API Management solution](https://www.p
 When you add team members to the Internal API Management solution:
 
 * You can then assign them the [API Network Manager and API Governance Manager](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) roles. Learn more about [managing team roles](#managing-team-roles).
-* All team members get access to the Private API Network.
-* Only team members added to this solution can be assigned the [API Editor](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) role in Postman APIs, enabling them to create and edit an unlimited amount of APIs. Team members not added to this solution will only have the [API Viewer](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) role.
+* Only the team members with a seat can publish/request to publish changes to the Private API Network, while the rest of the team can consume/read the network.
+* Only team members added to this solution can be assigned the [API Editor](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) role in Postman APIs, enabling them to create and edit an unlimited amount of APIs. Team members not added to this solution only have the [API Viewer](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) role.
 
     > If team members are assigned the API Editor role in the [API Builder](/docs/designing-and-developing-your-api/the-api-workflow/) and you add at least one team member to the Internal API Management solution, team members not added to this solution will no longer be assigned the API Editor role. They'll only be assigned the API Viewer role.
 

--- a/src/pages/docs/administration/managing-your-team/managing-your-team.md
+++ b/src/pages/docs/administration/managing-your-team/managing-your-team.md
@@ -270,8 +270,8 @@ You can add team members to the [Internal API Management solution](https://www.p
 When you add team members to the Internal API Management solution:
 
 * You can then assign them the [API Network Manager and API Governance Manager](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) roles. Learn more about [managing team roles](#managing-team-roles).
-* Only the team members with a seat can publish or request to publish changes to the Private API Network, while the rest of the team can consume and read from the network.
-* Only team members added to this solution can be assigned the [API Editor](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) role in Postman APIs, enabling them to create and edit an unlimited amount of APIs. Team members not added to this solution only have the [API Viewer](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) role.
+* Only the team members added to this solution can publish or request to publish changes to the Private API Network, while the rest of the team can consume and read from the network.
+* Only the team members added to this solution can be assigned the [API Editor](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) role in Postman APIs, enabling them to create and edit an unlimited amount of APIs. Team members not added to this solution only have the [API Viewer](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) role.
 
     > If team members are assigned the API Editor role in the [API Builder](/docs/designing-and-developing-your-api/the-api-workflow/) and you add at least one team member to the Internal API Management solution, team members not added to this solution will no longer be assigned the API Editor role. They'll only be assigned the API Viewer role.
 

--- a/src/pages/docs/administration/managing-your-team/managing-your-team.md
+++ b/src/pages/docs/administration/managing-your-team/managing-your-team.md
@@ -270,7 +270,7 @@ You can add team members to the [Internal API Management solution](https://www.p
 When you add team members to the Internal API Management solution:
 
 * You can then assign them the [API Network Manager and API Governance Manager](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) roles. Learn more about [managing team roles](#managing-team-roles).
-* Only the team members with a seat can publish/request to publish changes to the Private API Network, while the rest of the team can consume/read the network.
+* Only the team members with a seat can publish or request to publish changes to the Private API Network, while the rest of the team can consume and read from the network.
 * Only team members added to this solution can be assigned the [API Editor](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) role in Postman APIs, enabling them to create and edit an unlimited amount of APIs. Team members not added to this solution only have the [API Viewer](/docs/collaborating-in-postman/roles-and-permissions/#api-roles) role.
 
     > If team members are assigned the API Editor role in the [API Builder](/docs/designing-and-developing-your-api/the-api-workflow/) and you add at least one team member to the Internal API Management solution, team members not added to this solution will no longer be assigned the API Editor role. They'll only be assigned the API Viewer role.

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -44,7 +44,7 @@ Workspaces, collections, and APIs in the Private API Network are visible to logg
 
 [Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network. You can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) at the folder level, giving them permission to manage specific folders and the elements in them.
 
-<img alt="Private API Network overview" src="https://assets.postman.com/postman-docs/v10/private-api-network-permissions-v10.jpg"/>
+<img alt="Private API Network overview" src="https://assets.postman.com/postman-docs/v10/private-api-network-folders-v10.jpg"/>
 
 ## Contents
 

--- a/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
+++ b/src/pages/docs/collaborating-in-postman/private-api-network/adding-private-network.md
@@ -38,11 +38,13 @@ contextual_links:
 
 The _Private API Network_ provides a [central directory](https://www.postman.com/api-platform/api-catalog/) of workspaces, collections, and APIs your team uses internally. Your Postman team can access these resources and start using them right away. By using the Private API Network, you can enable developers across your organization to discover, consume, and track API development in one place.
 
+The Private API Network is available through the [Postman for Internal API Management solution](/docs/administration/managing-your-team/managing-your-team/#internal-api-management-solution). If you are an Enterprise Essentials user, you must add this solution and a relevant number of seats to enable users on your team to publish and request to publish changes to the network. The rest of the team can consume and read the network.
+
 Workspaces, collections, and APIs in the Private API Network are visible to logged-in users who are on your Postman team. Users who aren't on your team can't find or access these resources.
 
 [Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) and [API Network Managers](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) can manage all folders and elements in your Private API Network. You can assign team members the [Folder Manager role](/docs/collaborating-in-postman/roles-and-permissions/#network-roles) at the folder level, giving them permission to manage specific folders and the elements in them.
 
-<img alt="Private API Network overview" src="https://assets.postman.com/postman-docs/v10/private-api-network-overview-v10-4.jpg"/>
+<img alt="Private API Network overview" src="https://assets.postman.com/postman-docs/v10/private-api-network-permissions-v10.jpg"/>
 
 ## Contents
 


### PR DESCRIPTION
Updated the Private API Network and Admin pages to reflect the read/write separation, replaced a screenshot