### PR TITLE
[TW-1749] Turn off Guest toggle behavior

### DIFF
--- a/src/pages/docs/collaborating-in-postman/sharing.md
+++ b/src/pages/docs/collaborating-in-postman/sharing.md
@@ -156,7 +156,7 @@ You can change an external user's role at the team and collection levels. You ca
 
 To learn how to change an external user's team role, see [Manage guests](/docs/administration/managing-your-team/manage-team-members/#manage-guests). To learn how an external user can request a role change, see [Requesting Editor role access for a collection as an external user](/docs/collaborating-in-postman/requesting-access-to-elements/#requesting-editor-role-access-for-a-collection-as-an-external-user).
 
-You can turn off the toggle next to **Allow Guests to join your team and view this collection with the link**. When you turn this off, new external users can no longer be assigned the Guest role. External users already assigned the Guest role will continue to have access to the collection. If this is turned off for all collections an external user could access, they will be removed from the team and unable to access collections in the team.
+You can turn off the toggle next to **Allow Guests to join your team and view this collection with the link**. When you turn this off, new external users can no longer be assigned the Guest role. External users already assigned the Guest role will continue to have access to the collection.
 
 To remove external users at the team level, see [Remove team members](/docs/administration/managing-your-team/manage-team-members/#remove-team-members). In certain cases, Guests with access to only one collection are automatically removed from the team:
 


### PR DESCRIPTION
The LC docs incorrectly mentioned that turning off the toggle for all collections a Guest can access will remove them from the team. This information is now removed from the LC docs.