### PR TITLE
[TW-1154] Minor refresh and Vale fix

### DIFF
--- a/src/pages/docs/collaborating-in-postman/user-groups.md
+++ b/src/pages/docs/collaborating-in-postman/user-groups.md
@@ -21,28 +21,20 @@ contextual_links:
 
 > **[Groups are available on Postman Enterprise plans.](https://www.postman.com/pricing)**
 
-With Postman groups, you can arrange users into groups that reflect your organizational structure. You can add users to a group, then assign that group roles and access to the resources they'll be using across Postman. You can also efficiently onboard new team members by adding them to existing groups in your organization, instantly giving them access to the elements they'll be working on. Groups enable you to broadly control access from a single dashboard in Postman and manage it at scale across your Enterprise team.
+With Postman groups, you can arrange users into groups that reflect your organizational structure. You can add users to a group, then assign that group roles and access to the resources they'll be using across Postman. You can also efficiently onboard new team members by adding them to existing groups in your organization, instantly giving them access to the elements they'll be working on. Groups enable you to control access from a single dashboard in Postman and manage it at scale across your Enterprise team.
 
 [Admins and Super Admins](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) can create, manage, and delete groups. [Developers](/docs/collaborating-in-postman/roles-and-permissions/#team-roles) can also create, manage, and delete Developer-only groups.
 
 ## Contents
 
 * [Creating a group](#creating-a-group)
-
 * [Managing a group](#managing-a-group)
-
     * [Managing members of a group](#managing-members-of-a-group)
-
     * [Managing group managers](#managing-group-managers)
-
     * [Managing access control for a group](#managing-access-control-for-a-group)
-
         * [Editing team roles for a group](#editing-team-roles-for-a-group)
-
         * [Managing roles on workspaces and Postman elements](#managing-roles-on-workspaces-and-postman-elements)
-
     * [Editing details for a group](#editing-details-for-a-group)
-
 * [Deleting a group](#deleting-a-group)
 
 ## Creating a group


### PR DESCRIPTION
As it turns out, the images that were mentioned as being in need of updating in the [Jira ticket](https://postmanlabs.atlassian.net/browse/TW-1154) were, in fact, still correct. This task instead resolves one Vale error (`broadly`) and adjusted the TOC format to not have spaces in between each entry (like the other files in this folder).

This topic could use some splitting, and I've [proposed solution in the ticket](https://postmanlabs.atlassian.net/browse/TW-1154?focusedCommentId=660506). I checked the TW backlog and did not see any open tickets around doing this, so I created a [Jira ticket](https://postmanlabs.atlassian.net/browse/TW-1609).