### PR TITLE
[TW-1730] Permissions required for a GitLab API key

### DIFF
--- a/src/pages/docs/designing-and-developing-your-api/versioning-an-api/using-on-prem-git-repo.md
+++ b/src/pages/docs/designing-and-developing-your-api/versioning-an-api/using-on-prem-git-repo.md
@@ -86,6 +86,7 @@ To create an installed app for GitHub Enterprise Server or GitLab Self-Managed, 
 
     * **Homepage URL** - Enter the Postman homepage URL: `https://www.postman.com`
     * **Authorization callback URL** or **Redirect URI** - Enter the authorization callback URL provided in Postman: `https://integration-oauth.pstmn.io/v1/api-git-callback.html`
+    * **Scope** - For GitLab Self-Managed, make sure to select the `api` scope when creating the OAuth app to enable Postman to read and write to your repository.
 
 1. After registering the OAuth app, copy the app's **Client ID** and **Client secret** and enter them in Postman.
 1. Select **Save** to finish creating the installed app.

--- a/src/pages/docs/designing-and-developing-your-api/versioning-an-api/using-on-prem-git-repo.md
+++ b/src/pages/docs/designing-and-developing-your-api/versioning-an-api/using-on-prem-git-repo.md
@@ -86,7 +86,7 @@ To create an installed app for GitHub Enterprise Server or GitLab Self-Managed, 
 
     * **Homepage URL** - Enter the Postman homepage URL: `https://www.postman.com`
     * **Authorization callback URL** or **Redirect URI** - Enter the authorization callback URL provided in Postman: `https://integration-oauth.pstmn.io/v1/api-git-callback.html`
-    * **Scope** - For GitLab Self-Managed, make sure to select the `api` scope when creating the OAuth app to enable Postman to read and write to your repository.
+    * **Scopes** - Make sure to select the appropriate scopes when creating the OAuth app to enable Postman to read and write to your repository. For GitHub, select the `repo` and `user` scopes. For GitLab Self-Managed, select the `api` scope.
 
 1. After registering the OAuth app, copy the app's **Client ID** and **Client secret** and enter them in Postman.
 1. Select **Save** to finish creating the installed app.


### PR DESCRIPTION
Add required permissions for GitHub and GitLab when creating an installed app

View the beta docs here: [Creating an installed app](https://tw-1730-gitlab-api-scope.learning.postman-beta.com/docs/designing-and-developing-your-api/versioning-an-api/using-on-prem-git-repo/#creating-an-installed-app)