### PR TITLE
[c] update-msgpackr npm package at depth of 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13006,9 +13006,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msgpackr": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.0.tgz",
-      "integrity": "sha512-rVQ5YAQDoZKZLX+h8tNq7FiHrPJoeGHViz3U4wIcykhAEpwF/nH2Vbk8dQxmpX5JavkI8C7pt4bnkJ02ZmRoUw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
+      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
       "requires": {
         "msgpackr-extract": "^3.0.2"
       }


### PR DESCRIPTION
* ran `npm audit`
* ran suggested `npm update msgpackr --depth 10` to clear VULN
* generated new package-lock file