### PR TITLE
[TW-1677] Clarify inviting verified users to join a team

### DIFF
--- a/src/pages/docs/administration/domain-verification-and-capture/add-and-verify-a-domain.md
+++ b/src/pages/docs/administration/domain-verification-and-capture/add-and-verify-a-domain.md
@@ -15,7 +15,7 @@ contextual_links:
 
 As a [Team Admin](/docs/collaborating-in-postman/roles-and-permissions/#team-roles), you can add and verify a domain or subdomain. This enables Postman to implicitly trust your team and its connection to your organization. It also improves the onboarding process as you continue to grow your Postman team. Domain verification is one of the [prerequisites for enabling domain capture](/docs/administration/domain-verification-and-capture/domain-capture-overview/#prerequisites-for-domain-capture).
 
-When you verify your organization's domain, it removes the friction of adding users who have already verified their email addresses with the relevant domain when they created Postman accounts. Postman will no longer require users' permission to join your team, letting you instantly provide new teammates with all of the resources they’ll need to be successful contributors.
+When you verify your organization's domain, Team Admins can add users who have already verified their email addresses with the relevant domain when they created Postman accounts. Postman won't require users to accept an invite to join your team. This lets you instantly provide new teammates with all of the resources they’ll need to be successful contributors.
 
 Without a verified domain, individual accounts that you invite to your team are given the option to join or dismiss the invite. If they choose to join, they're also required to reauthenticate prior to accessing the team.
 

--- a/src/pages/docs/administration/domain-verification-and-capture/domain-capture-overview.md
+++ b/src/pages/docs/administration/domain-verification-and-capture/domain-capture-overview.md
@@ -13,9 +13,9 @@ contextual_links:
 
 > **[Domain verification is available on Postman Enterprise plans. Domain capture is available on Postman Enterprise Ultimate plans.](https://www.postman.com/pricing)**
 
-Domain verification and capture enable you to improve your team's onboarding experience and simplify team management. With these features, you can instantly give people access to the teams and resources they need to collaborate in Postman.
+Domain verification and capture enable you to improve your team's onboarding experience and simplify team management. With these features, Team Admins can instantly give people access to the teams and resources they need to collaborate in Postman.
 
-[Domain verification](/docs/administration/domain-verification-and-capture/add-and-verify-a-domain/) enables Postman to trust your team and its connection to your organization. When you verify your organization's domain, Postman will no longer require users' permission to join your team if they've verified their email addresses with the relevant domain. This enables you to instantly provide new teammates with all of the resources they’ll need to be successful contributors. Domain verification is one of the [prerequisites for enabling domain capture](#prerequisites-for-domain-capture).
+[Domain verification](/docs/administration/domain-verification-and-capture/add-and-verify-a-domain/) enables Postman to trust your team and its connection to your organization. When you verify your organization's domain, Team Admins can add users to your team who verified their email addresses with the relevant domain. Users won't need to accept an invite to join your team, enabling you to instantly provide new teammates with all of the resources they’ll need. Domain verification is one of the [prerequisites for enabling domain capture](#prerequisites-for-domain-capture).
 
 [Domain capture](/docs/administration/domain-verification-and-capture/enable-domain-capture/) consolidates all of the Postman user accounts that exist within your organization into one team. When you enable it, any accounts associated with the verified internet domain or subdomain will only be able to use Postman within your team. Moving forward, any Postman users who sign up for a new account with the relevant domain will be automatically added to your team as new members.
 


### PR DESCRIPTION
Clarified the overview about adding users to a team when the user's email is verified with the relevant domain. If the organization's domain is verified, Team Admins can invite a user to join the team, which adds them to the team without having to accept an invite. If the organization's domain isn't verified, the user must accept an invite and complete extra steps to join the team.

**Beta site**:
* [Domain verification and capture overview](https://tw-1677-domain-verification-clarification.learning.postman-beta.com/docs/administration/domain-verification-and-capture/domain-capture-overview/)
* [Verify your organization’s domain](https://tw-1677-domain-verification-clarification.learning.postman-beta.com/docs/administration/domain-verification-and-capture/add-and-verify-a-domain/)