### PR TITLE
[TW-1650] Postman Vault March non-Enterprise

### DIFF
--- a/src/pages/docs/sending-requests/postman-vault-secrets.md
+++ b/src/pages/docs/sending-requests/postman-vault-secrets.md
@@ -94,7 +94,7 @@ When Postman generates your vault key, you have the following options for saving
 
 1. Select **Open Vault** to [add vault secrets to your Postman Vault](#add-sensitive-data-as-vault-secrets).
 
-    ![Save vault key](https://assets.postman.com/postman-docs/v10/save-postman-vault-key-v10-23-b.jpg)
+    ![Save vault key](https://assets.postman.com/postman-docs/v10/save-postman-vault-key-v10-24.jpg)
 
 > If your Postman Vault is open, you can select the information icon <img alt="Information icon" src="https://assets.postman.com/postman-docs/icon-information-v9-5.jpg#icon" width="16px"> in the top right to copy or download your vault key.
 
@@ -114,7 +114,7 @@ You can reset your vault key if you lose it, but Postman will permanently delete
 
 After you [save your vault key](#save-your-vault-key), you can add sensitive data, such as API keys and passwords, to your Postman Vault and reuse them in your local instance of Postman. You can also add secrets from the HTTP request builder.
 
-> Vault secrets aren't preserved in your Postman Vault after signing out of Postman. This means that references to the secret will be [unresolved](#fix-unresolved-vault-secrets) when you sign in to Postman. You can fix this by adding the vault secrets back to your Postman Vault after you sign in.
+> Vault secrets aren't preserved in your Postman Vault after signing out of Postman. This means that references to the secret will be [unresolved](#fix-unresolved-vault-secrets) when you sign in to Postman. You can add your vault secrets back to your Postman Vault after you sign in.
 
 To add secrets to your Postman Vault, do the following:
 

--- a/src/pages/docs/sending-requests/postman-vault-secrets.md
+++ b/src/pages/docs/sending-requests/postman-vault-secrets.md
@@ -7,9 +7,9 @@ plan: beta
 
 *Postman Vault* enables you to store sensitive data as vault secrets in your local instance of Postman. This enables you to securely reuse sensitive data in your HTTP collections, environments, and requests. Only you can access and use your vault secrets, and secrets aren't synced to the Postman cloud.
 
-When you first open your Postman Vault, Postman generates a [vault key](#manage-your-vault-key) that enables you to access your encrypted vault secrets. Once you store your vault key in a secure location, you can [add sensitive data as vault secrets](#add-sensitive-data-as-vault-secrets) in your Postman Vault. Then you can [reference your vault secrets](#use-vault-secrets) in your HTTP collections, requests, and more.
+When you first open your Postman Vault, Postman generates a [vault key](#manage-your-vault-key) that enables you to access your Postman Vault later. Once you store your vault key in a secure location, you can [add sensitive data as vault secrets](#add-sensitive-data-as-vault-secrets) in your Postman Vault. Then you can [reference your vault secrets](#use-vault-secrets) in your HTTP collections, requests, and more.
 
-You can use your Postman Vault from the [Postman desktop app](/docs/getting-started/installation/installation-and-updates/) or the [Postman web app](/docs/getting-started/installation/installation-and-updates/#use-the-postman-web-app). Learn about Postman Vault [features that require the Postman desktop app or the Postman web app](#feature-availability).
+You can use your Postman Vault from the [Postman desktop app](/docs/getting-started/installation/installation-and-updates/) or the [Postman web app](/docs/getting-started/installation/installation-and-updates/#use-the-postman-web-app). Learn about Postman Vault [features that require the Postman desktop app](#feature-availability).
 
 ## Contents
 
@@ -41,6 +41,10 @@ Vault secrets are created at the *vault* scope, which is the broadest scope comp
 
 > If a variable in a different scope has the same name as a vault secret, the value stored in a narrower scope won't be used. For example, if there is a collection variable named `postman-api-key` and a vault secret also named `postman-api-key`, the collection value won't be used when the request runs. Learn how to [reference vault secrets](#use-vault-secrets) in Postman.
 
+<!-- -->
+
+> If you're using the Postman web app with Safari as your web browser, it deletes vault secrets from your local instance of Postman after seven days of inactivity. You must use a different web browser if you want your vault secrets available for more than seven days without inactivity. Learn about the [browser requirements](/docs/getting-started/installation/installation-and-updates/#browser-requirements) for the Postman web app.
+
 ### Compare vault secrets and variables
 
 Both vault secrets and variables enable you to store and reference data in Postman. One may be a better fit than the other, depending on your use case or preferences.
@@ -64,18 +68,18 @@ You can open your vault secrets in Postman Vault as follows:
 
     > If you stored your vault key in your system's password manager, Postman automatically gets your vault key. You must use the [Postman Desktop Agent](/docs/getting-started/basics/about-postman-agent/#the-postman-desktop-agent) if you're using the Postman web app so Postman can get your vault key.
 
-> Learn about Postman Vault [features that require the Postman desktop app or the Postman web app](#feature-availability).
+> Learn about Postman Vault [features that require the Postman desktop app](#feature-availability).
 
 ## Manage your vault key
 
-When you open Postman Vault for the first time, Postman generates a [vault key](#save-your-vault-key) that's used to access your encrypted vault secrets. You can [reset your vault key](#reset-your-vault-key) if you lose it, but Postman will permanently delete your vault secrets. Once you save your vault key, you can [add vault secrets to your Postman Vault](#add-sensitive-data-as-vault-secrets).
+When you open Postman Vault for the first time, Postman generates a [vault key](#save-your-vault-key) that's used to access your Postman Vault later. You can [reset your vault key](#reset-your-vault-key) if you lose it, but Postman will permanently delete your vault secrets. Once you save your vault key, you can [add vault secrets to your Postman Vault](#add-sensitive-data-as-vault-secrets).
 
 Your vault secrets are encrypted using the AES-256-GCM encryption algorithm.
 
 When Postman generates your vault key, you have the following options for saving your key:
 
-* Save your vault key in a secure location. Each time you sign in to Postman, you'll need to manually enter your vault key, enabling you to access your Postman Vault and vault secrets.
-* Postman can store your vault key in your system's password manager, such as Keychain Access on macOS. This enables Postman to automatically get your vault key, giving you access to your Postman Vault and vault secrets when you sign in to Postman.
+* Save your vault key in a secure location. Each time you sign in to Postman, you'll need to manually enter your vault key, enabling you to access your Postman Vault.
+* Postman can store your vault key in your system's password manager, such as Keychain Access on macOS. This enables Postman to automatically get your vault key, giving you access to your Postman Vault when you sign in to Postman.
 
 ### Save your vault key
 
@@ -109,6 +113,8 @@ You can reset your vault key if you lose it, but Postman will permanently delete
 ## Add sensitive data as vault secrets
 
 After you [save your vault key](#save-your-vault-key), you can add sensitive data, such as API keys and passwords, to your Postman Vault and reuse them in your local instance of Postman. You can also add secrets from the HTTP request builder.
+
+> Vault secrets aren't preserved in your Postman Vault after signing out of Postman. This means that references to the secret will be [unresolved](#fix-unresolved-vault-secrets) when you sign in to Postman. You can fix this by adding the vault secrets back to your Postman Vault after you sign in.
 
 To add secrets to your Postman Vault, do the following:
 
@@ -188,11 +194,9 @@ pm.variables.get("vault:variable-key");
 
 ![Reference vault secrets in Postman](https://assets.postman.com/postman-docs/v10/use-postman-vault-secrets-v10-23.jpg)
 
+Secrets stored in your Postman Vault are masked when they're logged to the [Postman Console](/docs/sending-requests/troubleshooting-api-requests/).
+
 > If you reference a vault secret as the initial value of a variable, such as an environment variable, the reference to the secret (for example `{{vault:secret-name}}`) is synced using Postman's cloud servers, and shared with anyone who has access to the workspace. The vault secret's value stored in your Postman Vault isn't synced or shared. Learn more about [initial and current values](/docs/sending-requests/variables/variables/#initial-and-current-values).
-
-<!-- -->
-
-> Secrets stored in your Postman Vault are masked when they're logged to the [Postman Console](/docs/sending-requests/troubleshooting-api-requests/).
 
 ## Fix unresolved vault secrets
 
@@ -205,9 +209,8 @@ A vault secret can be unresolved for the following reasons:
 * You aren't using the [Postman Desktop Agent](/docs/getting-started/basics/about-postman-agent/#the-postman-desktop-agent) or the [Postman Browser Agent](/docs/getting-started/basics/about-postman-agent/#the-postman-browser-agent) to send requests from the Postman web app.
 * The secret is turned off in your Postman Vault.
 * The secret isn't allowed to be in requests to the domain.
-* You haven't entered your vault key since you last signed in to Postman.
 
-> Learn about Postman Vault [features that require the Postman desktop app or the Postman web app](#feature-availability).
+> Learn about Postman Vault [features that require the Postman desktop](#feature-availability).
 
 If the vault secret exists in your Postman Vault and it's turned off, hover over the reference to the secret, then select **Enable Secret**.
 
@@ -223,16 +226,8 @@ If a vault secret is referenced in your request and you haven't entered your vau
 
 ## Feature availability
 
-Some Postman Vault features require the Postman desktop app or the Postman web app.
-
 The following features require the Postman desktop app:
 
 * **Open Postman Vault from public workspaces** - You must use the Postman desktop app to open your Postman Vault from a [public workspace](/docs/collaborating-in-postman/using-workspaces/public-workspaces/), and reference vault secrets in a public workspace. If you're using the Postman web app, you must add new vault secrets to your Postman Vault if you're opening it from a public workspace.
 
 * **Preserve vault secrets when you join or leave a team** - You must use the Postman desktop app to preserve your encrypted vault secrets after you [join a new team](/docs/collaborating-in-postman/working-with-your-team/team-collaboration/#joining-a-team) or [leave a team](/docs/collaborating-in-postman/working-with-your-team/team-collaboration/#leaving-a-team). If you're using the Postman web app, vault secrets won't be available from your Postman Vault when you join a new team or leave a team. Then you can add new vault secrets to the team you joined from, or a team you rejoined if using the Postman web app.
-
-The following features require the Postman web app:
-
-* **Preserve vault secrets after signing out of Postman** - You must use the Postman web app to preserve your encrypted vault secrets after signing out of Postman. If you're using the Postman desktop app, vault secrets won't be available from your Postman Vault after signing out of Postman. Then you can add new vault secrets when you sign in to Postman with the desktop app.
-
-    > If you're using the Postman web app with Safari as your web browser, it deletes vault secrets from your local instance of Postman after seven days of inactivity. You must use a different web browser if you want your vault secrets available for more than seven days without inactivity. Learn about the [browser requirements](/docs/getting-started/installation/installation-and-updates/#browser-requirements) for the Postman web app.

--- a/src/pages/docs/sending-requests/postman-vault-secrets.md
+++ b/src/pages/docs/sending-requests/postman-vault-secrets.md
@@ -43,7 +43,7 @@ Vault secrets are created at the *vault* scope, which is the broadest scope comp
 
 <!-- -->
 
-> If you're using the Postman web app with Safari as your web browser, it deletes vault secrets from your local instance of Postman after seven days of inactivity. You must use a different web browser if you want your vault secrets available for more than seven days without inactivity. Learn about the [browser requirements](/docs/getting-started/installation/installation-and-updates/#browser-requirements) for the Postman web app.
+> If you're using the Postman web app with Safari as your web browser, it deletes vault secrets from your local instance of Postman after seven days of inactivity. Use a different web browser if you want your vault secrets available for more than seven days without activity in the Postman web app. Learn about the [browser requirements](/docs/getting-started/installation/installation-and-updates/#browser-requirements) for the Postman web app.
 
 ### Compare vault secrets and variables
 


### PR DESCRIPTION
In this release, Postman won't preserve your vault secrets after signing out of the web app. Previously we documented that the web app was required to preserve secrets on sign out.

* Clarified that you need your vault key to access your Postman Vault, and not your vault secrets. The reason is that the vault key doesn't give you access to your secrets because secrets aren't preserved, and the key is required when you sign in.
* Clarified that secrets aren't preserved when you sign out, and this might be a reason why your secrets are unresolved when you sign in.
* There are now only features that require the desktop app. Updated referenced to the "Feature availability" section to reflect this.
* Updated a screenshot with copy changes.

---

[Beta site](https://tw-1650-postman-vault-march-non-enterprise.learning.postman-beta.com/docs/sending-requests/postman-vault-secrets/)