### PR TITLE
[TW-1633] Remove unneeded references to Scratch Pad

### DIFF
--- a/src/pages/docs/getting-started/importing-and-exporting/exporting-data.md
+++ b/src/pages/docs/getting-started/importing-and-exporting/exporting-data.md
@@ -44,8 +44,6 @@ You can export your Postman data, including collections, environments, global va
 
 You can export a data dump of all your collections, environments, globals, and header presets in Postman.
 
-> You can export individual collections and environments from the [Scratch Pad](/docs/getting-started/basics/using-scratch-pad/). You can't make bulk data exports of all collections and environments at once.
-
 1. Select the settings icon <img alt="Settings icon" src="https://assets.postman.com/postman-docs/icon-settings-v9.jpg#icon" width="16px"> in the header, then select **Settings**.
 
 1. Select the **Data** tab, then select **Request Data Export** to start your request for the data dump.

--- a/src/pages/docs/getting-started/installation/settings.md
+++ b/src/pages/docs/getting-started/installation/settings.md
@@ -144,8 +144,6 @@ Use the **Data** tab to request a bulk export of Postman data or to import data.
 
 Importing a dump file may overwrite your existing collections and environments, so use caution. Always make a backup before importing files. Learn more about [importing and exporting data](/docs/getting-started/importing-and-exporting/importing-and-exporting-overview/).
 
-If you have data on the [Scratch Pad](/docs/getting-started/basics/using-scratch-pad/), you can migrate the data to a workspace. Learn more about [migrating Scratch Pad data to a workspace](/docs/getting-started/basics/using-scratch-pad/#migrating-scratch-pad-data-to-a-workspace).
-
 ## Add-ons
 
 Select **Download Newman from npm** to download Newman, Postman's command line companion. Newman integrates your Postman collections with your build system and runs automated API tests. Learn more about [command line integration with Newman](/docs/collections/using-newman-cli/command-line-integration-with-newman/).


### PR DESCRIPTION
- Removed two notes mentioning the Scratch Pad (another Scratch Pad note was already removed in #5373)
- The information in these notes is already included on the Scratch Pad page: `/docs/getting-started/basics/using-scratch-pad/`

[View the beta docs](https://tw-1633-remove-scratch-pad-refs.learning.postman-beta.com/docs/collections/running-collections/intro-to-collection-runs/)