### PR TITLE
[PAPI-2400] Remove line about apiKey query param in "Generate and use Postman API keys"

### DIFF
--- a/src/pages/docs/developer/postman-api/authentication.md
+++ b/src/pages/docs/developer/postman-api/authentication.md
@@ -69,7 +69,7 @@ Use **API key settings** to specify expiration periods for your keys.
 
 ### Use your Postman API key
 
-After you have a Postman API key, you must authenticate your requests to the Postman API by sending your API Key in the `X-Api-Key` header of every request you make. Your API Key provides access to any Postman data you have permissions for.
+After you have a Postman API key, you must authenticate your requests to the Postman API by sending your API key in the `X-Api-Key` header of every request you make. Your API key provides access to any Postman data you have permissions for.
 
 You can store your API key in a [variable](/docs/sending-requests/variables/). If you name it `postman-api-key`, the Postman API collection will use it automatically.
 

--- a/src/pages/docs/developer/postman-api/authentication.md
+++ b/src/pages/docs/developer/postman-api/authentication.md
@@ -69,11 +69,7 @@ Use **API key settings** to specify expiration periods for your keys.
 
 ### Use your Postman API key
 
-After you have a Postman API key, you must authenticate your requests to the Postman API by sending your API Key in the `X-Api-Key` header of every request you make.
-
-You can also send the key as an `apikey` URL query parameter. An API key sent as part of the header has a higher priority in case you send the key using both request header and query parameter.
-
-Your API Key provides access to any Postman data you have permissions for.
+After you have a Postman API key, you must authenticate your requests to the Postman API by sending your API Key in the `X-Api-Key` header of every request you make. Your API Key provides access to any Postman data you have permissions for.
 
 You can store your API key in a [variable](/docs/sending-requests/variables/). If you name it `postman-api-key`, the Postman API collection will use it automatically.
 

--- a/src/pages/docs/developer/postman-api/authentication.md
+++ b/src/pages/docs/developer/postman-api/authentication.md
@@ -1,6 +1,6 @@
 ---
 title: "Generate and use Postman API keys"
-updated: 2023-06-15
+updated: 2024-01-25
 search_keyword: "postman api key, collection access key, postman api"
 contextual_links:
   - type: section


### PR DESCRIPTION
This is a minor update to remove the mention of using an API key query parameter, as this is planned for deprecation/unsupported (see https://postmanlabs.atlassian.net/browse/PAPI-2380 for further details).