### PR TITLE
[TW-1731] Update CNX images

### DIFF
--- a/src/pages/docs/collaborating-in-postman/using-workspaces/creating-workspaces.md
+++ b/src/pages/docs/collaborating-in-postman/using-workspaces/creating-workspaces.md
@@ -80,7 +80,7 @@ _Workspace as an element_ represents a whole container where being an Admin give
 
 To create a new workspace, you can also select **New** in the sidebar, then select **Workspace** and follow the same steps.
 
-<img alt="Create new workspace" src="https://assets.postman.com/postman-docs/v10/create-new-workspace-v10-1.jpg" width="500px"/>
+<img alt="Create new workspace" src="https://assets.postman.com/postman-docs/v10/create-new-workspace-v10-2.jpg" width="500px"/>
 
 You can also create a new workspace in the [Workspaces dashboard](https://app.getpostman.com/dashboard). Select **Create Workspace** and follow the same steps.
 

--- a/src/pages/docs/getting-started/basics/navigating-postman.md
+++ b/src/pages/docs/getting-started/basics/navigating-postman.md
@@ -108,9 +108,9 @@ To see the task options that are available for elements in the sidebar, select t
 
 For collections, folders and requests inside a collection, and requests in History, you can select more than one element at a time. Press and hold **⌘** or **Ctrl**, then select the desired elements. For elements that are next to each other, press and hold **Shift**, then select the desired elements. For collections and their contents, you can also use [keyboard shortcuts](/docs/getting-started/installation/settings/#shortcuts) for tasks like copying, pasting, and deleting.
 
-You can select **New** in the sidebar to create requests, collections, APIs, and other common Postman elements. Select an element to create it in your workspace. You can also pin the elements you use most often. To pin an element, hover over an element and select the pin element icon <img alt="Pin element icon" src="https://assets.postman.com/postman-docs/v10/icon-pin-element-v10.jpg#icon" width="17px">. To unpin an element, hover over the pinned element and deselect the pin element icon <img alt="Unpin element icon" src="https://assets.postman.com/postman-docs/v10/icon-unpin-element-icon-v10.jpg#icon" width="17px">.
+You can select **New** in the sidebar to create requests, collections, and other common Postman elements. Select an element to create it in your workspace. You can also pin the elements you use most often. To pin an element, hover over an element and select the pin element icon <img alt="Pin element icon" src="https://assets.postman.com/postman-docs/v10/icon-pin-element-v10.jpg#icon" width="17px">. To unpin an element, hover over the pinned element and deselect the pin element icon <img alt="Unpin element icon" src="https://assets.postman.com/postman-docs/v10/icon-unpin-element-icon-v10.jpg#icon" width="17px">.
 
-<img src="https://assets.postman.com/postman-docs/v10/create-new-pin-elements-v10.jpg" alt="Pin elements" width="500px"/>
+<img src="https://assets.postman.com/postman-docs/v10/create-new-pin-elements-v10-1.jpg" alt="Pin elements" width="500px"/>
 
 To hide the sidebar, select the hide sidebar icon <img alt="Hide sidebar icon" src="https://assets.postman.com/postman-docs/icon-hide-sidebar-v9.jpg#icon" width="18px"> from the [footer](#footer) or right-click in an empty part of the sidebar and select **Collapse sidebar**.
 

--- a/src/pages/docs/getting-started/first-steps/creating-the-first-collection.md
+++ b/src/pages/docs/getting-started/first-steps/creating-the-first-collection.md
@@ -49,7 +49,7 @@ To create a collection, do the following:
 1. If you haven't already, [install the Postman desktop app](/docs/getting-started/first-steps/get-postman/) and [sign in to Postman](/docs/getting-started/first-steps/sign-in-to-postman/).
 1. Select **New > HTTP**.
 
-    <img alt="Create new request" src="https://assets.postman.com/postman-docs/v10/create-new-http-v10-4.jpg" width="500px"/>
+    <img alt="Create new request" src="https://assets.postman.com/postman-docs/v10/create-new-http-v10-6.jpg" width="500px"/>
 
 1. Enter a request in the request builder and select **Save**.
 1. Create a new collection by selecting **New Collection**. Enter a collection name, and then select **Create**.

--- a/src/pages/docs/sending-requests/create-requests/request-basics.md
+++ b/src/pages/docs/sending-requests/create-requests/request-basics.md
@@ -31,7 +31,7 @@ Your requests can include multiple details determining the data Postman will sen
 
 You can create a new request from a workspace, by using **New > HTTP**, or by selecting **+** to open a new tab.
 
-<img alt="Create new request" src="https://assets.postman.com/postman-docs/v10/create-new-http-v10-4.jpg" width="500px"/>
+<img alt="Create new request" src="https://assets.postman.com/postman-docs/v10/create-new-http-v10-6.jpg" width="500px"/>
 
 Select **Save** to save your request. You can give your request a name and description, and choose or create a [collection](/docs/sending-requests/create-requests/intro-to-collections/) to save it in.
 
@@ -49,9 +49,9 @@ You can change the protocol for a new request. Select **New** in the sidebar and
 
 In addition to HTTP, Postman supports sending requests using [GraphQL](/docs/sending-requests/graphql/graphql-overview/), [gRPC](/docs/sending-requests/grpc/grpc-client-overview/), [WebSocket](/docs/sending-requests/websocket/websocket-overview/), [MQTT](/docs/sending-requests/mqtt-client/mqtt-client-overview/), and [SOAP](/docs/sending-requests/soap/making-soap-requests/) protocols.
 
-> You can't change the request protocol after you select **Save**.
+<img alt="Select protocol" src="https://assets.postman.com/postman-docs/v10/select-protocol-v10.jpg" width="200px" />
 
-<img alt="Select protocol" src="https://assets.postman.com/postman-docs/v10/select-protocol-v10-22.gif" />
+> You can't change the request protocol after you select **Save**.
 
 ### Specify request URLs
 

--- a/src/pages/docs/sending-requests/grpc/first-grpc-request.md
+++ b/src/pages/docs/sending-requests/grpc/first-grpc-request.md
@@ -51,7 +51,7 @@ This example will create and execute a unary request. To learn about invoking th
 
 1. In Postman, select  **New > gRPC** to open a request in a new tab. (In the Postman desktop app, you can also select **⌘+N** or **Ctrl+N**, then select **gRPC**.)
 
-    <img src="https://assets.postman.com/postman-docs/v10/create-new-grpc-v10-2.jpg" alt="New gRPC request" width="500px"/>
+    <img src="https://assets.postman.com/postman-docs/v10/create-new-grpc-v10-3.jpg" alt="New gRPC request" width="500px"/>
 
 1. Enter a URL into **Server URL**. For this example, use the Postman gRPC echo service, which is `grpc.postman-echo.com`.
 

--- a/src/pages/docs/sending-requests/grpc/grpc-request-interface.md
+++ b/src/pages/docs/sending-requests/grpc/grpc-request-interface.md
@@ -32,7 +32,7 @@ gRPC requests in Postman include a variety of tools, views, and controls to help
 
 Create a new gRPC request by selecting **New** in the sidebar. Select **gRPC** from the list to open a blank gRPC request in a new tab.
 
-<img src="https://assets.postman.com/postman-docs/v10/create-new-grpc-v10-2.jpg" alt="New gRPC request" width="500px"/>
+<img src="https://assets.postman.com/postman-docs/v10/create-new-grpc-v10-3.jpg" alt="New gRPC request" width="500px"/>
 
 ## The request section
 
@@ -44,7 +44,7 @@ The request section includes the required configurations to connect to the serve
 
     > You can't change the request protocol after you select **Save**.
 
-    <img src="https://assets.postman.com/postman-docs/v10/select-protocol-v10-22.gif" alt="Select protocol" />
+    <img src="https://assets.postman.com/postman-docs/v10/grpc-tab-request-v10.jpg" alt="Select protocol" width="200px" />
 
 * **Server URL** - Defines the endpoint where the service is hosted. A gRPC URL often starts with `grpc://` instead of `http://` or `https://`. While creating a new request, you can also browse through URLs you've used by selecting the URL box. This helps you create the request faster if you’re testing multiple methods on the same endpoint.
 

--- a/src/pages/docs/sending-requests/mqtt-client/first-mqtt-request.md
+++ b/src/pages/docs/sending-requests/mqtt-client/first-mqtt-request.md
@@ -24,7 +24,7 @@ In this example of an MQTT request, you will connect to a public broker, subscri
 
 In Postman, select **New > MQTT** to create a new request. (In the Postman desktop app, you can also select **⌘+N** or **Ctrl+N**, then select **MQTT**).
 
-  <img src="https://assets.postman.com/postman-docs/v10/mqtt/mqtt-new-request-v10.jpg" alt="New MQTT request" width="500px"/>
+  <img src="https://assets.postman.com/postman-docs/v10/mqtt/mqtt-new-request-v10-1.jpg" alt="New MQTT request" width="500px"/>
 
 ## Connect to a broker with Postman
 

--- a/src/pages/docs/sending-requests/mqtt-client/mqtt-request-interface.md
+++ b/src/pages/docs/sending-requests/mqtt-client/mqtt-request-interface.md
@@ -24,7 +24,7 @@ MQTT requests in Postman include a variety of tools, views, and controls to help
 
 Create a new MQTT request by selecting the **New** button in the sidebar, which brings up the **Create new** dialog. Select **MQTT** from the list to open a blank MQTT request in a new tab.
 
-  <img src="https://assets.postman.com/postman-docs/v10/mqtt/mqtt-new-request-v10.jpg" alt="New MQTT request" width="500px"/>
+  <img src="https://assets.postman.com/postman-docs/v10/mqtt/mqtt-new-request-v10-1.jpg" alt="New MQTT request" width="500px"/>
 
 You can also create a new MQTT request by selecting the New Tab icon <img alt="New Tab icon" src="https://assets.postman.com/postman-docs/v10/icon-pin-collection-v10.14.0.jpg#icon" width="16px"> in the tabs bar and selecting the **Request type** button next to the request name (Untitled Request) and selecting **MQTT** from the list.
 

--- a/src/pages/docs/sending-requests/soap/making-soap-requests.md
+++ b/src/pages/docs/sending-requests/soap/making-soap-requests.md
@@ -43,7 +43,7 @@ Postman can make HTTP calls using Simple Object Access Protocol (SOAP), a platfo
 
 1. To open an HTTP request, select __New > HTTP__.
 
-    <img alt="Create new request" src="https://assets.postman.com/postman-docs/v10/create-new-http-v10-4.jpg" width="500px"/>
+    <img alt="Create new request" src="https://assets.postman.com/postman-docs/v10/create-new-http-v10-6.jpg" width="500px"/>
 
 1. Enter your SOAP endpoint URL in the address field. For this example, use the following endpoint URL: `https://www.dataaccess.com/webservicesserver/NumberConversion.wso`.
 

--- a/src/pages/docs/sending-requests/websocket/create-a-websocket-request.md
+++ b/src/pages/docs/sending-requests/websocket/create-a-websocket-request.md
@@ -29,7 +29,7 @@ You can create a WebSocket request from the sidebar in Postman.
 
 1. Select **New > WebSocket** to open a raw WebSocket request in a new tab. You can also select **New > Socket.IO** to open a [Socket.IO request](/docs/sending-requests/websocket/create-a-socketio-request/) in a new tab. (In the Postman desktop app, you can also select **⌘+N** or **Ctrl+N**.)
 
-    <img src="https://assets.postman.com/postman-docs/v10/create-new-websocket-v10-2.jpg" alt="New WebSocket request" width="500px"/>
+    <img src="https://assets.postman.com/postman-docs/v10/create-new-websocket-v10-3.jpg" alt="New WebSocket request" width="500px"/>
 
 1. Enter the WebSocket server URL. A WebSocket URL begins with `ws://` or `wss://`.
 


### PR DESCRIPTION
This updates the CNX images to match that you can't create a new API via this method. I also updated the text in `/docs/getting-started/basics/navigating-postman` to omit "API" from the sentence at line 111.

Part of this update was to remove the use of animated gifs in the following:

- `/docs/sending-requests/grpc/grpc-request-interface/`
- `/docs/sending-requests/create-requests/request-basics/`

These now use static images of the menu so it is much easier to maintain as this changes over time.

You can view each change at the follow beta preview links:
- https://tw-1731-update-cnx-images.learning.postman-beta.com/docs/getting-started/first-steps/creating-the-first-collection/
- https://tw-1731-update-cnx-images.learning.postman-beta.com/docs/getting-started/basics/navigating-postman/#sidebar
- https://tw-1731-update-cnx-images.learning.postman-beta.com/docs/sending-requests/create-requests/request-basics/
- https://tw-1731-update-cnx-images.learning.postman-beta.com/docs/sending-requests/grpc/grpc-request-interface/
- https://tw-1731-update-cnx-images.learning.postman-beta.com/docs/sending-requests/grpc/first-grpc-request/
- https://tw-1731-update-cnx-images.learning.postman-beta.com/docs/sending-requests/websocket/create-a-websocket-request/
- https://tw-1731-update-cnx-images.learning.postman-beta.com/docs/sending-requests/mqtt-client/mqtt-request-interface/
- https://tw-1731-update-cnx-images.learning.postman-beta.com/docs/sending-requests/mqtt-client/first-mqtt-request/
- https://tw-1731-update-cnx-images.learning.postman-beta.com/docs/sending-requests/soap/making-soap-requests/
- https://tw-1731-update-cnx-images.learning.postman-beta.com/docs/collaborating-in-postman/using-workspaces/creating-workspaces/