### PR TITLE
Remove smart quotes from titles

### DIFF
--- a/lint-front.js
+++ b/lint-front.js
@@ -23,7 +23,7 @@ function readFiles(dirPath) {
           console.error(`ERROR: ** Smart quotes detected in title: ${data['title']} **`);
         }
       } else {
-        console.error(`Missing 'title' field in frontmatter`);
+        console.error(`Missing 'title' field in frontmatter (%s)`, itemPath);
       }
     }
  });

--- a/src/pages/docs/administration/domain-verification-and-capture/add-and-verify-a-domain.md
+++ b/src/pages/docs/administration/domain-verification-and-capture/add-and-verify-a-domain.md
@@ -1,5 +1,5 @@
 ---
-title: "Verify your organization’s domain in Postman"
+title: "Verify your organization's domain in Postman"
 updated: 2023-10-03
 contextual_links:
   - type: section

--- a/src/pages/docs/introduction/overview.md
+++ b/src/pages/docs/introduction/overview.md
@@ -69,7 +69,7 @@ To learn more about Postman Flows, see [Build API applications visually using Po
 
 The Postman CLI is a secure command-line companion for Postman. You can use the Postman CLI to run a collection, send run results to Postman, check API definitions against configured API Governance and API Security rules, and more.
 
-To learn more about the Postman CLI, see [Explore Postman’s command-line companion](/docs/postman-cli/postman-cli-overview/).
+To learn more about the Postman CLI, see [Explore Postman's command-line companion](/docs/postman-cli/postman-cli-overview/).
 
 ## Collaborate in Postman
 

--- a/src/pages/docs/postman-cli/postman-cli-overview.md
+++ b/src/pages/docs/postman-cli/postman-cli-overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Explore Postman’s command-line companion"
+title: "Explore Postman's command-line companion"
 updated: 2023-03-20
 contextual_links:
   - type: section

--- a/src/pages/docs/postman-flows/gs/flows-usage.md
+++ b/src/pages/docs/postman-flows/gs/flows-usage.md
@@ -1,5 +1,5 @@
 ---
-title: "Manage your team’s usage of Postman Flows"
+title: "Manage your team's usage of Postman Flows"
 updated: 2023-11-22
 ---
 

--- a/src/pages/docs/sending-requests/cookies.md
+++ b/src/pages/docs/sending-requests/cookies.md
@@ -1,5 +1,5 @@
 ---
-title: "Create and capture cookies using Postman’s cookie manager"
+title: "Create and capture cookies using Postman's cookie manager"
 order: 28
 page_id: "cookies"
 updated: 2022-03-02


### PR DESCRIPTION
Also adds to the logging message to say where missing title files actually are.