### PR TITLE
[MARKENG-3101] remove undefined from classNames in global nav

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -320,7 +320,7 @@ const Header = (props) => {
                                 <h6 className="dropdown-header">{col.title}</h6>
                                 {col.subItemsCol.map((link) => (
                                   <a
-                                    className={`${link.link} dropdown-item`}
+                                    className={`${link.link ? `${link.link}` : ''} dropdown-item`}
                                     href={link.url}
                                     key={link.title}
                                   >


### PR DESCRIPTION
Removes `undefined` from the `classNames` by checking if `link.link` exists before adding it to the class

Preview Branch:
https://markeng-3101.learning.postman-beta.com/



<img width="811" alt="PR-3101" src="https://github.com/postmanlabs/postman-docs/assets/90945264/2339bf10-1db2-47a3-81ca-df2dfe5211bb">
