### PR TITLE
[TW-1559] Update Run in Postman overview

### DIFF
--- a/src/components/LeftNav/LeftNavItems.jsx
+++ b/src/components/LeftNav/LeftNavItems.jsx
@@ -1246,7 +1246,7 @@ export const leftNavItems = [
         slug: '/docs/publishing-your-api/run-in-postman/introduction-run-button/',
         subMenuItems2: [
           {
-            name: 'Share with Run in Postman',
+            name: 'Run in Postman overview',
             url: '/docs/publishing-your-api/run-in-postman/introduction-run-button/',
           },
           {

--- a/src/components/LeftNav/LeftNavItems.jsx
+++ b/src/components/LeftNav/LeftNavItems.jsx
@@ -1246,7 +1246,7 @@ export const leftNavItems = [
         slug: '/docs/publishing-your-api/run-in-postman/introduction-run-button/',
         subMenuItems2: [
           {
-            name: 'Run in Postman overview',
+            name: 'Overview',
             url: '/docs/publishing-your-api/run-in-postman/introduction-run-button/',
           },
           {

--- a/src/pages/docs/publishing-your-api/run-in-postman/introduction-run-button.md
+++ b/src/pages/docs/publishing-your-api/run-in-postman/introduction-run-button.md
@@ -1,5 +1,5 @@
 ---
-title: "Share collections with Run in Postman buttons"
+title: "Run in Postman overview"
 updated: 2022-09-21
 contextual_links:
   - type: section
@@ -30,14 +30,16 @@ contextual_links:
     url:  "https://www.postman.com/case-studies/box/"
 ---
 
-The **Run in Postman** button <img alt="Run in Postman button" src="https://assets.postman.com/postman-docs/run-in-postman-button-icon.jpg#icon" width="100px"/> is a way to share a Postman Collection (and optional environment) with your users. Live **Run in Postman** buttons automatically stay updated with changes to your collection, providing consumers with its most recent version. You can also attach an environment to your live button to help onboard new users to your API quickly and efficiently.
+The **Run in Postman** button <img alt="Run in Postman button" src="https://assets.postman.com/postman-docs/run-in-postman-button-icon.jpg#icon" width="100px"/> enables you to share your Postman Collection (and optional environment) with other users. The button creates a [fork](/docs/collaborating-in-postman/using-version-control/forking-elements/) of the collection, which lets users stay updated with any changes to your collection and provides consumers with its most recent version. You can also attach an environment to your **Run in Postman** button to help onboard new users to your API quickly and efficiently.
+
+You can get started by [creating a **Run in Postman** button](/docs/publishing-your-api/run-in-postman/creating-run-button/) for your collection or [integrate the button](/docs/publishing-your-api/run-in-postman/run-button-API/) in your API documentation or developer portal.
+
+> Don't leak sensitive data like access keys in your collection or environment. Read more about [securely using API keys in Postman](https://blog.postman.com/how-to-use-api-keys/).
 
 ## User interaction with your button
 
-When a user comes across the **Run in Postman** button <img alt="Run in Postman button" src="https://assets.postman.com/postman-docs/run-in-postman-button-icon.jpg#icon" width="100px"/> they can choose to fork the collection to their workspace, view the collection in the public workspace, or import the collection into Postman. Then, they can begin interacting with your API. The **Run in Postman** button allows the consumers to fork your collection, which creates a copy of the collection while maintaining a link to the parent.
+When a user comes across the **Run in Postman** button <img alt="Run in Postman button" src="https://assets.postman.com/postman-docs/run-in-postman-button-icon.jpg#icon" width="100px"/> in your collection they can choose to fork the collection to their workspace, view the collection in the public workspace, or import the collection into Postman. Then, they can begin interacting with your API. The **Run in Postman** button allows the consumers to fork your collection, which creates a copy of the collection while maintaining a link to the parent.
 
 <img alt="Fork collection for run in postman" src="https://assets.postman.com/postman-docs/fork-collection-for-run-in-postman.jpg" height="350px"/>
 
-**Run in Postman** buttons are only available for documentation and embed flows.
-
-> Don't leak sensitive data like access keys in your collection or environment. Read more about [securely using API keys in Postman](https://blog.postman.com/how-to-use-api-keys/).
+> **Run in Postman** buttons are only available for documentation and embed flows.

--- a/src/pages/docs/publishing-your-api/run-in-postman/introduction-run-button.md
+++ b/src/pages/docs/publishing-your-api/run-in-postman/introduction-run-button.md
@@ -1,6 +1,6 @@
 ---
-title: "Run in Postman overview"
-updated: 2022-09-21
+title: "Share collections with Run in Postman buttons"
+updated: 2024-01-10
 contextual_links:
   - type: section
     name: "Additional resources"
@@ -30,7 +30,7 @@ contextual_links:
     url:  "https://www.postman.com/case-studies/box/"
 ---
 
-The **Run in Postman** button <img alt="Run in Postman button" src="https://assets.postman.com/postman-docs/run-in-postman-button-icon.jpg#icon" width="100px"/> enables you to share your Postman Collection (and optional environment) with other users. The button creates a [fork](/docs/collaborating-in-postman/using-version-control/forking-elements/) of the collection, which lets users stay updated with any changes to your collection and provides consumers with its most recent version. You can also attach an environment to your **Run in Postman** button to help onboard new users to your API quickly and efficiently.
+The **Run in Postman** button <img alt="Run in Postman button" src="https://assets.postman.com/postman-docs/run-in-postman-button-icon.jpg#icon" width="100px"/> enables you to share your Postman Collection with other users. The button creates a [fork](/docs/collaborating-in-postman/using-version-control/forking-elements/) of the collection, which lets users stay updated with any changes to your collection and provides consumers with its most recent version. You can also attach an environment to your **Run in Postman** button to help onboard new users to your API quickly and efficiently.
 
 You can get started by [creating a **Run in Postman** button](/docs/publishing-your-api/run-in-postman/creating-run-button/) for your collection or [integrate the button](/docs/publishing-your-api/run-in-postman/run-button-API/) in your API documentation or developer portal.
 
@@ -41,5 +41,3 @@ You can get started by [creating a **Run in Postman** button](/docs/publishing-y
 When a user comes across the **Run in Postman** button <img alt="Run in Postman button" src="https://assets.postman.com/postman-docs/run-in-postman-button-icon.jpg#icon" width="100px"/> in your collection they can choose to fork the collection to their workspace, view the collection in the public workspace, or import the collection into Postman. Then, they can begin interacting with your API. The **Run in Postman** button allows the consumers to fork your collection, which creates a copy of the collection while maintaining a link to the parent.
 
 <img alt="Fork collection for run in postman" src="https://assets.postman.com/postman-docs/fork-collection-for-run-in-postman.jpg" height="350px"/>
-
-> **Run in Postman** buttons are only available for documentation and embed flows.


### PR DESCRIPTION
- Updated the page title/header and LeftNav title.
- Updated the introduction statement a bit with some links out to other LC documentation (like forks, and the additional Run in Postman articles).
- Made some minor revisions, including moving the warning about sensitive data to the end of the overview section so that it's more visible.